### PR TITLE
Traceline: flatten multiline bash + restore the native tool surface (#10)

### DIFF
--- a/extensions/_lib/ansi.ts
+++ b/extensions/_lib/ansi.ts
@@ -1,9 +1,14 @@
 // Shared ANSI helpers for the pine-of-glass extension family.
 // This directory has no index.ts on purpose: pi's extension discovery skips it.
 
+/** Matches one OSC sequence (hyperlink/title). The payload can never contain ESC — ESC
+ * starts the ST terminator — so excluding it keeps the match from greedily swallowing
+ * the visible text between an ST-terminated OSC 8 open and its close. */
+export const OSC_SEQUENCE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+
 /** Strip CSI (colors/cursor) and OSC (hyperlink/title) escape sequences. */
 export function stripAnsi(text: string): string {
   return text
     .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
-    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "");
+    .replace(OSC_SEQUENCE, "");
 }

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -28,11 +28,23 @@ When tool rows are collapsed, each one renders as a single line:
 
 Rendering reuses Pi's own tool-call renderer, so the visual grammar (bold command name, accented paths/backticks, warning line ranges, custom-tool renderers) tracks Pi's defaults. On top of that sits an **ink hierarchy**: shell plumbing in bash rows (`&&`, `|`, `;`, `2>/dev/null`, heredoc markers) is dimmed so the command segments carry the brightness, and the boilerplate `(timeout Ns)` suffix is dropped — the full invocation is one Ctrl+T or click away. One blank line precedes a group of tool calls; consecutive tool calls stay tight, and a tool row sits tight under the collapsed `Thinking...` line that motivated it, so each thought→action couplet reads as one unit.
 
