### PR TITLE
Design language: family contract + style/number-grammar foundation (pass 1)

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -1,0 +1,331 @@
+# The pine-of-glass design language
+
+One visual grammar for the extension family — `pi-contextimate`, `pi-traceline`,
+`pi-cachemire`, and anything added later. This document is the contract; `extensions/_lib`
+is its implementation. When a renderer and this document disagree, one of them is wrong —
+fix whichever it is, deliberately.
+
+**Status: agreed 2026-06-12.** Decisions marked `[D]` were proposed-by-default and
+confirmed; the former open questions are resolved in §11. Changes to this language are
+fine — but they are design decisions, made here first, then implemented.
+
+## Why
+
+The three extensions answer adjacent questions about the same agent loop:
+
+| | granularity | currency | question |
+|---|---|---|---|
+| contextimate | static prefix | estimated tokens | what am I carrying? |
+| traceline | per tool call | exact chars | what did tools do? |
+| cachemire | per model call / turn | exact provider tokens & $ | what did the loop cost, and why? |
+
+They should read as one instrument panel, not three apps that happen to share a repo.
+Today they are three dialects: three glyph sets, three colour-sourcing strategies, and
+two private number formatters despite `_lib/fmt.ts` claiming a shared grammar. This
+document defines the single language; the per-extension conformance lists at the end
+say exactly what each one changes to speak it.
+
+## Principles
+
+1. **Skimmable first, auditable second.** The default rendering of every surface is
+   optimized for the half-second glance. Methodology, provenance, and caveats exist —
+   once, in a dim place — never repeated per row.
+2. **Quantities carry the eye.** Counts are right-aligned or column-aligned, in one
+   number grammar, so magnitude can be compared down a column without reading.
+3. **Severity is colour, identity is glyph, content is neutral.** Status lives in the
+   1-character marker that opens a line; the body text stays in the neutral ink ramp.
+   A wall of family output should look calm until something is actually wrong or big.
+4. **Honest tense and honest certainty.** Estimates wear `~`; provider-reported numbers
+   do not. In-flight statements are progressive with estimates; resolved statements are
+   past tense with exacts. Wording strength matches evidence strength
+   (contract → definite, documented band → hedged, nothing → "likely").
+5. **The theme owns the ink.** All colour flows through `_lib/style.ts`, which derives
+   from the active pi `Theme`. No raw ANSI colour constants in extension code. Family
+   identity comes from the glyph and layout grammar, not from a brand colour.
+6. **Silence when healthy.** Lines appear when they inform a decision or flag an
+   anomaly (cachemire's materiality threshold is the precedent). No ambient chrome.
+
+## 1. Glyph grammar
+
+Every family-rendered line opens with a one-character marker in the 2-space gutter.
+The marker identifies the *kind* of line; its **colour carries status**; the body text
+stays neutral.
+
+| glyph | meaning | used by |
+|---|---|---|
+| `›` | a tool action (one trace row) | traceline |
+| `◍` | a loop-economics fact (clock, notice, ledger line) | cachemire |
+| `▸` | an expandable/summarizable section header | contextimate (all modes) |
+
+Status scale — family-shared vocabulary (today cachemire-only):
+
+| glyph | meaning |
+|---|---|
+| `○` | cold / empty |
+| `●` | hit / full |
+| `◑` | partial |
+| `◌` | miss / broken |
+
+Auxiliary marks, always at the **dim** ink level: `…` (truncation), `↵` (flattened
+newline), `·` (U+00B7, the only inline fact separator).
+
+Rules:
+- One glyph per line, gutter position, never inline mid-sentence.
+- New line kinds reuse an existing glyph if the kind matches; a new glyph is a design
+  decision recorded here, not an ad-hoc choice.
+
+## 2. Ink hierarchy
+
+Four levels, mapped to pi theme roles. Every piece of text in a family surface is
+assigned a level on purpose.
+
+| level | role | carries | theme source |
+|---|---|---|---|
+| L0 | discriminator | verb/tool name, basename, totals, panel brand | `text` + bold; panel brands/totals `accent` |
+| L1 | content | operative arguments, values | `text` |
+| L2 | secondary identity | directories, descriptions, field types | `muted` |
+| L3 | apparatus | methodology, plumbing (`&&`, `2>/dev/null`), markers, units, causes | `dim` |
+
+Status/severity tones (glyphs and quantity suffixes only, never body prose):
+
+| tone | meaning | theme source |
+|---|---|---|
+| success | completed / hit / fresh | `success` |
+| warning | fading / closing / large / partial | `warning` |
+| error | failed / broken / huge | `error` |
+| running | in flight | none faithful — `style.ts` fallback (ANSI blue) `[D]` |
+
+The test of a good ink assignment: squint. Only L0 and any non-dim severity tones
+should survive the squint. If a slab of tool rows survives at the same brightness as
+assistant prose, the hierarchy is wrong (this is today's traceline complaint).
+
+## 3. Colour sourcing
+
+- **All ink goes through `_lib/style.ts`.** No `\x1b[32m`, no hardcoded
+  `rgb(128,128,128)` in extension files. `style.ts` resolves tones against the live
+  `Theme` (`theme.fg("dim", …)` etc.), so light terminals and custom themes work.
+- **The family accent is `theme.fg("accent")`** `[D — resolved]`. The original orange
+  `rgb(245,151,52)` was an arbitrary pick, not a brand, and is dropped. Accent is used
+  sparingly: panel brands (`[Contextimate]`), highlighted token figures, total rows,
+  the filled part of proportion bars. Recognizability comes from the glyph and layout
+  grammar, which survives any theme.
+- Backgrounds are always **borrowed live from pi** (traceline's
+  `contentBox.bgFn` / `toolSuccessBg` pattern), never synthesized.
+- Components that render before a `Theme` handle exists may use `style.ts` raw
+  fallbacks; everything rendered after `session_start` has `ctx.ui.theme` and must use it.
+
+## 4. Number grammar
+
+One formatter family in `_lib/fmt.ts`, used by everyone. Private formatters
+(`compactTokenNumber` in contextimate, `formatTokensK` in cachemire) are deleted.
+
+| quantity | format | examples |
+|---|---|---|
+| counts | **fixed k-unit**, one decimal (`0.0k`–`999.9k`); one-decimal M ≥ 1M | `0.1k`, `1.2k`, `52.3k`, `9.1M` |
+| chars | count + ` ch` (`formatChars`) | `0.4k ch`, `1.4k ch`, `35.2k ch` |
+| tokens, estimated | `~` + count + ` tokens` (unit word may be dropped in columns) | `~0.1k tokens`, `~14.2k tokens` |
+| tokens, provider-reported | count, **no `~`** | `64.1k tokens` |
+| money | `$` two decimals; `~` when projected | `$0.05`, `$17.03`, `~$2.67` |
+| duration | compact mixed units, no spaces | `14s`, `4m30s`, `9h50m` |
+| share | integer percent in parens; one decimal only for context-window usage | `(97%)`, `32.2% / 200k ctx` |
+
+Hard rules:
+- **One unit, everywhere.** `[D — confirmed]` Counts never switch between raw integers
+  and k-units: same-unit rendering is what makes magnitudes comparable down a column
+  and across surfaces. `0.1k ch` and `35.2k ch` compare at a glance; `133 ch` and
+  `35.2k ch` do not. `0.0k` is acceptable noise; mixed units are not.
+  - This re-specifies `compactCount` in `_lib/fmt.ts` to fixed-k (its raw-integer
+    branch is removed), which *changes current output*: traceline suffixes
+    (`133 ch` → `0.1k ch`) and the cachemire ledger (`out 400` → `out 0.4k`).
+  - M is the only permitted step-up, at ≥ 1M, where k becomes unreadable
+    (`9.1M`, not `9100.0k`).
+- The `~`/no-`~` distinction is semantic — estimated vs provider-reported — not
+  stylistic. Do not add `~` for visual symmetry or drop it to save a column.
+- Bare counts (no unit) are allowed only directly after a labelled verb where the unit
+  is unambiguous: `read 150.3k · wrote 1.8k` (cachemire ledger style).
+- `formatUsd` and `formatDuration` move from cachemire into `_lib/fmt.ts`.
+
+## 5. Layout grammar
+
+- **Gutter:** 2 spaces, then the glyph, then 1 space, then the body.
+- **Quantities right.** Per-row magnitudes are a right-aligned dim suffix with a ≥2-space
+  gap (traceline's `… 1.4k ch` pattern) or a column-aligned field (contextimate rows,
+  cachemire `/cache` table). Never woven mid-sentence when the line is a row in a list.
+- **Facts inline are `·`-separated**, ordered: *what happened · how big · share · cost ·
+  cause*. Cause is always last and always L3-dim.
+- **Methodology appears once per panel** — a dim line under the panel header, or the
+  right side of a section header — never on data rows. Data rows carry at most a raw
+  size in parens: `(9.2k ch)`.
+- **Blank lines:** one before a group; none within it; a row sits tight under the
+  collapsed `Thinking…` line that motivated it (traceline's couplet rule, family-wide).
+- **Tildify** home paths; **middle-truncate** protecting the tail; dim the directory,
+  brighten the basename. (Traceline's rules, promoted to family rules; contextimate's
+  expanded tool paths already comply approximately.)
+
+### Panel headers
+
+Panels (multi-line surfaces with a top: contextimate's estimator, cachemire's `/cache`
+ledger) share one header form:
+
+```
+[Contextimate] summary → compact → expanded
+  ctrl+o: cycle view · model anthropic/claude-opus-4-8 · counts ch ÷ 2.6 (Claude 4.7+ heuristic)
+```
+
+- Line 1: `[Name]` in bold theme accent + mode pips when the panel has modes
+  (active mode accent-bold, others dim, `→` dim).
+- Line 2: dim hint line — keybinding, scope/profile, and the panel's methodology (once).
+- `[D]` Panels brand with the **extension name** (`[Contextimate]`, `[Cachemire]`), not
+  descriptive titles (`[Context Estimator]`, `Cachemire — cache & loop ledger`). One
+  naming system; the descriptive part can live in the dim hint line. This renames a
+  documented surface (README, tests) — flagged for explicit approval. `[Q]`
+
+### Proportion
+
+Magnitude tables answer "how big"; panels should also answer "**of what**". Where a
+total has a meaningful budget (context window), show share — a percent column and/or a
+single stacked bar:
+
+```
+  Total request   64.1k tokens (32.2% / 200k ctx)
+  ████████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  harness 14k · session 50k · free 136k
+```
+
+`[D]` contextimate's summary gains this (one bar + per-row share of harness); details in
+its conformance list. Bars use `█`/`▒`, accent for the carried part, dim for free.
+
+## 6. Severity grammar
+
+Anomaly thresholds tint the *quantity suffix or glyph*, not the body:
+
+- **Tool result size** (traceline): dim below 10k ch · warning ≥ 10k ch · error ≥ 50k ch.
+  Thresholds in `style.ts`, overridable via the family config convention
+  (`~/.pi/agent/pi-traceline.json`).
+- **Cache materiality** (cachemire, existing precedent): notices only above $0.05 or
+  20k re-written tokens — silence when healthy.
+- Severity colour is reserved for *exceeded thresholds and real states*. Nothing is
+  tinted "for visual interest".
+
+## 7. Wording grammar
+
+- **Tense rule (cachemire's, family-wide):** in-flight = progressive + `~`
+  (`cache breaking · re-writing ~138.2k`); resolved = past + exact
+  (`cache broke · re-wrote 138.2k`).
+- **Certainty ladder:** contract-backed → definite (`cache cold`); documented band →
+  hedged (`cache fading`); unknown provider → `likely`. Never write definite words on
+  soft evidence.
+- Status one-liners are lowercase; Title Case only for panel headers and row labels.
+- Causes are stated from observed evidence (payload diffs, usage), never inferred — and
+  say `unknown` when unknown.
+
+## 8. `_lib/style.ts` (to be created)
+
+The single implementation of sections 1–6. Sketch:
+
+```ts
+// identity
+export const GLYPH: { tool: "›"; econ: "◍"; section: "▸" };
+export const SCALE: { cold: "○"; hit: "●"; partial: "◑"; miss: "◌" };
+export const SEP = " · ";
+
+// ink — all colour flows through here
+export type Tone = "text" | "muted" | "dim" | "success" | "warning" | "error" | "running" | "accent";
+export function ink(theme: Theme | undefined, tone: Tone, text: string): string; // theme-derived, raw-ANSI fallback
+
+// layout helpers (lifted from traceline / contextimate, deduplicated)
+export function rightAlignSuffix(body: string, suffix: string, width: number): string;
+export function middleTruncate(line: string, width: number): string;   // moves from traceline
+export function tildify(text: string): string;                          // moves from traceline (OSC-8-safe)
+export function panelHeader(theme, name: string, pips?: …, hint?: string): string[];
+
+// severity
+export function sizeTone(chars: number, overrides?): Tone;             // dim | warning | error
+```
+
+`_lib/fmt.ts` grows `formatTokens(value, { exact?: boolean })`, `formatUsd`,
+`formatDuration`. `_lib` keeps no `index.ts` (pi discovery skips it).
+
+## 9. Conformance: what each extension changes
+
+### pi-contextimate
+
+1. Delete `compactTokenNumber`; use shared fixed-k `compactCount`. Visible change is
+   small: `~0.1k` stays `~0.1k`; integer-k above 1000 gains one decimal
+   (`~64k` → `~64.1k`) so precision is uniform down a column.
+2. Methodology to the header hint line (once); summary/compact rows keep only
+   `(9.2k ch)`; expanded section headers keep the full per-section method (that *is*
+   the audit view).
+3. `▸` on summary rows too (today compact-only), so sections read as the same object
+   across modes.
+4. Proportion: percent-of-window on the two total rows + one stacked bar under
+   `Total request`; optional per-row share of harness in summary. `[D]`
+5. Header becomes `[Contextimate]` + pips (pending the `[Q]` naming call); the pips
+   pattern moves to `style.ts` for reuse.
+6. Hardcoded `ORANGE` constant deleted; brand/figure/total highlights move to
+   `ink(theme, "accent", …)` — the orange was an arbitrary pick and is not retained.
+
+### pi-traceline
+
+1. All ink through `style.ts`: `MUTED_GREY`/raw ANSI replaced with theme-derived tones
+   (the bg-borrowing stays as-is — it is the model the family follows).
+2. **Severity-tinted size suffix** per section 6 — makes "which outputs ballooned"
+   actually pop; today every suffix is uniform grey. Suffix numbers move to fixed-k
+   via the shared formatter (`133 ch` → `0.1k ch`).
+3. **Repeated-preamble dimming:** when a row's leading segment (`cd X &&`, identical
+   pipeline head) repeats the previous row's, render that head at L3-dim (or elide to a
+   dim `⋯ &&`). Kills the wall-of-`cd` (issue #14).
+4. Body ink one step down: verb (L0) + operative tail/basename (L1) bright; mid-line
+   arguments L1→L2 where separable; plumbing stays L3. Tool slabs must fail the squint
+   test against prose.
+5. Fold paginated reads of one file into one row (`read …/index.ts:1-200,201-400 · 2
+   calls · 37.0k ch`) and fix doubled `Thinking…` lines — issue #14's scope, executed
+   under this language.
+6. `›`, `↵`, middle-truncation, tildify: unchanged in behaviour; implementation moves
+   to `_lib` so the family shares it.
+
+### pi-cachemire (WIP — apply before first publish)
+
+1. Delete `formatTokensK`; use fixed-k `compactCount` (ledger `out 400` becomes
+   `out 0.4k`). `formatUsd`/`formatDuration` move to `_lib/fmt.ts` (call sites
+   unchanged).
+2. `/cache` ledger adopts the panel-header grammar (`[Cachemire]` + dim profile/hint
+   line, pending `[Q]`).
+3. Status glyphs `○ ● ◑ ◌` and `◍` move to `style.SCALE`/`style.GLYPH` — promoted to
+   family vocabulary, behaviour unchanged.
+4. Clock/notice tones (green/yellow/grey) become theme-derived via `ink()`.
+5. Inline fact order audited against section 5 (*what · size · share · cost · cause*) —
+   mostly already true.
+
+## 10. Testing
+
+- Goldens are the visual regression net: each panel mode at 80 and 120 cols
+  (contextimate already has these; add traceline one-line goldens and cachemire
+  ledger/notice goldens). Regenerate with `UPDATE_GOLDENS=1 npm test`; review the diff
+  like code — number-grammar migration (4.) will move many goldens at once, in one
+  dedicated commit.
+- `style.ts` gets direct unit tests (tone fallbacks without a theme, severity
+  thresholds, right-align/truncate edge cases) — most lift from
+  `tests/traceline/one-line.test.ts`.
+- Contract tests are unaffected (no new pi-internal seams; `style.ts` consumes the
+  public `Theme`).
+
+## 11. Resolved questions
+
+All resolved with Thomas, 2026-06-12:
+
+1. **Panel naming** → extension names: `[Contextimate]`, `[Cachemire]` (descriptive
+   text demoted to the dim hint line). README/test references updated in each pass.
+2. **Contextimate proportion** → bar + percent (§5).
+3. **"Running" tone** → ANSI-blue fallback in `style.ts` (no faithful theme role;
+   `accent` would collide with brand/total highlights, `warning` overloads "fading").
+4. **Family accent** → theme-`accent`-derived; the orange was arbitrary and is dropped (§3).
+5. **Number grammar** → fixed k-units everywhere; no raw-integer counts (§4).
+
+## Suggested implementation order
+
+1. `_lib/style.ts` + `_lib/fmt.ts` additions, with tests (no visible change).
+2. Traceline pass (sections 6 + conformance 1–4; issue #14 items 3/5 can ride along).
+3. Contextimate pass (number grammar + methodology placement + proportion).
+4. Cachemire pass (cheap once 1. exists; before it ships in the npm package).
+
+One PR per pass; goldens regenerated within the pass that moves them.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -125,7 +125,7 @@ One formatter family in `_lib/fmt.ts`, used by everyone. Private formatters
 | chars | count + ` ch` (`formatChars`) | `0.4k ch`, `1.4k ch`, `35.2k ch` |
 | tokens, estimated | `~` + count + ` tokens` (unit word may be dropped in columns) | `~0.1k tokens`, `~14.2k tokens` |
 | tokens, provider-reported | count, **no `~`** | `64.1k tokens` |
-| money | `$` two decimals; `~` when projected | `$0.05`, `$17.03`, `~$2.67` |
+| money | `$` two decimals (three below $0.10, where the third digit is significant); `~` when projected | `$0.052`, `$17.03`, `~$2.67` |
 | duration | compact mixed units, no spaces | `14s`, `4m30s`, `9h50m` |
 | share | integer percent in parens; one decimal only for context-window usage | `(97%)`, `32.2% / 200k ctx` |
 

--- a/extensions/_lib/fmt.ts
+++ b/extensions/_lib/fmt.ts
@@ -1,16 +1,43 @@
-// Shared number grammar for the pine-of-glass extension family.
-// One language across extensions: counts are raw integers below 1000, one-decimal
-// k-units above (412, 1.2k, 52.3k), one-decimal M-units above a million (9.1M);
-// char counts read `412 ch`.
+// Shared number grammar for the pine-of-glass extension family
+// (docs/design-language.md §4). One unit, everywhere: counts render in fixed
+// one-decimal k-units (0.1k, 1.2k, 52.3k) so magnitudes compare down a column —
+// raw integers never appear. M is the only step-up, at ≥1M, where k becomes
+// unreadable (9.1M, not 9100.0k). Char counts read `0.4k ch`.
 
 export function compactCount(value: number): string {
   if (!Number.isFinite(value)) return "?";
   const rounded = Math.round(value);
   if (Math.abs(rounded) >= 999_950) return `${(rounded / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(rounded) >= 1000) return `${(rounded / 1000).toFixed(1)}k`;
-  return String(rounded);
+  return `${(rounded / 1000).toFixed(1)}k`;
 }
 
 export function formatChars(value: number): string {
   return `${compactCount(value)} ch`;
+}
+
+/**
+ * Token counts wear the estimate marker unless provider-reported: the ~/no-~
+ * distinction is semantic, never stylistic (design language §4).
+ */
+export function formatTokens(value: number, options: { exact?: boolean } = {}): string {
+  return `${options.exact ? "" : "~"}${compactCount(value)} tokens`;
+}
+
+/** Money: two decimals; three below $0.10, where the third digit is significant. */
+export function formatUsd(value: number): string {
+  return value >= 0.10 ? `$${value.toFixed(2)}` : `$${value.toFixed(3)}`;
+}
+
+/** Durations: compact mixed units, no spaces — 14s, 2m41s, 9h50m. */
+export function formatDuration(ms: number): string {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    const rest = seconds % 60;
+    return rest > 0 ? `${minutes}m${rest.toString().padStart(2, "0")}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const restMinutes = minutes % 60;
+  return restMinutes > 0 ? `${hours}h${restMinutes}m` : `${hours}h`;
 }

--- a/extensions/_lib/style.ts
+++ b/extensions/_lib/style.ts
@@ -1,0 +1,100 @@
+// The pine-of-glass family style — implementation of docs/design-language.md §§1–6.
+// Identity lives in glyphs and layout, not colour: all ink is theme-derived through
+// ink(), with raw-ANSI fallbacks only for surfaces rendered before a Theme handle
+// exists and for the one tone pi's theme has no faithful role for ("running").
+
+import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+
+/** Line-kind glyphs: one per line, gutter position (design language §1). */
+export const GLYPH = {
+  /** a tool action (one trace row) — traceline */
+  tool: "\u203a", // ›
+  /** a loop-economics fact (clock, notice, ledger line) — cachemire */
+  econ: "\u25cd", // ◍
+  /** an expandable/summarizable section header — contextimate */
+  section: "\u25b8", // ▸
+} as const;
+
+/** Status scale — family-shared vocabulary (design language §1). */
+export const SCALE = {
+  cold: "\u25cb", // ○ cold / empty
+  hit: "\u25cf", // ● hit / full
+  partial: "\u25d1", // ◑ partial
+  miss: "\u25cc", // ◌ miss / broken
+} as const;
+
+/** The only inline fact separator (design language §5). */
+export const SEP = " \u00b7 "; // ·
+
+/**
+ * Ink tones (design language §2): the neutral ramp (text/muted/dim), the status
+ * tones (success/warning/error/running), and the family accent.
+ */
+export type Tone =
+  | "text"
+  | "muted"
+  | "dim"
+  | "success"
+  | "warning"
+  | "error"
+  | "running"
+  | "accent";
+
+const THEME_ROLE: Partial<Record<Tone, ThemeColor>> = {
+  text: "text",
+  muted: "muted",
+  dim: "dim",
+  success: "success",
+  warning: "warning",
+  error: "error",
+  accent: "accent",
+  // "running" has no faithful theme role (accent would collide with brand/total
+  // highlights; warning overloads "fading") — resolved to the ANSI-blue raw tone
+  // (design language §11).
+};
+
+const RESET = "\x1b[0m";
+
+// Raw fallbacks: basic ANSI only (widest terminal support), used when no Theme is
+// available yet. "text" and "accent" fall back to uncoloured text — plain is honest
+// before the theme exists.
+const RAW: Record<Tone, string> = {
+  text: "",
+  muted: "\x1b[90m",
+  dim: "\x1b[90m",
+  success: "\x1b[32m",
+  warning: "\x1b[33m",
+  error: "\x1b[31m",
+  running: "\x1b[34m",
+  accent: "",
+};
+
+/** All family ink flows through here (design language §3). */
+export function ink(theme: Theme | undefined, tone: Tone, text: string): string {
+  if (text.length === 0) return text;
+  const role = THEME_ROLE[tone];
+  if (theme && role) {
+    try {
+      return theme.fg(role, text);
+    } catch {
+      // fall through to the raw tone — never let styling break a render
+    }
+  }
+  const open = RAW[tone];
+  return open ? `${open}${text}${RESET}` : text;
+}
+
+/** Severity thresholds for tool result sizes, in chars (design language §6). */
+export type SizeThresholds = { warning: number; error: number };
+
+export const SIZE_THRESHOLDS: SizeThresholds = { warning: 10_000, error: 50_000 };
+
+/**
+ * Tone for a result-size quantity: dim below the warning threshold so healthy rows
+ * stay quiet; warning/error above so ballooned outputs jump out of the column.
+ */
+export function sizeTone(chars: number, thresholds: SizeThresholds = SIZE_THRESHOLDS): Tone {
+  if (chars >= thresholds.error) return "error";
+  if (chars >= thresholds.warning) return "warning";
+  return "dim";
+}

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -164,7 +164,7 @@ and `/cache` for the full per-call table:
 ```
 ◍ Cachemire — cache & loop ledger   anthropic · 5m TTL · anthropic/claude-opus-4-8
    call     gap    input     read    wrote     out    cost  event
-      1       —    12.1k        0   138.2k     400   $0.55  ○ cold start
+      1       —    12.1k     0.0k   138.2k    0.4k   $0.55  ○ cold start
       2     14s     1.2k   150.3k     1.8k    1.1k   $0.04  ● hit
    totals: 2 calls · input 13.3k · read 150.3k · wrote 140.0k · out 1.5k · $0.59
    caching saved ~$0.65 vs uncached $0.91 (−71%) · API-priced; notional on subscription

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -6,7 +6,7 @@ import { stripAnsi } from "../_lib/ansi.ts";
 import { captureTui } from "../_lib/capture.ts";
 import { findChatContainer } from "../_lib/chat.ts";
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
-import { compactCount } from "../_lib/fmt.ts";
+import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 
 /**
  * pi-cachemire — explains the cache and loop economics of a pi session.
@@ -556,26 +556,13 @@ export function sessionSavings(records: CallRecord[]): { actual: number; uncache
 }
 
 // --- formatting ------------------------------------------------------------------------
+// formatUsd / formatDuration live in _lib/fmt.ts (family number grammar); re-exported
+// here because the test suite reaches them through this module's internals surface.
+
+export { formatDuration, formatUsd } from "../_lib/fmt.ts";
 
 export function formatTokensK(value: number): string {
   return compactCount(value);
-}
-
-export function formatUsd(value: number): string {
-  return value >= 0.10 ? `$${value.toFixed(2)}` : `$${value.toFixed(3)}`;
-}
-
-export function formatDuration(ms: number): string {
-  const seconds = Math.max(0, Math.round(ms / 1000));
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) {
-    const rest = seconds % 60;
-    return rest > 0 ? `${minutes}m${rest.toString().padStart(2, "0")}s` : `${minutes}m`;
-  }
-  const hours = Math.floor(minutes / 60);
-  const restMinutes = minutes % 60;
-  return restMinutes > 0 ? `${hours}h${restMinutes}m` : `${hours}h`;
 }
 
 // --- cache clock (pure state → text; tones applied by the widget layer) -----------------

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -13,11 +13,11 @@ When tool rows are collapsed, each one renders as a single line:
 ```
 › read resource .pi/agent/AGENTS.md:1-20                 1.4k ch
 › [skill] google-workspace-stack:1-20                    1.0k ch
-› [skill] tmux:1-20                                       912 ch
+› [skill] tmux:1-20                                      0.9k ch
 › subagent list                                          1.1k ch
-› subagent delegate                                       131 ch
-› write /tmp/pi-extension-test-...-elephant.txt            85 ch
-› $ rm /tmp/pi-extension-test-...-elephant.txt ...          0 ch
+› subagent delegate                                      0.1k ch
+› write /tmp/pi-extension-test-...-elephant.txt          0.1k ch
+› $ rm /tmp/pi-extension-test-...-elephant.txt ...       0.0k ch
 ```
 
 - **The arc of the turn** - every tool call in order, one line each, so you see the path Pi took.
@@ -37,7 +37,7 @@ Each trace line sits on Pi's own status-tinted tool background — the same shad
 Bash commands keep their real newlines — heredocs, inline `python3 -c` scripts, chained `tmux` pipelines. Taking only the first rendered line collapsed them to an uninformative prefix like `$ python3 -c "` (issue #10). Instead, the whole command is flattened into the one trace line with a dim `↵` marking each original break, and middle truncation then keeps both the head and the *operative tail* — the checks at the end of a pipeline, not just its preamble:
 
 ```
-› $ python3 -c " ↵ import json ↵ p='~/.pi/agent/… -p -t pog-th | grep -E "cache|fable" | tail -4   257 ch
+› $ python3 -c " ↵ import json ↵ p='~/.pi/agent/… -p -t pog-th | grep -E "cache|fable" | tail -4  0.3k ch
 ```
 
 ### Reading the end of the line
@@ -51,7 +51,7 @@ The discriminating part of a row usually lives at the **tail** — the filename 
 ```
 ›  read ~/projects/pine-of-glass/…/pi-traceline/README.md:1-300         3.8k ch
 ›  read ~/projects/pine-of-glass/…/pi-traceline/index.ts:1-200         18.5k ch
-›  $ cd ~/projects/pine-of-glass && rm -f docs/img/…-native.png            0 ch
+›  $ cd ~/projects/pine-of-glass && rm -f docs/img/…-native.png         0.0k ch
 ```
 
 ## Install

--- a/tests/cachemire/economics-and-render.test.ts
+++ b/tests/cachemire/economics-and-render.test.ts
@@ -43,7 +43,7 @@ test("session savings aggregate only over priced calls", () => {
 
 test("formatting primitives", () => {
   assert.equal(formatTokensK(940_100), "940.1k");
-  assert.equal(formatTokensK(312), "312");
+  assert.equal(formatTokensK(312), "0.3k"); // one unit everywhere — design language §4
   assert.equal(formatUsd(0.523), "$0.52");
   assert.equal(formatUsd(0.0523), "$0.052");
   assert.equal(formatDuration(41_000), "41s");
@@ -294,7 +294,7 @@ test("ledger view: rows, totals, and the savings line", () => {
   ];
   const lines = renderLedger(records, { providerLabel: "anthropic", window: CONTRACT_5M, modelLabel: "anthropic/claude-opus-4-8" });
   assert.match(lines[0]!, /Cachemire — cache & loop ledger\s+anthropic · 5m TTL · anthropic\/claude-opus-4-8/);
-  assert.match(lines[2]!, /^\s+1\s+—\s+12\.1k\s+0\s+138\.2k\s+400\s+\$0\.55\s+○ cold start$/);
+  assert.match(lines[2]!, /^\s+1\s+—\s+12\.1k\s+0\.0k\s+138\.2k\s+0\.4k\s+\$0\.55\s+○ cold start$/);
   assert.match(lines[3]!, /14s.*150\.3k.*● hit$/);
   assert.match(lines[4]!, /totals: 2 calls · input 13\.3k · read 150\.3k · wrote 140\.0k · out 1\.5k · \$0\.59/);
   assert.match(lines[5]!, /caching saved ~\$2\.37 vs uncached \$2\.96 \(−80%\) · API-priced; notional on subscription/);

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -139,7 +139,7 @@ test("real ToolExecutionComponent satisfies traceline's duck type and one-line p
   const line = traceline.oneLine(comp as never, 80);
   const visible = traceline.stripAnsi(line);
   assert.ok(visible.includes("read"), `one-line render lost the invocation: ${JSON.stringify(visible)}`);
-  assert.ok(/\b11 ch$/.test(visible.trimEnd()), `result-size suffix missing: ${JSON.stringify(visible)}`);
+  assert.ok(/\b0\.0k ch$/.test(visible.trimEnd()), `result-size suffix missing: ${JSON.stringify(visible)}`);
 
   // Error path drives the red status colour.
   comp.updateResult({ content: [{ type: "text", text: "boom" }], isError: true }, false);

--- a/tests/fixtures/goldens/contextimate-compact-anthropic-120.txt
+++ b/tests/fixtures/goldens/contextimate-compact-anthropic-120.txt
@@ -2,13 +2,13 @@
 [Context Estimator] summary → compact → expanded
   <expand-key>: cycle view · model anthropic/claude-opus-4-8 · Claude 4.7+ heuristic
 
-  ▸ Runtime system prompt      ~0.1k tokens (201 ch ÷ 2.6)
+  ▸ Runtime system prompt      ~0.1k tokens (0.2k ch ÷ 2.6)
 
-  ▸ Global AGENTS.md           ~0.0k tokens (64 ch ÷ 2.6)
+  ▸ Global AGENTS.md           ~0.0k tokens (0.1k ch ÷ 2.6)
 
-  ▸ ~/projects/demo/AGENTS.md  ~0.0k tokens (52 ch ÷ 2.6)
+  ▸ ~/projects/demo/AGENTS.md  ~0.0k tokens (0.1k ch ÷ 2.6)
 
-  ▸ Skill frontmatter (3)      ~0.3k tokens (743 ch ÷ 2.6)
+  ▸ Skill frontmatter (3)      ~0.3k tokens (0.7k ch ÷ 2.6)
     alpha-skill                ~0.1k  Handles A & B cases with a long description so it sorts first in token order for…
     beta-skill                 ~0.1k  It's the medium one.
     gamma                      ~0.1k  Tiny.

--- a/tests/fixtures/goldens/contextimate-compact-anthropic-80.txt
+++ b/tests/fixtures/goldens/contextimate-compact-anthropic-80.txt
@@ -2,13 +2,13 @@
 [Context Estimator] summary → compact → expanded
   <expand-key>: cycle view · model anthropic/claude-opus-4-8 · Claude 4.7+ heuristic
 
-  ▸ Runtime system prompt      ~0.1k tokens (201 ch ÷ 2.6)
+  ▸ Runtime system prompt      ~0.1k tokens (0.2k ch ÷ 2.6)
 
-  ▸ Global AGENTS.md           ~0.0k tokens (64 ch ÷ 2.6)
+  ▸ Global AGENTS.md           ~0.0k tokens (0.1k ch ÷ 2.6)
 
-  ▸ ~/projects/demo/AGENTS.md  ~0.0k tokens (52 ch ÷ 2.6)
+  ▸ ~/projects/demo/AGENTS.md  ~0.0k tokens (0.1k ch ÷ 2.6)
 
-  ▸ Skill frontmatter (3)      ~0.3k tokens (743 ch ÷ 2.6)
+  ▸ Skill frontmatter (3)      ~0.3k tokens (0.7k ch ÷ 2.6)
     alpha-skill                ~0.1k  Handles A & B cases with a long descripti…
     beta-skill                 ~0.1k  It's the medium one.
     gamma                      ~0.1k  Tiny.

--- a/tests/fixtures/goldens/contextimate-compact-codex-100.txt
+++ b/tests/fixtures/goldens/contextimate-compact-codex-100.txt
@@ -2,13 +2,13 @@
 [Context Estimator] summary → compact → expanded
   <expand-key>: cycle view · model openai-codex/gpt-5.5 · OpenAI-Codex heuristic
 
-  ▸ Runtime system prompt      ~0.1k tokens (201 ch ÷ 4)
+  ▸ Runtime system prompt      ~0.1k tokens (0.2k ch ÷ 4)
 
-  ▸ Global AGENTS.md           ~0.0k tokens (64 ch ÷ 4)
+  ▸ Global AGENTS.md           ~0.0k tokens (0.1k ch ÷ 4)
 
-  ▸ ~/projects/demo/AGENTS.md  ~0.0k tokens (52 ch ÷ 4)
+  ▸ ~/projects/demo/AGENTS.md  ~0.0k tokens (0.1k ch ÷ 4)
 
-  ▸ Skill frontmatter (3)      ~0.2k tokens (743 ch ÷ 4)
+  ▸ Skill frontmatter (3)      ~0.2k tokens (0.7k ch ÷ 4)
     alpha-skill                ~0.1k  Handles A & B cases with a long description so it sorts first…
     beta-skill                 ~0.0k  It's the medium one.
     gamma                      ~0.0k  Tiny.

--- a/tests/fixtures/goldens/contextimate-expanded-anthropic-120.txt
+++ b/tests/fixtures/goldens/contextimate-expanded-anthropic-120.txt
@@ -9,7 +9,7 @@
   Total session                             ~63k tokens (Pi current - harness)
   Total request                              64k tokens (32.2% / 200k ctx)
 
-  Runtime system prompt  ~0.1k tokens                                                                       201 ch ÷ 2.6
+  Runtime system prompt  ~0.1k tokens                                                                      0.2k ch ÷ 2.6
     assembled at runtime: pi base prompt + tool/extension instructions · preview only
     of which tool/extension instructions: ~0.0k tokens (2 tool snippets, 1 guideline) · already counted in this row
 
@@ -20,20 +20,20 @@
     Guidelines:
     - Prefer rg over grep for searching.
 
-  Global AGENTS.md  ~0.0k tokens                                                                             64 ch ÷ 2.6
+  Global AGENTS.md  ~0.0k tokens                                                                           0.1k ch ÷ 2.6
     ~/.pi/agent/AGENTS.md · preview only
 
     # Global guidance
     Prefer clarity &amp; precision in every reply.
 
-  ~/projects/demo/AGENTS.md  ~0.0k tokens                                                                    52 ch ÷ 2.6
+  ~/projects/demo/AGENTS.md  ~0.0k tokens                                                                  0.1k ch ÷ 2.6
     ~/projects/demo/AGENTS.md · preview only
 
     # Demo project
     Run the demo suite before committing.
 
-  Skill frontmatter (3)  ~0.3k tokens                                                                       743 ch ÷ 2.6
-    list wrapper/markup  ~0.1k tokens (195 ch ÷ 2.6)
+  Skill frontmatter (3)  ~0.3k tokens                                                                      0.7k ch ÷ 2.6
+    list wrapper/markup  ~0.1k tokens (0.2k ch ÷ 2.6)
 
     alpha-skill  ~0.1k  Handles A & B cases with a long description so it sorts first in token order for the fixture.
     beta-skill   ~0.1k  It's the medium one.

--- a/tests/fixtures/goldens/contextimate-expanded-anthropic-80.txt
+++ b/tests/fixtures/goldens/contextimate-expanded-anthropic-80.txt
@@ -9,7 +9,7 @@
   Total session                             ~63k tokens (Pi current - harness)
   Total request                              64k tokens (32.2% / 200k ctx)
 
-  Runtime system prompt  ~0.1k tokens                               201 ch ÷ 2.6
+  Runtime system prompt  ~0.1k tokens                              0.2k ch ÷ 2.6
     assembled at runtime: pi base prompt + tool/extension instructions · preview only
     of which tool/extension instructions: ~0.0k tokens (2 tool snippets, 1 guideline) · already counted in this row
 
@@ -20,20 +20,20 @@
     Guidelines:
     - Prefer rg over grep for searching.
 
-  Global AGENTS.md  ~0.0k tokens                                     64 ch ÷ 2.6
+  Global AGENTS.md  ~0.0k tokens                                   0.1k ch ÷ 2.6
     ~/.pi/agent/AGENTS.md · preview only
 
     # Global guidance
     Prefer clarity &amp; precision in every reply.
 
-  ~/projects/demo/AGENTS.md  ~0.0k tokens                            52 ch ÷ 2.6
+  ~/projects/demo/AGENTS.md  ~0.0k tokens                          0.1k ch ÷ 2.6
     ~/projects/demo/AGENTS.md · preview only
 
     # Demo project
     Run the demo suite before committing.
 
-  Skill frontmatter (3)  ~0.3k tokens                               743 ch ÷ 2.6
-    list wrapper/markup  ~0.1k tokens (195 ch ÷ 2.6)
+  Skill frontmatter (3)  ~0.3k tokens                              0.7k ch ÷ 2.6
+    list wrapper/markup  ~0.1k tokens (0.2k ch ÷ 2.6)
 
     alpha-skill  ~0.1k  Handles A & B cases with a long description so it sorts…
     beta-skill   ~0.1k  It's the medium one.

--- a/tests/fixtures/goldens/contextimate-expanded-codex-100.txt
+++ b/tests/fixtures/goldens/contextimate-expanded-codex-100.txt
@@ -9,7 +9,7 @@
   Total session                             ~64k tokens (Pi current - harness)
   Total request                              64k tokens (32.2% / 200k ctx)
 
-  Runtime system prompt  ~0.1k tokens                                                     201 ch ÷ 4
+  Runtime system prompt  ~0.1k tokens                                                    0.2k ch ÷ 4
     assembled at runtime: pi base prompt + tool/extension instructions · preview only
     of which tool/extension instructions: ~0.0k tokens (2 tool snippets, 1 guideline) · already counted in this row
 
@@ -20,20 +20,20 @@
     Guidelines:
     - Prefer rg over grep for searching.
 
-  Global AGENTS.md  ~0.0k tokens                                                           64 ch ÷ 4
+  Global AGENTS.md  ~0.0k tokens                                                         0.1k ch ÷ 4
     ~/.pi/agent/AGENTS.md · preview only
 
     # Global guidance
     Prefer clarity &amp; precision in every reply.
 
-  ~/projects/demo/AGENTS.md  ~0.0k tokens                                                  52 ch ÷ 4
+  ~/projects/demo/AGENTS.md  ~0.0k tokens                                                0.1k ch ÷ 4
     ~/projects/demo/AGENTS.md · preview only
 
     # Demo project
     Run the demo suite before committing.
 
-  Skill frontmatter (3)  ~0.2k tokens                                                     743 ch ÷ 4
-    list wrapper/markup  ~0.0k tokens (195 ch ÷ 4)
+  Skill frontmatter (3)  ~0.2k tokens                                                    0.7k ch ÷ 4
+    list wrapper/markup  ~0.0k tokens (0.2k ch ÷ 4)
 
     alpha-skill  ~0.1k  Handles A & B cases with a long description so it sorts first in token orde…
     beta-skill   ~0.0k  It's the medium one.

--- a/tests/fixtures/goldens/contextimate-summary-anthropic.txt
+++ b/tests/fixtures/goldens/contextimate-summary-anthropic.txt
@@ -2,10 +2,10 @@
 [Context Estimator] summary → compact → expanded
   <expand-key>: cycle view · model anthropic/claude-opus-4-8 · Claude 4.7+ heuristic
 
-  Runtime system prompt                      ~0.1k tokens (201 ch ÷ 2.6)
-  Global AGENTS.md                           ~0.0k tokens (64 ch ÷ 2.6)
-  ~/projects/demo/AGENTS.md                  ~0.0k tokens (52 ch ÷ 2.6)
-  Skill frontmatter (3)                      ~0.3k tokens (743 ch ÷ 2.6)
+  Runtime system prompt                      ~0.1k tokens (0.2k ch ÷ 2.6)
+  Global AGENTS.md                           ~0.0k tokens (0.1k ch ÷ 2.6)
+  ~/projects/demo/AGENTS.md                  ~0.0k tokens (0.1k ch ÷ 2.6)
+  Skill frontmatter (3)                      ~0.3k tokens (0.7k ch ÷ 2.6)
   Tools (3/4 active)                         ~0.5k tokens (1.2k ch ÷ 2.6 · Anthropic tool payload)
   Total harness                              ~0.9k tokens (2.2k ch)
 

--- a/tests/fixtures/goldens/contextimate-summary-codex.txt
+++ b/tests/fixtures/goldens/contextimate-summary-codex.txt
@@ -2,10 +2,10 @@
 [Context Estimator] summary → compact → expanded
   <expand-key>: cycle view · model openai-codex/gpt-5.5 · OpenAI-Codex heuristic
 
-  Runtime system prompt                      ~0.1k tokens (201 ch ÷ 4)
-  Global AGENTS.md                           ~0.0k tokens (64 ch ÷ 4)
-  ~/projects/demo/AGENTS.md                  ~0.0k tokens (52 ch ÷ 4)
-  Skill frontmatter (3)                      ~0.2k tokens (743 ch ÷ 4)
+  Runtime system prompt                      ~0.1k tokens (0.2k ch ÷ 4)
+  Global AGENTS.md                           ~0.0k tokens (0.1k ch ÷ 4)
+  ~/projects/demo/AGENTS.md                  ~0.0k tokens (0.1k ch ÷ 4)
+  Skill frontmatter (3)                      ~0.2k tokens (0.7k ch ÷ 4)
   Tools (3/4 active)                         ~0.2k tokens (1.3k ch · OpenAI formula · schema text ÷ 6.6)
   Total harness                              ~0.4k tokens (2.3k ch)
 

--- a/tests/lib/fmt.test.ts
+++ b/tests/lib/fmt.test.ts
@@ -1,0 +1,43 @@
+// _lib/fmt.ts — the family number grammar (docs/design-language.md §4).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { compactCount, formatChars, formatTokens, formatUsd, formatDuration } from "../../extensions/_lib/fmt.ts";
+
+test("counts: one unit everywhere — fixed k below 1M, M above", () => {
+  assert.equal(compactCount(0), "0.0k");
+  assert.equal(compactCount(133), "0.1k");
+  assert.equal(compactCount(412), "0.4k");
+  assert.equal(compactCount(999), "1.0k");
+  assert.equal(compactCount(1_234), "1.2k");
+  assert.equal(compactCount(52_300), "52.3k");
+  assert.equal(compactCount(999_949), "999.9k");
+  assert.equal(compactCount(999_950), "1.0M");
+  assert.equal(compactCount(9_100_000), "9.1M");
+  assert.equal(compactCount(Number.NaN), "?");
+});
+
+test("chars carry the ch unit", () => {
+  assert.equal(formatChars(133), "0.1k ch");
+  assert.equal(formatChars(35_200), "35.2k ch");
+});
+
+test("tokens: ~ marks estimates; exact provider-reported counts drop it", () => {
+  assert.equal(formatTokens(14_200), "~14.2k tokens");
+  assert.equal(formatTokens(64_100, { exact: true }), "64.1k tokens");
+  assert.equal(formatTokens(78), "~0.1k tokens");
+});
+
+test("money: two decimals, three below $0.10", () => {
+  assert.equal(formatUsd(17.03), "$17.03");
+  assert.equal(formatUsd(0.523), "$0.52");
+  assert.equal(formatUsd(0.0523), "$0.052");
+  assert.equal(formatUsd(0.1), "$0.10");
+});
+
+test("durations: compact mixed units, no spaces", () => {
+  assert.equal(formatDuration(14_000), "14s");
+  assert.equal(formatDuration(270_000), "4m30s");
+  assert.equal(formatDuration(120_000), "2m");
+  assert.equal(formatDuration(35_400_000), "9h50m");
+});

--- a/tests/lib/style.test.ts
+++ b/tests/lib/style.test.ts
@@ -1,0 +1,66 @@
+// _lib/style.ts — the family style implementation (docs/design-language.md §§1–6).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+
+import { GLYPH, SCALE, SEP, ink, sizeTone, SIZE_THRESHOLDS } from "../../extensions/_lib/style.ts";
+
+// A recording theme: proves ink() routes through Theme.fg with the right role.
+const recordingTheme = {
+  fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+  bold: (text: string) => text,
+  bg: (_color: string, text: string) => text,
+} as unknown as Theme;
+
+test("family glyphs and separator are the documented characters", () => {
+  assert.equal(GLYPH.tool, "›");
+  assert.equal(GLYPH.econ, "◍");
+  assert.equal(GLYPH.section, "▸");
+  assert.deepEqual([SCALE.cold, SCALE.hit, SCALE.partial, SCALE.miss], ["○", "●", "◑", "◌"]);
+  assert.equal(SEP, " · ");
+});
+
+test("ink derives from the theme for every role-mapped tone", () => {
+  assert.equal(ink(recordingTheme, "text", "x"), "<text>x</text>");
+  assert.equal(ink(recordingTheme, "muted", "x"), "<muted>x</muted>");
+  assert.equal(ink(recordingTheme, "dim", "x"), "<dim>x</dim>");
+  assert.equal(ink(recordingTheme, "success", "x"), "<success>x</success>");
+  assert.equal(ink(recordingTheme, "warning", "x"), "<warning>x</warning>");
+  assert.equal(ink(recordingTheme, "error", "x"), "<error>x</error>");
+  assert.equal(ink(recordingTheme, "accent", "x"), "<accent>x</accent>");
+});
+
+test("running has no faithful theme role: raw ANSI blue even with a theme", () => {
+  assert.equal(ink(recordingTheme, "running", "x"), "\x1b[34mx\x1b[0m");
+  assert.equal(ink(undefined, "running", "x"), "\x1b[34mx\x1b[0m");
+});
+
+test("without a theme, ink falls back to basic ANSI; text/accent stay plain", () => {
+  assert.equal(ink(undefined, "dim", "x"), "\x1b[90mx\x1b[0m");
+  assert.equal(ink(undefined, "muted", "x"), "\x1b[90mx\x1b[0m");
+  assert.equal(ink(undefined, "success", "x"), "\x1b[32mx\x1b[0m");
+  assert.equal(ink(undefined, "warning", "x"), "\x1b[33mx\x1b[0m");
+  assert.equal(ink(undefined, "error", "x"), "\x1b[31mx\x1b[0m");
+  assert.equal(ink(undefined, "text", "x"), "x");
+  assert.equal(ink(undefined, "accent", "x"), "x");
+});
+
+test("ink never styles empty text and never lets a broken theme break a render", () => {
+  assert.equal(ink(recordingTheme, "dim", ""), "");
+  const broken = { fg: () => { throw new Error("boom"); } } as unknown as Theme;
+  assert.equal(ink(broken, "error", "x"), "\x1b[31mx\x1b[0m");
+});
+
+test("sizeTone: dim below warning, warning at 10k ch, error at 50k ch", () => {
+  assert.equal(sizeTone(0), "dim");
+  assert.equal(sizeTone(9_999), "dim");
+  assert.equal(sizeTone(10_000), "warning");
+  assert.equal(sizeTone(49_999), "warning");
+  assert.equal(sizeTone(50_000), "error");
+  assert.deepEqual(SIZE_THRESHOLDS, { warning: 10_000, error: 50_000 });
+});
+
+test("sizeTone honours overridden thresholds", () => {
+  assert.equal(sizeTone(500, { warning: 100, error: 1_000 }), "warning");
+  assert.equal(sizeTone(2_000, { warning: 100, error: 1_000 }), "error");
+});

--- a/tests/traceline/one-line.test.ts
+++ b/tests/traceline/one-line.test.ts
@@ -48,10 +48,11 @@ beforeEach(() => {
 });
 
 test("row grammar units", () => {
-  // Family number grammar: raw integers below 1000, one-decimal k above.
-  assert.equal(formatCharCount(0), "0");
-  assert.equal(formatCharCount(49), "49");
-  assert.equal(formatCharCount(412), "412");
+  // Family number grammar (design language §4): one unit everywhere — fixed
+  // one-decimal k so suffixes compare down the column; raw integers never appear.
+  assert.equal(formatCharCount(0), "0.0k");
+  assert.equal(formatCharCount(49), "0.0k");
+  assert.equal(formatCharCount(412), "0.4k");
   assert.equal(formatCharCount(1437), "1.4k");
   assert.equal(formatCharCount(10_000), "10.0k");
   assert.equal(lineRange({ offset: 1, limit: 20 }), ":1-20");


### PR DESCRIPTION
## What

1. **`docs/design-language.md`** — the family design contract agreed with Thomas (2026-06-12): glyph grammar, 4-level ink hierarchy, theme-derived colour (orange dropped → theme `accent`), fixed-k number grammar, layout/severity/wording rules, per-extension conformance lists, and resolved decisions (panel naming → `[Contextimate]`/`[Cachemire]`, proportion bar in, running tone = ANSI-blue fallback).
2. **`extensions/_lib/style.ts`** (new) — the implementation seam: `GLYPH`/`SCALE`/`SEP`, `ink()` (all colour theme-derived via `Theme.fg`, raw-ANSI fallbacks pre-theme; never breaks a render), `sizeTone()` severity thresholds (warning ≥10k ch, error ≥50k ch).
3. **Number grammar: one unit, everywhere** — `compactCount` drops its raw-integer branch so counts compare down a column (`133 ch` → `0.1k ch`; M only at ≥1M). `formatTokens`/`formatUsd`/`formatDuration` join `_lib/fmt.ts`; cachemire delegates to them.

## Visible changes

- traceline result suffixes: `133 ch` → `0.1k ch`, `0 ch` → `0.0k ch`
- contextimate char details: `(201 ch ÷ 2.6)` → `(0.2k ch ÷ 2.6)` (goldens regenerated + reviewed)
- cachemire ledger: `out 400` → `out 0.4k`

`style.ts` is not yet consumed by the extensions — passes 2–4 (traceline, contextimate, cachemire conformance) build on it per the doc's implementation order.

## Verification

- `npm run typecheck` clean
- `npm test`: 115/115 (new `tests/lib/{style,fmt}.test.ts`; goldens regenerated under `UPDATE_GOLDENS=1` and diff-reviewed; cachemire/traceline/contract expectations updated to the fixed-k grammar)
