### PR TITLE
Cachemire: name the replica behind unexplained band-cache misses (#6)

### DIFF
--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -103,6 +103,23 @@ alone would still have hit the unchanged ~15k early prefix. The unknown-cause hi
 window-aware for this — band windows say `best-effort cache: fresh write not yet
 readable, or replica routing` instead of Anthropic's `provider-side eviction?`.
 
+Cachemire now runs that entry arithmetic itself. Every call's prompt total is kept, and
+when a later read on a band cache equals `floor₅₁₂` of one — within the 1h hard cap,
+newest match wins — the cause names the entry instead of shrugging:
+
+```
+◍ cache partial · read 49.2k of 63.1k expected · re-wrote 14.0k (22% of prompt)
+  · cause: read matches call #38's entry (13m24s old) · likely a different replica from the last write
+```
+
+When an idle gap *does* explain the miss, the entry refines rather than replaces it:
+`evicted after idle 11m48s (typical window 5m–1h) · fell back to call #38's entry (13m
+old)`. Live motivation: session 019e9758 produced a burst of breaks within seconds —
+reads alternating 62,464 → 49,152 → 62,464 → 65,024 — which a single cache cannot do
+(eviction cannot resurrect a shorter entry between two reads of a longer one); ≥3
+replica lineages were advancing independently, and each break was one replica's
+first-touch. The matcher turns that hand analysis into the default diagnosis.
+
 **2. Cache forensics** — every provider request is fingerprinted (system prompt, each
 tool, each history message; `cache_control` breakpoints stripped, since pi moves the
 breakpoint every call by design). When a call's `cacheRead` collapses, the diff names
@@ -127,8 +144,9 @@ break didn't happen — usually shared-prefix warmth: another session with the s
 harness prefix kept the early breakpoints alive past your idle gap.
 
 Cause ladder: compaction (from pi's compact events) → named segment mutation (model /
-system / tools / history) → TTL expiry → unknown. Compaction's own summarizer call is
-labelled, not warned about. Notices only appear above a materiality threshold
+system / tools / history) → TTL expiry (refined by an entry match when one exists) →
+entry match on band caches (`read matches call #N's entry · likely a different replica`)
+→ unknown. Compaction's own summarizer call is labelled, not warned about. Notices only appear above a materiality threshold
 (default: $0.05 or 20k re-written tokens) — silence when healthy. An unpredicted break
 (e.g. provider-side eviction) still gets a resolved-form line when usage arrives; a
 send that aborts before usage resolves the notice to an explicit "outcome unknown".

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -866,6 +866,10 @@ interface CachemireState {
   providerLabel?: string;
   compacted: boolean;
   inCompaction: boolean;
+  /** Records before this index belong to a dead cache lineage (pre-compaction, or before
+   * a model/system/tools/history/thinking change): entries the current prefix cannot
+   * read, so entry matching never names them. */
+  lineageStart: number;
   /** In-flight break notice placed at request time; resolved in place when usage arrives. */
   pendingNotice?: Text;
   run?: RunAggregate;
@@ -894,6 +898,7 @@ function state(): CachemireState {
       expectedRead: 0,
       compacted: false,
       inCompaction: false,
+      lineageStart: 0,
     };
   }
   return g.__piCachemire;
@@ -1005,6 +1010,9 @@ export default function piCachemire(pi: ExtensionAPI): void {
       // and cachedTokens is denominated in the old model's tokenizer.
       s.lastCallModelId = restoredModelId ?? s.lastCallModelId;
       s.modelSwitched = s.lastCallModelId !== undefined && model?.id !== undefined && s.lastCallModelId !== model.id;
+      // Restored under a different model: the restored entries are unreadable (caches are
+      // per-model), so they are out of lineage for entry matching from the start.
+      if (s.modelSwitched) s.lineageStart = s.records.length;
     }
     if (!ctx.hasUI) return;
     s.ui = ctx.ui as unknown as CachemireState["ui"];
