### PR TITLE
Cachemire: chat lines persist across pi's chat rebuilds

### DIFF
--- a/extensions/_lib/chat.ts
+++ b/extensions/_lib/chat.ts
@@ -2,6 +2,7 @@
 // against extension-visible component shapes and contract-tested against the
 // installed pi (tests/contract/pi-internals.test.ts), never imported from
 // pi internals — that is what lets the family survive `pi update`.
+import { stripAnsi } from "./ansi.ts";
 
 /** A tool execution row: has setExpanded() and a toolName property. */
 export function isToolRow(component: unknown): boolean {
@@ -41,7 +42,27 @@ export function findContainerBy(
   return undefined;
 }
 
-/** pi's chat container: the one whose direct children include the chat rows. */
+// The startup resource listing pi renders into the chat container at session start:
+// leaf ExpandableText sections whose first line is a [Section] header. This is the
+// chat container's only reliable pre-rows tenant (the welcome/changelog block is
+// gated on updates), and the same seam pi-contextimate has anchored on since v1.
+const RESOURCE_HEADER_RE = /^\s*\[(Context|Skills|Prompts|Extensions|Themes)\]/m;
+
+function isResourceRow(component: unknown): boolean {
+  const c = component as { render?: (width: number) => string[]; children?: unknown };
+  if (!c || typeof c.render !== "function" || Array.isArray(c.children)) return false;
+  try {
+    return RESOURCE_HEADER_RE.test(stripAnsi(c.render(200).join("\n")));
+  } catch {
+    return false;
+  }
+}
+
+/** pi's chat container: the one whose direct children include the chat rows — or, in a
+ * fresh session with no rows yet, the startup resource listing. */
 export function findChatContainer(node: unknown): ContainerLike | undefined {
-  return findContainerBy(node, (children) => children.some((c) => isToolRow(c) || isAssistantRow(c)));
+  return (
+    findContainerBy(node, (children) => children.some((c) => isToolRow(c) || isAssistantRow(c))) ??
+    findContainerBy(node, (children) => children.some((c) => isResourceRow(c)))
+  );
 }

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -228,3 +228,12 @@ Scrollback lines are appended to pi's chat container directly (found structurall
 traceline); if that internal seam ever drifts, cachemire degrades to plain `notify`
 lines and the contract test suite names the break. Nothing in pi's `node_modules` is
 modified, so this survives `pi update`.