+### The tool surface
+
+Each trace line sits on Pi's own status-tinted tool background — the same shaded surface the expanded block uses (`toolPendingBg` / `toolSuccessBg` / `toolErrorBg` from your active theme, borrowed live from the row itself, so themes and light/dark handling come for free). Collapsed and expanded views read as the *same object at different zoom*, trace rows stop dissolving into surrounding prose, and consecutive calls tile into one shaded slab per tool group. The band retints when a result lands (pending → success/error), and tools that render their own framing get no band — exactly matching native. 
+
+### Multiline commands stay one line
+
+Bash commands keep their real newlines — heredocs, inline `python3 -c` scripts, chained `tmux` pipelines. Taking only the first rendered line collapsed them to an uninformative prefix like `$ python3 -c "` (issue #10). Instead, the whole command is flattened into the one trace line with a dim `↵` marking each original break, and middle truncation then keeps both the head and the *operative tail* — the checks at the end of a pipeline, not just its preamble:
+
+```
+› $ python3 -c " ↵ import json ↵ p='~/.pi/agent/… -p -t pog-th | grep -E "cache|fable" | tail -4   257 ch
+```
+
 ### Reading the end of the line
 
 The discriminating part of a row usually lives at the **tail** — the filename + `:line-range` for a path, or the operative end of a command — while the head is boilerplate (long `~/projects/...` prefixes, `cd ... &&` preambles). So instead of a trailing ellipsis that deletes the signal, `pi-traceline`:
 
-- **tildifies** home directories (`/Users/you/...` -> `~/...`) to reclaim width before truncating;
+- **tildifies** home directories (`/Users/you/...` -> `~/...`) to reclaim width before truncating (OSC 8 hyperlink URLs are left intact, so click targets keep working);
 - **middle-truncates** with a dimmed `…`, protecting the tail so the basename and `:range` survive, snapping the cut to a nearby `/` or space;
 - **dims the directory** on plain file reads so the basename — *which* file — stands out.
 

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -3,7 +3,7 @@ import { isKeyRelease, isKeyRepeat, matchesKey, truncateToWidth, visibleWidth } 
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { stripAnsi } from "../_lib/ansi.ts";
+import { OSC_SEQUENCE, stripAnsi } from "../_lib/ansi.ts";
 import { captureTui } from "../_lib/capture.ts";
 import { findChatContainer, isAssistantRow, isToolRow } from "../_lib/chat.ts";
 import { compactCount } from "../_lib/fmt.ts";
@@ -21,6 +21,12 @@ import { compactCount } from "../_lib/fmt.ts";
  *
  * One-line rendering reuses pi's native tool call renderer, so visual defaults
  * (bold command name, accent paths/backticks, warning line ranges, etc.) drift with pi.
+ * Each row sits on pi's own status-tinted tool background (the same shaded surface the
+ * expanded block uses, borrowed live from the row's contentBox), so collapsed and
+ * expanded read as the same object at different zoom — and consecutive rows tile into
+ * one shaded slab per tool group. Multiline bash commands are flattened into the one
+ * trace line with a dim ↵ marking each original break, so heredocs and inline scripts
+ * keep their operative tail instead of collapsing to `$ python3 -c "`.
  * The ink follows an information hierarchy: shell plumbing (`&&`, `|`, `2>/dev/null`,
  * heredoc markers) is dimmed so command segments pop, and the boilerplate `(timeout Ns)`
  * suffix is dropped — the full invocation is one Ctrl+T away. Home-dir prefixes are
@@ -76,7 +82,8 @@ const TOOL_AFTER_BULLET = " ";
 const TOOL_PREFIX_VISIBLE_WIDTH = TOOL_GUTTER.length + 1 + TOOL_AFTER_BULLET.length;
 const ONE_LINE_CAPTURE_WIDTH = 10_000;
 const ONE_LINE_ELLIPSIS = "\u2026";
-const TRACELINE_PATCH_VERSION = 10;
+const LINE_BREAK_MARK = "\u21b5"; // ↵ — marks a real newline in a flattened invocation
+const TRACELINE_PATCH_VERSION = 11;
 const TRACELINE_CONTAINER_PATCH_VERSION = 1;
 const MIN_HEAD_COLS = 6;
 const TAIL_RATIO = 0.55;
@@ -392,11 +399,14 @@ function resultCharSuffix(comp: any): string {
 }
 
 // Replace an absolute home-directory prefix with ~ so boilerplate path heads stop eating
-// width (e.g. bash `cd /Users/me/... && ...` -> `cd ~/... && ...`). Safe on ANSI strings: the
-// home path is contiguous text and never contains escape codes.
+// width (e.g. bash `cd /Users/me/... && ...` -> `cd ~/... && ...`). OSC sequences are
+// skipped: a read row's OSC 8 hyperlink carries a file:// URL containing the home path,
+// and tildifying *that* would corrupt the click target.
 function tildify(text: string): string {
   const home = homedir();
-  return home ? text.split(home).join("~") : text;
+  if (!home) return text;
+  const pattern = new RegExp(`${OSC_SEQUENCE.source}|${home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "g");
+  return text.replace(pattern, (match) => (match === home ? "~" : match));
 }
 
 function isVisibleBoundary(ch: string): boolean {
@@ -490,6 +500,18 @@ function compactJson(value: unknown): string {
 
 function firstVisibleLine(lines: string[]): string | undefined {
   return lines.find((line) => stripAnsi(line).trim().length > 0);
+}
+
+// Bash commands keep their real newlines (heredocs, inline python, chained pipelines),
+// so first-line-only collapses them to an uninformative prefix like `$ python3 -c "`
+// (issue #10). Flatten every visible line into the one trace line, with a dim ↵ where
+// each break was — middle truncation then keeps the head *and* the operative tail.
+function flattenInvocationLines(lines: string[]): string | undefined {
+  const visible = lines
+    .filter((line) => stripAnsi(line).trim().length > 0)
+    .map((line) => trimLeadingVisibleWhitespace(line.trimEnd()));
+  if (visible.length === 0) return undefined;
+  return visible.join(` ${MUTED_GREY}${LINE_BREAK_MARK}${RESET} `);
 }
 
 function filterSgrParams(
@@ -655,7 +677,11 @@ function colourCommandPrefix(comp: any, line: string): string {
 function nativeInvocationLine(comp: any): string | undefined {
   const call = comp?.callRendererComponent;
   if (!call || typeof call.render !== "function") return undefined;
-  const line = firstVisibleLine(withLayoutSuppressed(() => call.render(ONE_LINE_CAPTURE_WIDTH)));
+  const rendered = withLayoutSuppressed(() => call.render(ONE_LINE_CAPTURE_WIDTH));
+  const lines = Array.isArray(rendered) ? rendered : [];
+  // Bash: every rendered line is invocation (the command's own newlines), so flatten.
+  // Other tools keep first-line-only — that is what suppresses their preview/body lines.
+  const line = toolLabel(comp?.toolName) === "bash" ? flattenInvocationLines(lines) : firstVisibleLine(lines);
   return line
     ? colourCommandPrefix(comp, stripSgrBackgrounds(stripTimeoutSuffix(stripTrailingExpandHint(line))))
     : undefined;
@@ -693,6 +719,30 @@ function pathEmphasisLine(comp: any, nativeColored: string): string | undefined 
   return `${statusColor(comp)}${BOLD}read${BOLD_OFF}${RESET} ${MUTED_GREY}${dir}${RESET}${base}${MUTED_GREY}${range}${RESET}`;
 }
 
+// The shaded tool surface, borrowed live from the row itself. pi keeps contentBox.bgFn
+// status-synced (toolPendingBg / toolSuccessBg / toolErrorBg from the active theme), so
+// the collapsed row inherits the exact background the expanded block would have — theme,
+// light/dark, and colour-mode handling all come for free, and the band retints when the
+// result lands. Self-framing tools have no native shade, so they get none here either.
+function rowBackground(comp: any): ((text: string) => string) | undefined {
+  try {
+    if (typeof comp?.getRenderShell === "function" && comp.getRenderShell() === "self") return undefined;
+    const bgFn = comp?.contentBox?.bgFn;
+    return typeof bgFn === "function" ? bgFn : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Full-width band: pad to width, then re-assert the background after every full SGR
+// reset (traceline's own ink uses \x1b[0m liberally) so the surface never punches holes.
+function shadeRow(line: string, width: number, bgFn: (text: string) => string): string {
+  const [open = "", close = ""] = bgFn("\u0000").split("\u0000");
+  if (!open) return line;
+  const padded = `${line}${" ".repeat(Math.max(0, width - visibleWidth(line)))}`;
+  return `${open}${padded.split(RESET).join(`${RESET}${open}`)}${close}`;
+}
+
 function oneLine(comp: any, width: number): string {
   const lineWidth = Math.max(1, width);
   const available = Math.max(1, lineWidth - TOOL_PREFIX_VISIBLE_WIDTH);
@@ -701,7 +751,9 @@ function oneLine(comp: any, width: number): string {
   const tilded = tildify(base);
   const invocation = toolLabel(comp?.toolName) === "bash" ? dimShellPlumbing(tilded) : tilded;
   const fitted = fitOneLineAndSuffix(invocation, resultCharSuffix(comp), available);
-  return truncateToWidth(`${hiddenToolPrefix(comp)}${fitted}`, lineWidth, ONE_LINE_ELLIPSIS);
+  const row = truncateToWidth(`${hiddenToolPrefix(comp)}${fitted}`, lineWidth, ONE_LINE_ELLIPSIS);
+  const bgFn = rowBackground(comp);
+  return bgFn ? shadeRow(row, lineWidth, bgFn) : row;
 }
 
 // An assistant turn that renders nothing (a tool-call-only turn with no visible
@@ -826,6 +878,9 @@ export const internals = {
   tildify,
   stripTimeoutSuffix,
   dimShellPlumbing,
+  flattenInvocationLines,
+  rowBackground,
+  shadeRow,
   // row grammar
   formatCharCount,
   lineRange,

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -401,12 +401,17 @@ function resultCharSuffix(comp: any): string {
 // Replace an absolute home-directory prefix with ~ so boilerplate path heads stop eating
 // width (e.g. bash `cd /Users/me/... && ...` -> `cd ~/... && ...`). OSC sequences are
 // skipped: a read row's OSC 8 hyperlink carries a file:// URL containing the home path,
-// and tildifying *that* would corrupt the click target.
-function tildify(text: string): string {
+// and tildifying *that* would corrupt the click target. The pattern is built once —
+// tildify runs for every visible row on every frame.
+const TILDIFY_PATTERN = (() => {
   const home = homedir();
-  if (!home) return text;
-  const pattern = new RegExp(`${OSC_SEQUENCE.source}|${home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "g");
-  return text.replace(pattern, (match) => (match === home ? "~" : match));
+  if (!home) return undefined;
+  return new RegExp(`${OSC_SEQUENCE.source}|${home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "g");
+})();
+
+function tildify(text: string): string {
+  if (!TILDIFY_PATTERN) return text;
+  return text.replace(TILDIFY_PATTERN, (match) => (match.startsWith("\x1b") ? match : "~"));
 }
 
 function isVisibleBoundary(ch: string): boolean {

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -145,6 +145,44 @@ test("real ToolExecutionComponent satisfies traceline's duck type and one-line p
   assert.equal(traceline.toolStatus(comp), "error");
 });
 
+test("real ToolExecutionComponent: bash multiline render + tool-surface seams traceline borrows", () => {
+  pi.initTheme(undefined, false);
+  const comp = new pi.ToolExecutionComponent(
+    "bash",
+    "tool-2",
+    { command: 'python3 -c "\nimport json\nprint(1)\n" && echo done', timeout: 70 },
+    undefined,
+    undefined,
+    {} as never,
+    tmpdir(),
+  );
+
+  // Multiline commands render one line per real newline, timeout suffix on the last —
+  // the shape flattenInvocationLines + stripTimeoutSuffix assume (issue #10).
+  const callComp = (comp as unknown as { callRendererComponent?: { render?: (w: number) => string[] } }).callRendererComponent;
+  assert.ok(callComp && typeof callComp.render === "function", "bash callRendererComponent gone — one-line path falls back");
+  const lines = callComp.render(10_000);
+  assert.ok(lines.length >= 4, `bash call no longer renders one line per newline: ${JSON.stringify(lines)}`);
+  assert.ok(traceline.stripAnsi(lines[lines.length - 1]!).includes("(timeout 70s)"), "timeout suffix moved off the last line");
+
+  const flat = traceline.stripAnsi(traceline.oneLine(comp as never, 200));
+  assert.ok(flat.includes("echo done"), `flattened bash row lost its tail: ${flat}`);
+
+  // The shaded surface: contentBox.bgFn is the status-synced theme background, and its
+  // output shape (open + text + bg-only close) is what shadeRow's \u0000 split parses.
+  const box = (comp as unknown as { contentBox?: { bgFn?: (text: string) => string } }).contentBox;
+  assert.ok(box && typeof box.bgFn === "function", "contentBox.bgFn gone — traceline rows lose the tool surface");
+  const [open = "", close = ""] = box.bgFn("\u0000").split("\u0000");
+  assert.ok(/^\x1b\[48;/.test(open), `theme.bg open is no longer a bg SGR prefix: ${JSON.stringify(open)}`);
+  assert.equal(close, "\x1b[49m", "theme.bg no longer closes with bg-only reset — shadeRow re-assertion breaks");
+  // Anything other than "self" composes through the bg-painted contentBox; rowBackground
+  // only opts out on "self", so the invariant to pin is bash not being self-framed.
+  const shell = (comp as unknown as { getRenderShell?: () => string }).getRenderShell?.();
+  assert.ok(typeof shell === "string" && shell !== "self", `bash render shell became self-framed (${shell}) — rows lose the shade`);
+  const shaded = traceline.oneLine(comp as never, 80);
+  assert.ok(shaded.startsWith(open), "real row did not open on the theme tool background");
+});
+
 test("real AssistantMessageComponent satisfies traceline's assistant duck type", () => {
   const component = new pi.AssistantMessageComponent({ role: "assistant", content: [{ type: "text", text: "hi" }] } as never);
   assert.equal(traceline.isAssistantRow(component), true, "AssistantMessageComponent no longer matches isAssistantRow");

--- a/tests/traceline/one-line.test.ts
+++ b/tests/traceline/one-line.test.ts
@@ -21,6 +21,9 @@ const {
   isAssistantRow,
   stripTimeoutSuffix,
   dimShellPlumbing,
+  flattenInvocationLines,
+  rowBackground,
+  shadeRow,
 } = internals;
 
 const g = globalThis as Record<string, unknown>;
@@ -124,6 +127,79 @@ test("bash rows: timeout boilerplate stripped, shell plumbing dimmed, segments b
   assert.equal(dimShellPlumbing("echo 'a&&b'"), "echo 'a&&b'", "unspaced operators are left alone");
   assert.equal(stripTimeoutSuffix("$ ls (timeout 10s)"), "$ ls\x1b[0m");
   assert.equal(stripTimeoutSuffix("$ ls"), "$ ls");
+});
+
+test("multiline bash flattens to one line: tail survives, breaks marked, timeout stripped (#10)", () => {
+  // The issue #10 shape: an inline python heredoc-ish command plus chained tmux checks,
+  // where the first rendered line alone (`$ python3 -c "`) says nothing.
+  const comp = toolComp({
+    toolName: "bash",
+    args: { command: "python3 ...", timeout: 70 },
+    callRendererComponent: {
+      render: () => [
+        '$ python3 -c "',
+        "  import json",
+        "  d=json.load(open(p))",
+        '  " && tmux send-keys -t pog-th BTab && tmux capture-pane -p | tail -4 (timeout 70s)',
+      ],
+    },
+  });
+  const line = oneLine(comp, 160);
+  const visible = stripAnsi(line);
+  assert.ok(visible.startsWith('  › $ python3 -c "'), visible);
+  assert.ok(visible.includes("capture-pane"), `operative tail must survive: ${visible}`);
+  assert.ok(visible.includes("\u21b5"), `original line breaks must be marked: ${visible}`);
+  assert.ok(line.includes("\x1b[38;2;128;128;128m\u21b5\x1b[0m"), "break marks must be dimmed");
+  assert.ok(!visible.includes("timeout"), `timeout boilerplate stays stripped after flatten: ${visible}`);
+
+  // Narrow widths middle-truncate but still keep both ends of the flattened command.
+  const narrow = stripAnsi(oneLine(comp, 60));
+  assert.ok(narrow.includes("python3"), narrow);
+  assert.ok(narrow.includes("tail -4"), narrow);
+
+  // Unit edges: blank-only lines drop out; a single line flattens to itself, unmarked.
+  assert.equal(flattenInvocationLines(["", "   "]), undefined);
+  assert.equal(stripAnsi(flattenInvocationLines(["$ ls -la"])!), "$ ls -la");
+  assert.equal(stripAnsi(flattenInvocationLines(["$ cat <<'EOF'", "  body", "EOF"])!), "$ cat <<'EOF' \u21b5 body \u21b5 EOF");
+});
+
+test("rows sit on the native tool surface: full-width band, reset-proof, self-shell exempt", () => {
+  const BG_OPEN = "\x1b[48;2;30;30;40m";
+  const bgFn = (text: string) => `${BG_OPEN}${text}\x1b[49m`; // theme.bg shape
+  const comp = toolComp({ contentBox: { bgFn }, getRenderShell: () => "box" });
+
+  const line = oneLine(comp, 80);
+  assert.ok(line.startsWith(BG_OPEN), "row must open on the tool background");
+  assert.ok(line.endsWith("\x1b[49m"), "row must close only the background");
+  assert.equal(visibleWidth(line), 80, "band must span the full width");
+  for (const segment of line.split("\x1b[0m").slice(1)) {
+    assert.ok(segment.startsWith(BG_OPEN), `background must be re-asserted after every reset: ${JSON.stringify(segment)}`);
+  }
+
+  // No native shade → no band: self-framing tools and rows without a contentBox.
+  assert.equal(rowBackground(toolComp({ contentBox: { bgFn }, getRenderShell: () => "self" })), undefined);
+  assert.equal(rowBackground(toolComp()), undefined);
+  assert.equal(oneLine(toolComp(), 80).includes(BG_OPEN), false);
+
+  // A bgFn that paints nothing leaves the row untouched.
+  assert.equal(shadeRow("x", 10, (text) => text), "x");
+});
+
+test("hyperlinked read rows (OSC 8, ST-terminated): text survives stripAnsi, URL survives tildify, emphasis applies", () => {
+  // pi-tui's hyperlink() emits \x1b]8;;URL\x1b\\TEXT\x1b]8;;\x1b\\ on hyperlink-capable
+  // terminals. A greedy OSC strip swallowed TEXT (killing path emphasis), and a naive
+  // tildify rewrote the home dir inside the URL (breaking the click target).
+  const url = `file://${homedir()}/projects/demo/file.ts`;
+  const linked = `read \x1b]8;;${url}\x1b\\~/projects/demo/file.ts\x1b]8;;\x1b\\:1-40`;
+  assert.equal(stripAnsi(linked), "read ~/projects/demo/file.ts:1-40", "link text must survive stripAnsi");
+  assert.ok(tildify(linked).includes(`\x1b]8;;${url}\x1b\\`), "OSC URL must not be tildified");
+
+  const comp = toolComp({ callRendererComponent: { render: () => [linked] } });
+  const line = oneLine(comp, 80);
+  assert.ok(
+    line.includes("\x1b[38;2;128;128;128m~/projects/demo/\x1b[0m"),
+    `path emphasis must apply on hyperlink terminals: ${JSON.stringify(line)}`,
+  );
 });
 
 test("native invocation drops the expand hint and keeps only the first visible line", () => {


### PR DESCRIPTION
Fixes #10, plus the design pass discussed alongside it: one-line rows looked like plain prose (same white ink, no tool surface).

## 1. Multiline bash flattening (#10)

`formatBashCall` keeps the command's real newlines, and one-line mode took only the first rendered line — so heredocs/inline scripts collapsed to `$ python3 -c "`. Now every visible call line flattens into the one trace line with a dim `↵` marking each break; middle truncation keeps the head **and** the operative tail:

```
› $ python3 -c " ↵ import json ↵ p='~/.pi/agent/… -p -t pog-th | grep -E "cache|fable" | tail -4   257 ch
```

Bash-only by design: for other tools, first-line-only is what suppresses preview/body lines. The `(timeout Ns)` suffix stays dropped per the existing ink-hierarchy decision (it now lands at the end of the flattened line, where the existing stripper removes it; the full invocation remains one Ctrl+T away).

## 2. The tool surface

Each row now sits on pi's own status-tinted tool background — the exact `toolPendingBg`/`toolSuccessBg`/`toolErrorBg` surface the expanded block uses, borrowed live from the row's `contentBox.bgFn`. Properties that fall out for free: theme/light-dark/colour-mode correctness, retint when the result lands, no band for self-framing tools (matching native), and collapsed↔expanded reading as the same object at different zoom. Consecutive rows tile into one shaded slab per tool group. The band is reset-proof (re-asserted after every full SGR reset).

## 3. OSC 8 fixes the visual pass surfaced (pre-existing)

- `_lib` `stripAnsi`'s OSC matcher was greedy across ST-terminated hyperlink pairs, swallowing the link text — silently disabling read-row path emphasis on hyperlink-capable terminals. OSC payloads can never contain ESC, so the matcher now stops at the first terminator.
- `tildify` rewrote the home dir inside `file://` hyperlink URLs, corrupting click targets. It now skips OSC sequence contents.

Known trade-off: when path emphasis applies on hyperlink terminals (it previously never did, due to the greedy strip), the rebuilt line is plain text rather than a hyperlink — same as the existing non-hyperlink rendering.

## Verification

- typecheck clean; 97/97 tests (3 new unit tests + 1 new contract test pinning the bash multiline render shape, `contentBox.bgFn`, `theme.bg` output shape, and bash not self-framed)
- Visual verification: real `ToolExecutionComponent`s rendered through the new path and screenshotted — read emphasis on the success band, flattened #10-shaped command, error row red, running row neutral, slab grouping vs prose. Patch version bumped for live reloads.