@@ -1125,13 +1133,19 @@ export default function piCachemire(pi: ExtensionAPI): void {
     const fingerprintCause = s.prevFingerprint && s.pendingFingerprint
       ? diffFingerprints(s.prevFingerprint, s.pendingFingerprint)
       : undefined;
+    // Any invalidating change re-keys the cache: records before it are a dead lineage
+    // whose entries this prefix cannot read, and a 512-bucket collision with one would
+    // name an unreadable entry. Conservative on purpose — a mutation that happened to
+    // leave the cache warm still advances the boundary (false negatives degrade to the
+    // generic unknown hint; false positives would be dishonest).
+    if (s.compacted || fingerprintCause) s.lineageStart = s.records.length;
     // Entry ages use the request-start anchor (entries are written/refreshed during
     // request processing); restored records fall back to their response-ish message
     // timestamp — marginally optimistic, same caveat as the restore-time TTL anchor.
     const entryMatch = s.window.kind === "band"
       ? matchPriorEntry(
           usage.cacheRead,
-          s.records.map((record) => ({ index: record.index, at: record.requestAt ?? record.at, promptTokens: promptTokens(record.usage) })),
+          s.records.slice(s.lineageStart).map((record) => ({ index: record.index, at: record.requestAt ?? record.at, promptTokens: promptTokens(record.usage) })),
           requestAt,
           s.window.hardMs,
         )

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -17,7 +17,8 @@ import { compactCount } from "../_lib/fmt.ts";
  *   2. "Why did the cache break?"  → forensics: every provider request is fingerprinted
  *      (system / tools / history segments, cache_control stripped); on a miss the diff
  *      names the culprit — TTL expiry, compaction, model switch, system prompt edit,
- *      tool-list change, or history mutation — with the exact re-written tokens and cost.
+ *      tool-list change, history mutation, or (on best-effort caches) a stale replica
+ *      identified by entry arithmetic — with the exact re-written tokens and cost.
  *   3. "Am I using too many calls?"→ a one-line ledger entry per user turn (auto-shown for
  *      multi-call turns) and a /cache command with the full per-call table plus actual vs
  *      counterfactual-uncached spend ("caching saved $X").
@@ -62,7 +63,7 @@ export interface RequestFingerprint {
 
 export type CauseKind =
   | "cold" | "ttl" | "compaction" | "compaction-work" | "model" | "thinking" | "system"
-  | "tools" | "history" | "restored" | "unknown";
+  | "tools" | "history" | "replica" | "restored" | "unknown";
 
 export interface CallCause { kind: CauseKind; detail: string }
 
@@ -364,6 +365,42 @@ export function diffFingerprints(prev: RequestFingerprint, cur: RequestFingerpri
   return undefined;
 }
 
+// --- forensics: which entry did a best-effort read hit? --------------------------------
+
+// OpenAI's backend checkpoints cache entries at 512-token granularity: in live gpt-5.5
+// sessions (the README's double-break case; session 019e9758's burst of breaks within
+// seconds) every hit read exactly floor512 of an earlier call's prompt total. Matching a
+// later cacheRead against stored prompt totals therefore names *which* entry the request
+// hit — and a match behind the latest write is the replica-routing tell: a single cache
+// could not serve an older, shorter entry between two reads of a newer, longer one. The
+// public API documents 128-token increments; matching stays at the observed 512 until
+// live evidence demands widening (a looser bucket would multiply coincidental matches).
+const ENTRY_GRANULARITY = 512;
+
+export interface PriorEntry { index: number; at: number; promptTokens: number }
+export interface EntryMatch { index: number; ageMs: number }
+
+export function matchPriorEntry(
+  cacheRead: number,
+  priors: PriorEntry[],
+  now: number,
+  maxAgeMs: number,
+): EntryMatch | undefined {
+  if (cacheRead <= 0 || cacheRead % ENTRY_GRANULARITY !== 0) return undefined;
+  // Newest match wins: several prompts can share a 512-token bucket, and recent entries
+  // are the ones still alive. Age-gates on write time (read-refreshes are not tracked):
+  // an entry older than the hard cap cannot be asserted, so the match degrades to the
+  // generic unknown hint rather than naming a dead entry.
+  for (let i = priors.length - 1; i >= 0; i--) {
+    const prior = priors[i]!;
+    if (now - prior.at > maxAgeMs) break;
+    if (Math.floor(prior.promptTokens / ENTRY_GRANULARITY) * ENTRY_GRANULARITY === cacheRead) {
+      return { index: prior.index, ageMs: Math.max(0, now - prior.at) };
+    }
+  }
+  return undefined;
+}
+
 // --- classification --------------------------------------------------------------------
 
 export interface ClassifyInput {
@@ -377,6 +414,8 @@ export interface ClassifyInput {
   fingerprintCause?: CallCause;
   /** The previous call re-wrote the prefix (was itself a miss/cold write). */
   prevWrote?: boolean;
+  /** This read equals floor512 of an earlier call's prompt total (see matchPriorEntry). */
+  entryMatch?: EntryMatch;
 }
 
 // Hint wording for a miss nothing else explains. Window-aware: under a contract TTL
@@ -414,8 +453,19 @@ export function classifyCall(args: ClassifyInput): CallClassification {
       : args.fingerprintCause;
   } else if (idleCause) {
     // For a band window's "maybe" zone the observed miss is itself the confirmation:
-    // the prefix was evicted within the documented typical window.
-    cause = idleCause;
+    // the prefix was evicted within the documented typical window. An entry match refines
+    // it: the newer entries were evicted, and the read fell back to a surviving older one.
+    cause = args.entryMatch
+      ? { ...idleCause, detail: `${idleCause.detail} \u00b7 fell back to call #${args.entryMatch.index}'s entry (${formatDuration(args.entryMatch.ageMs)} old)` }
+      : idleCause;
+  } else if (args.entryMatch && args.window?.kind === "band") {
+    // Nothing else explains the miss, but the arithmetic names the entry it hit. Behind
+    // the latest write with no idle gap, a different replica is the only consistent story.
+    cause = {
+      kind: "replica",
+      detail: `read matches call #${args.entryMatch.index}'s entry (${formatDuration(args.entryMatch.ageMs)} old)` +
+        " \u00b7 likely a different replica from the last write",
+    };
   } else {
     // Rendered behind "cause: " — the detail must not restate the word.
     cause = { kind: "unknown", detail: unknownMissDetail(args) };
@@ -1072,6 +1122,14 @@ export default function piCachemire(pi: ExtensionAPI): void {
     const fingerprintCause = s.prevFingerprint && s.pendingFingerprint
       ? diffFingerprints(s.prevFingerprint, s.pendingFingerprint)
       : undefined;
+    const entryMatch = s.window.kind === "band"
+      ? matchPriorEntry(
+          usage.cacheRead,
+          s.records.map((record) => ({ index: record.index, at: record.at, promptTokens: promptTokens(record.usage) })),
+          requestAt,
+          s.window.hardMs,
+        )
+      : undefined;
     const classification = classifyCall({
       isFirst: s.records.length === 0,
       gapMs,
@@ -1082,6 +1140,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
       inCompaction: s.inCompaction,
       fingerprintCause,
       prevWrote: ["miss", "cold", "partial"].includes(s.records.at(-1)?.classification.kind ?? ""),
+      entryMatch,
     });
     const record: CallRecord = {
       index: s.records.length + 1,
@@ -1177,6 +1236,7 @@ export const internals = {
   renderBreakingLine,
   renderHeldLine,
   diffFingerprints,
+  matchPriorEntry,
   classifyCall,
   uncachedCostUsd,
   rewriteCostUsd,

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -75,6 +75,9 @@ export interface CallClassification {
 export interface CallRecord {
   index: number;
   at: number;
+  /** Request-start anchor (when the provider wrote/refreshed this call's cache entry);
+   * `at` is response end. Absent on restored records, whose timestamps are response-ish. */
+  requestAt?: number;
   gapMs?: number;
   usage: UsageLike;
   expectedRead: number;
@@ -1122,10 +1125,13 @@ export default function piCachemire(pi: ExtensionAPI): void {
     const fingerprintCause = s.prevFingerprint && s.pendingFingerprint
       ? diffFingerprints(s.prevFingerprint, s.pendingFingerprint)
       : undefined;
+    // Entry ages use the request-start anchor (entries are written/refreshed during
+    // request processing); restored records fall back to their response-ish message
+    // timestamp — marginally optimistic, same caveat as the restore-time TTL anchor.
     const entryMatch = s.window.kind === "band"
       ? matchPriorEntry(
           usage.cacheRead,
-          s.records.map((record) => ({ index: record.index, at: record.at, promptTokens: promptTokens(record.usage) })),
+          s.records.map((record) => ({ index: record.index, at: record.requestAt ?? record.at, promptTokens: promptTokens(record.usage) })),
           requestAt,
           s.window.hardMs,
         )
@@ -1145,6 +1151,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     const record: CallRecord = {
       index: s.records.length + 1,
       at: now,
+      requestAt,
       gapMs,
       usage,
       expectedRead: s.expectedRead,

--- a/tests/cachemire/forensics.test.ts
+++ b/tests/cachemire/forensics.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 
 import { internals } from "../../extensions/pi-cachemire/index.ts";
 
-const { stripCacheControl, fingerprintPayload, diffFingerprints, classifyCall } = internals;
+const { stripCacheControl, fingerprintPayload, diffFingerprints, classifyCall, matchPriorEntry } = internals;
 
 const MIN = 60_000;
 
@@ -224,6 +224,77 @@ test("classification ladder", () => {
 
   const summarizer = classifyCall({ isFirst: false, usage: usage(0), expectedRead: 100_000, inCompaction: true });
   assert.equal(summarizer.cause!.kind, "compaction-work");
+});
+
+test("matchPriorEntry names which prior call's entry a read hit", () => {
+  // Live arithmetic from session 019e9758: call #38 (prompt 49,417) wrote the entry that
+  // a burst of later calls read as exactly floor512(49,417) = 49,152 — while interleaved
+  // calls read a newer 62k entry. Mapping reads back to prompt totals is the diagnosis.
+  const now = 1_000_000_000;
+  const MIN_MS = 60_000;
+  const priors = [
+    { index: 37, at: now - 30 * MIN_MS, promptTokens: 49_300 }, // same 512-bucket, older
+    { index: 38, at: now - 13 * MIN_MS, promptTokens: 49_417 },
+    { index: 39, at: now - 12 * MIN_MS, promptTokens: 62_932 },
+  ];
+
+  const match = matchPriorEntry(49_152, priors, now, 60 * MIN_MS)!;
+  assert.equal(match.index, 38, "newest matching entry wins");
+  assert.equal(match.ageMs, 13 * MIN_MS);
+
+  // Entries older than the hard cap cannot be asserted — they are documented as removed.
+  assert.equal(matchPriorEntry(49_152, priors, now, 10 * MIN_MS), undefined);
+  // Reads that are not on a 512 checkpoint, or zero, never match.
+  assert.equal(matchPriorEntry(49_200, priors, now, 60 * MIN_MS), undefined);
+  assert.equal(matchPriorEntry(0, priors, now, 60 * MIN_MS), undefined);
+  // A read with no bucket-mate stays unmatched (falls to the generic unknown hint).
+  assert.equal(matchPriorEntry(51_200, priors, now, 60 * MIN_MS), undefined);
+});
+
+test("entry match upgrades unknown band misses and refines idle evictions", () => {
+  const band: { kind: "band"; softMs: number; hardMs: number } = { kind: "band", softMs: 5 * MIN, hardMs: 60 * MIN };
+  const base = {
+    isFirst: false,
+    expectedRead: 63_000,
+    usage: { input: 13_987, output: 319, cacheRead: 49_152, cacheWrite: 0 },
+  };
+
+  // No idle gap, read matches an older call's entry: the replica story, named.
+  const bounce = classifyCall({ ...base, gapMs: 5_000, window: band, entryMatch: { index: 38, ageMs: 13 * MIN } });
+  assert.equal(bounce.kind, "partial");
+  assert.equal(bounce.cause!.kind, "replica");
+  assert.equal(
+    bounce.cause!.detail,
+    "read matches call #38's entry (13m old) \u00b7 likely a different replica from the last write",
+  );
+
+  // Idle past the soft window: eviction stays the headline, the entry refines it.
+  const evicted = classifyCall({ ...base, gapMs: 11.8 * MIN, window: band, entryMatch: { index: 38, ageMs: 13 * MIN } });
+  assert.equal(evicted.cause!.kind, "ttl");
+  assert.equal(
+    evicted.cause!.detail,
+    "evicted after idle 11m48s (typical window 5m\u20131h) \u00b7 fell back to call #38's entry (13m old)",
+  );
+
+  // Named mutations outrank the entry match — the user's action is the root cause.
+  const mutated = classifyCall({
+    ...base,
+    gapMs: 5_000,
+    window: band,
+    fingerprintCause: { kind: "system", detail: "system prompt changed" },
+    entryMatch: { index: 38, ageMs: 13 * MIN },
+  });
+  assert.equal(mutated.cause!.kind, "system");
+
+  // Contract windows (Anthropic) use explicit breakpoints, not floor512 checkpoints —
+  // the arithmetic does not apply, so the match is ignored.
+  const contract = classifyCall({
+    ...base,
+    gapMs: 5_000,
+    window: { kind: "contract", ttlMs: 5 * MIN, source: "observed" },
+    entryMatch: { index: 38, ageMs: 13 * MIN },
+  });
+  assert.equal(contract.cause!.kind, "unknown");
 });
 
 test("unknown-miss hint is window-aware", () => {


### PR DESCRIPTION
Implements the entry/replica forensics proposed in the #6 follow-ups (and corroborated in [this analysis](https://github.com/tmustier/pine-of-glass/issues/6#issuecomment-4672309878)).

## What

On best-effort (band) caches, cachemire now keeps every call's prompt total and matches a later `cacheRead` against `floor₅₁₂` of them:

- **Unexplained miss/partial** → `cause: read matches call #N's entry (Xm old) · likely a different replica from the last write` (new `replica` cause kind), instead of `cause: unknown (best-effort cache: replica routing or early eviction)`.
- **Idle-eviction miss** → the existing TTL cause is refined: `evicted after idle 11m48s (typical window 5m–1h) · fell back to call #N's entry (Xm old)`.
- Matches are age-gated to the documented 1h hard cap, newest-wins within a 512-token bucket, and contract (Anthropic) windows ignore the arithmetic entirely — their entries are explicit breakpoints, not floor₅₁₂ checkpoints.

## Why

Session `019e9758` (2026-06-10) produced a burst of cache breaks within seconds, all labelled `cause: unknown`. Mapping each read to `floor₅₁₂` of prior prompt totals proved ≥3 replica lineages advancing independently (reads alternating 62,464 → 49,152 → 62,464 → 65,024 — a single cache cannot resurrect a shorter entry between two reads of a longer one). This PR turns that hand analysis into the default diagnosis.

## Testing

- `npm run typecheck` clean
- `npm test` — 2 new tests (matcher semantics incl. age-gating/bucket-collision/newest-wins; classification ladder placement incl. fingerprint-cause precedence and contract-window opt-out), all 21 cachemire+suite tests pass.

Closes #6.