+
+The lines also **persist across pi's chat rebuilds**. Ctrl+T (and compaction, tree
+navigation) rebuild the chat from session messages — raw appended children, including
+pi's own status lines, are dropped. Status lines are flotsam; cachemire's lines are
+forensic records, so each is tracked with a durable anchor (the nearest preceding tool
+row's `toolCallId`, or a message component's `role#timestamp`, plus its offset) and
+re-attached in place after every rebuild. When a rebuild no longer contains the anchor
+(compaction, branch navigation), the context the line annotated is gone — it is dropped
+rather than re-attached somewhere misleading.

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -839,6 +839,73 @@ export function loadConfig(cwd: string): CachemireConfig {
 // --- chat scrollback append (display-only; never touches LLM context) -------------------
 // ctx.ui.notify force-dims and replaces consecutive status lines, so ledger lines are
 // appended straight to pi's chat container (found structurally via the shared _lib).
+//
+// Persistence: pi rebuilds that container from session messages on several events
+// (Ctrl+T's reasoning toggle, compaction, tree navigation) — chatContainer.clear() plus
+// a re-render drops every raw appended child, including pi's own status lines. Status
+// lines are flotsam; cachemire's lines are forensic records, so each one is tracked
+// with a durable anchor — the nearest preceding child with rebuild-stable identity (a
+// tool row's toolCallId, or a message component's role#timestamp) plus the count of
+// unkeyed children between anchor and line — and re-attached after every rebuild. When
+// a rebuild no longer contains the anchor (compaction, branch navigation), the context
+// the line annotated is gone, so it is dropped rather than re-attached misleadingly.
+
+export interface AnchoredLine<C = unknown> {
+  spacer: C;
+  text: C;
+  /** Durable key of the nearest preceding keyed child; undefined = anchored to chat start. */
+  anchorKey?: string;
+  /** Unkeyed, non-cachemire children between the anchor and this line's spacer. */
+  gap: number;
+}
+
+export function childAnchorKey(child: unknown): string | undefined {
+  const c = child as { toolCallId?: unknown; lastMessage?: { role?: unknown; timestamp?: unknown } } | undefined;
+  if (typeof c?.toolCallId === "string") return `tool#${c.toolCallId}`;
+  const message = c?.lastMessage;
+  if (typeof message?.role === "string" && message.timestamp !== undefined) {
+    return `${message.role}#${message.timestamp}`;
+  }
+  return undefined;
+}
+
+export function anchorForAppend(children: unknown[], anchored: AnchoredLine[]): { anchorKey?: string; gap: number } {
+  const ours = new Set(anchored.flatMap((line) => [line.spacer, line.text]));
+  let gap = 0;
+  for (let i = children.length - 1; i >= 0; i--) {
+    const key = childAnchorKey(children[i]);
+    if (key !== undefined) return { anchorKey: key, gap };
+    if (!ours.has(children[i])) gap++;
+  }
+  return { gap };
+}
+
+/** Re-insert tracked lines into a rebuilt children array (mutated in place). Returns the
+ * survivors; lines whose anchor vanished are dropped. Idempotent: lines still present
+ * (e.g. the hook fired without a rebuild) are left where they are. */
+export function reattachAnchored(children: unknown[], anchored: AnchoredLine[]): AnchoredLine[] {
+  const ours = new Set(anchored.flatMap((line) => [line.spacer, line.text]));
+  const survivors: AnchoredLine[] = [];
+  for (const line of anchored) {
+    if (children.includes(line.text)) {
+      survivors.push(line);
+      continue;
+    }
+    let index = 0;
+    if (line.anchorKey !== undefined) {
+      const at = children.findIndex((child) => childAnchorKey(child) === line.anchorKey);
+      if (at === -1) continue;
+      index = at + 1;
+    }
+    // Walk the gap (skipping lines of ours already re-inserted, which don't count), then
+    // past any of ours sitting exactly at the target so append order is preserved.
+    let remaining = line.gap;
+    while (index < children.length && (ours.has(children[index]) || remaining-- > 0)) index++;
+    children.splice(index, 0, line.spacer, line.text);
+    survivors.push(line);
+  }
+  return survivors;
+}
 
 // --- live state ------------------------------------------------------------------------
 
@@ -866,6 +933,11 @@ interface CachemireState {
   providerLabel?: string;
   compacted: boolean;
   inCompaction: boolean;
+  /** Chat lines cachemire appended, with anchors for re-attachment after pi rebuilds. */
+  anchored: AnchoredLine[];
+  /** Cached chat container: rebuilds empty it of recognizable rows, but the instance
+   * lives for the whole interactive session, so the first find stays valid. */
+  chat?: { addChild?: (child: unknown) => void; children: unknown[] };
   /** Records before this index belong to a dead cache lineage (pre-compaction, or before
    * a model/system/tools/history/thinking change): entries the current prefix cannot
    * read, so entry matching never names them. */
@@ -898,6 +970,7 @@ function state(): CachemireState {
       expectedRead: 0,
       compacted: false,
       inCompaction: false,
+      anchored: [],
       lineageStart: 0,
     };
   }
@@ -936,14 +1009,44 @@ function updateWidget(now = Date.now()): void {
   s.ui.setWidget("pi-cachemire", text === "" ? undefined : [text]);
 }
 
+const CHAT_CLEAR_HOOK_VERSION = 1;
+
+// Wrap the chat container's clear() (instance-level, original preserved) so every
+// rebuild is followed by a re-attach. The rebuild that follows clear() is synchronous;
+// a microtask runs after it completes — including pi's own trailing status line — so
+// anchors are matched against the final rebuilt children.
+function ensureChatClearHook(chat: Record<string, unknown>): void {
+  if (typeof chat.clear !== "function" || chat.__piCachemireClearVersion === CHAT_CLEAR_HOOK_VERSION) return;
+  const original = (chat.__piCachemireOriginalClear as (() => unknown) | undefined) ??
+    (chat.clear as () => unknown).bind(chat);
+  chat.__piCachemireOriginalClear = original;
+  chat.clear = () => {
+    const result = original();
+    queueMicrotask(() => {
+      const s = state();
+      const children = (chat as { children?: unknown[] }).children;
+      if (!Array.isArray(children) || s.anchored.length === 0) return;
+      s.anchored = reattachAnchored(children, s.anchored);
+      s.tui?.requestRender?.(true);
+    });
+    return result;
+  };
+  chat.__piCachemireClearVersion = CHAT_CLEAR_HOOK_VERSION;
+}
+
 function appendChatLine(text: string): Text | undefined {
   const s = state();
-  const chat = s.tui ? findChatContainer(s.tui) : undefined;
-  if (chat?.addChild) {
+  const chat = (s.tui ? findChatContainer(s.tui) : undefined) ?? s.chat;
+  if (chat?.addChild && Array.isArray(chat.children)) {
+    s.chat = chat as CachemireState["chat"];
     try {
       const line = new Text(text, 1, 0);
-      chat.addChild(new Spacer(1));
+      const spacer = new Spacer(1);
+      const anchor = anchorForAppend(chat.children, s.anchored);
+      chat.addChild(spacer);
       chat.addChild(line);
+      s.anchored.push({ spacer, text: line, ...anchor });
+      ensureChatClearHook(chat as unknown as Record<string, unknown>);
       s.tui?.requestRender?.(true);
       return line;
     } catch {
@@ -1265,6 +1368,9 @@ export const internals = {
   formatTokensK,
   formatUsd,
   formatDuration,
+  childAnchorKey,
+  anchorForAppend,
+  reattachAnchored,
   cacheClock,
   renderRunSummary,
   renderMissLine,

--- a/tests/cachemire/persistence.test.ts
+++ b/tests/cachemire/persistence.test.ts
@@ -1,0 +1,86 @@
+// Chat-line persistence: cachemire's scrollback lines survive pi's chat rebuilds
+// (Ctrl+T reasoning toggle, etc.) by re-attaching at durable anchors. pi rebuilds the
+// container from session messages, so raw appended children — including pi's own status
+// lines — are dropped; these tests drive the pure anchor/re-attach machinery with
+// synthetic children shaped like the real components (shape pinned by the contract suite).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { internals } from "../../extensions/pi-cachemire/index.ts";
+import type { AnchoredLine } from "../../extensions/pi-cachemire/index.ts";
+
+const { childAnchorKey, anchorForAppend, reattachAnchored } = internals;
+
+const tool = (id: string) => ({ toolCallId: id, render: () => [] });
+const assistant = (ts: string) => ({ lastMessage: { role: "assistant", timestamp: ts }, render: () => [] });
+const spacer = () => ({ kind: "spacer" });
+const user = () => ({ kind: "user-message" }); // UserMessageComponent exposes no durable identity
+
+test("childAnchorKey: durable identities only", () => {
+  assert.equal(childAnchorKey(tool("t1")), "tool#t1");
+  assert.equal(childAnchorKey(assistant("2026-06-10T22:00:00.000Z")), "assistant#2026-06-10T22:00:00.000Z");
+  assert.equal(childAnchorKey(spacer()), undefined);
+  assert.equal(childAnchorKey(user()), undefined);
+  assert.equal(childAnchorKey(undefined), undefined);
+});
+
+test("anchorForAppend: nearest keyed predecessor, counting only unkeyed non-cachemire children", () => {
+  const t1 = tool("t1");
+  // [assistant, spacer, tool, spacer, user] → anchor = tool, gap = 2 (spacer + user)
+  const children: unknown[] = [assistant("T0"), spacer(), t1, spacer(), user()];
+  assert.deepEqual(anchorForAppend(children, []), { anchorKey: "tool#t1", gap: 2 });
+
+  // Lines of ours already appended after the anchor are not part of the gap.
+  const mine: AnchoredLine = { spacer: spacer(), text: { line: 1 }, anchorKey: "tool#t1", gap: 0 };
+  const withOurs = [t1, mine.spacer, mine.text, spacer(), user()];
+  assert.deepEqual(anchorForAppend(withOurs, [mine]), { anchorKey: "tool#t1", gap: 2 });
+
+  // No keyed child at all: anchored to chat start.
+  assert.deepEqual(anchorForAppend([spacer(), user()], []), { gap: 2 });
+});
+
+test("reattachAnchored: a Ctrl+T-style rebuild restores lines in place", () => {
+  // Append-time chat: [assistantA, toolT, SPACER, missLine, spacer, userB, SPACER, notice]
+  const missLine: AnchoredLine = { spacer: spacer(), text: { line: "miss" }, anchorKey: "tool#t1", gap: 0 };
+  const notice: AnchoredLine = { spacer: spacer(), text: { line: "notice" }, anchorKey: "tool#t1", gap: 2 };
+
+  // pi rebuilds from session messages: same sequence, new component objects, no our lines,
+  // plus pi's trailing status line pair.
+  const rebuilt: unknown[] = [assistant("T0"), tool("t1"), spacer(), user(), spacer(), { status: true }];
+  const survivors = reattachAnchored(rebuilt, [missLine, notice]);
+
+  assert.equal(survivors.length, 2);
+  assert.equal(rebuilt.indexOf(missLine.text), 3, "miss line returns to directly after its tool row");
+  assert.equal(rebuilt.indexOf(notice.text), 7, "notice returns to after the user message it preceded the response of");
+  assert.equal(rebuilt.indexOf(missLine.spacer), rebuilt.indexOf(missLine.text) - 1, "spacer travels with its line");
+
+  // Idempotent: a second pass (clear() is called twice per toggle) changes nothing.
+  const again = reattachAnchored(rebuilt, survivors);
+  assert.equal(again.length, 2);
+  assert.equal(rebuilt.filter((c) => c === missLine.text).length, 1, "no duplicate insertion");
+});
+
+test("reattachAnchored: vanished anchors drop their lines; start-anchored lines survive", () => {
+  const line: AnchoredLine = { spacer: spacer(), text: { line: "old" }, anchorKey: "tool#gone", gap: 0 };
+  const rebuilt: unknown[] = [assistant("T9")];
+  assert.equal(reattachAnchored(rebuilt, [line]).length, 0, "compaction/navigation removed the anchor — line drops");
+  assert.equal(rebuilt.length, 1, "children untouched for dropped lines");
+
+  // A line appended before any keyed child re-attaches at the chat start (after its gap).
+  const ledger: AnchoredLine = { spacer: spacer(), text: { line: "ledger" }, gap: 1 };
+  const fresh: unknown[] = [{ banner: true }, spacer(), { status: true }];
+  const survivors = reattachAnchored(fresh, [ledger]);
+  assert.equal(survivors.length, 1);
+  assert.equal(fresh.indexOf(ledger.text), 2, "inserted after its gap from the start");
+});
+
+test("multiple lines on one anchor keep append order", () => {
+  const a: AnchoredLine = { spacer: spacer(), text: { line: "a" }, anchorKey: "tool#t1", gap: 0 };
+  const b: AnchoredLine = { spacer: spacer(), text: { line: "b" }, anchorKey: "tool#t1", gap: 0 };
+  const rebuilt: unknown[] = [tool("t1"), { after: true }];
+  reattachAnchored(rebuilt, [a, b]);
+  const ia = rebuilt.indexOf(a.text);
+  const ib = rebuilt.indexOf(b.text);
+  assert.ok(ia < ib, "append order preserved");
+  assert.equal(ia, 2, "first line directly after the anchor");
+});

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -13,6 +13,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import * as pi from "@earendil-works/pi-coding-agent";
 import * as piTui from "@earendil-works/pi-tui";
 
+import { internals as cachemire } from "../../extensions/pi-cachemire/index.ts";
 import { internals as contextimate } from "../../extensions/pi-contextimate/index.ts";
 import { internals as traceline } from "../../extensions/pi-traceline/index.ts";
 
@@ -191,6 +192,48 @@ test("real AssistantMessageComponent satisfies traceline's assistant duck type",
   assert.equal(peek.hideThinkingBlock, false);
   component.setHideThinkingBlock(true);
   assert.equal(peek.hideThinkingBlock, true, "hideThinkingBlock no longer mirrors setHideThinkingBlock — collapse state desyncs");
+});
+
+test("chat-rebuild surface cachemire's line persistence depends on", () => {
+  // Ctrl+T (and compaction/navigation) rebuild the chat container from session messages:
+  // clear() + re-render drops raw appended children. Cachemire re-attaches its lines
+  // after every clear(), anchored on durable component identity.
+  const source = readFileSync(join(piRoot, "dist/modes/interactive/interactive-mode.js"), "utf8");
+  assert.ok(
+    /toggleThinkingBlockVisibility\(\)\s*\{[^}]*this\.chatContainer\.clear\(\)/s.test(source),
+    "Ctrl+T no longer clears the chat container — re-verify whether cachemire's clear hook is still needed/sufficient",
+  );
+  assert.ok(source.includes("rebuildChatFromMessages"), "rebuildChatFromMessages gone — rebuild path renamed");
+
+  // Anchor identities: tool rows by toolCallId, assistant rows by lastMessage role#timestamp.
+  pi.initTheme(undefined, false);
+  const toolComp = new pi.ToolExecutionComponent("read", "tool-9", { path: "/tmp/x" }, undefined, undefined, {} as never, tmpdir());
+  assert.equal(cachemire.childAnchorKey(toolComp), "tool#tool-9", "toolCallId drifted — tool-row anchors break");
+
+  const ts = "2026-06-10T22:00:00.000Z";
+  const assistantComp = new pi.AssistantMessageComponent(
+    { role: "assistant", content: [{ type: "text", text: "hi" }], timestamp: ts } as never,
+  );
+  assert.equal(
+    cachemire.childAnchorKey(assistantComp),
+    `assistant#${ts}`,
+    "AssistantMessageComponent.lastMessage role/timestamp drifted — assistant anchors break",
+  );
+
+  // The container instance exposes clear() and a mutable children array to hook.
+  const container = new piTui.Container();
+  assert.equal(typeof container.clear, "function", "Container.clear gone — clear hook cannot install");
+
+  // Pre-rows chat detection: the startup resource listing must still be rendered into
+  // chatContainer as sections (the seam both contextimate and _lib findChatContainer's
+  // fresh-session fallback anchor on), and its [Section] headers must keep their names.
+  assert.ok(
+    /addLoadedSection[\s\S]{0,400}this\.chatContainer\.addChild\(section\)/.test(source),
+    "startup resource sections no longer added to chatContainer — pre-rows chat detection dies",
+  );
+  for (const name of ["Skills", "Prompts", "Extensions", "Themes"]) {
+    assert.ok(source.includes(`"${name}"`), `startup section [${name}] renamed — RESOURCE_HEADER_RE drifts`);
+  }
 });
 
 test("TUI prototype chain still contains a patchable Container", () => {

--- a/tests/smoke/startup-smoke.mjs
+++ b/tests/smoke/startup-smoke.mjs
@@ -149,6 +149,17 @@ try {
   pane = capture({ visibleOnly: true });
   const blocks = (pane.match(/\[Context Estimator\]/g) ?? []).length;
   check("exactly one estimator block after /reload", blocks === 1, `found ${blocks}`);
+
+  // 4. Cachemire chat lines persist across pi's chat rebuild (Ctrl+T toggles reasoning
+  // visibility by clearing + rebuilding the chat container from session messages, which
+  // drops raw appended children). /cache appends a ledger line; it must still be on
+  // screen after the rebuild. Visible-only: scrollback retains pre-toggle frames.
+  run(["tmux", "send-keys", "-t", session, "/cache", "Enter"]);
+  waitFor("cachemire ledger renders", (text) => text.includes("cache & loop ledger"));
+  run(["tmux", "send-keys", "-t", session, "C-t"]);
+  pane = waitFor("thinking toggle status", (text) => /Thinking blocks: (hidden|visible)/.test(capture({ visibleOnly: true })));
+  pane = capture({ visibleOnly: true });
+  check("cachemire ledger survives the Ctrl+T chat rebuild", pane.includes("cache & loop ledger"));
 } finally {
   run(["tmux", "send-keys", "-t", session, "/exit", "Enter"]);
   sleep(1000);


### PR DESCRIPTION
Fixes the report that a `cache broke` line disappears on Ctrl+T.

## Why it vanished

Ctrl+T's reasoning toggle (and compaction / tree navigation) rebuild pi's chat container from session messages: `chatContainer.clear()` + re-render. Raw appended children — including pi's **own** status lines — are dropped by design. Cachemire's lines were raw children.

## Fix

- Every appended line is tracked with a **durable anchor**: the nearest preceding child with rebuild-stable identity (tool row `toolCallId`, or message component `role#timestamp`) plus the count of unkeyed children between anchor and line.
- A versioned instance hook on the container's `clear()` re-attaches lines via microtask once the synchronous rebuild (including pi's trailing status line) finishes. Idempotent across the double `clear()` per toggle.
- Lines whose anchor vanished (compaction, branch navigation) are **dropped, not misplaced** — the context they annotated is gone.
- `_lib findChatContainer` gains a fresh-session fallback: the startup resource listing (`[Section]` rows — the chat container's only reliable pre-rows tenant, and the seam contextimate has anchored on since v1). Previously `/cache` or a first-send notice in a fresh session fell back to `notify`, which pi's next status update replaces silently.

## Verification

- 5 new unit tests (anchor identity, gap math, Ctrl+T-style rebuild round-trip, idempotency, vanished-anchor drop, append-order preservation)
- contract test pinning the rebuild surface: Ctrl+T clears the chat, `toolCallId`/`lastMessage` identities, `Container.clear`, resource sections rendered into `chatContainer`
- **new live smoke step**: `/cache` then Ctrl+T in real pi — failed before the fix (ledger wiped), passes after (103/103 unit+contract, smoke green)
- README: persistence behaviour documented under the scrollback section