### PR TITLE
Traceline pass: theme-derived ink, severity suffixes, repetition folding (#14)

### DIFF
--- a/extensions/_lib/ansi.ts
+++ b/extensions/_lib/ansi.ts
@@ -12,3 +12,49 @@ export function stripAnsi(text: string): string {
     .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
     .replace(OSC_SEQUENCE, "");
 }
+
+/** Index of the last char of the escape sequence starting at `i`, or undefined. */
+export function ansiEndIndex(line: string, i: number): number | undefined {
+  if (line[i] !== "\x1b") return undefined;
+  if (line[i + 1] === "[") {
+    const end = line.slice(i).search(/[A-Za-z~]/);
+    return end >= 0 ? i + end : undefined;
+  }
+  if (line[i + 1] === "]") {
+    const bel = line.indexOf("\x07", i + 2);
+    const st = line.indexOf("\x1b\\", i + 2);
+    const end = bel === -1 ? st : st === -1 ? bel : Math.min(bel, st);
+    return end >= 0 ? end + (line[end] === "\x1b" ? 1 : 0) : undefined;
+  }
+  return undefined;
+}
+
+/** Raw string index of the visible character at visible index `target` (escape-aware). */
+export function rawIndexAtVisibleIndex(line: string, target: number): number {
+  let visible = 0;
+  for (let i = 0; i < line.length; i++) {
+    const ansiEnd = ansiEndIndex(line, i);
+    if (ansiEnd !== undefined) {
+      i = ansiEnd;
+      continue;
+    }
+    if (visible === target) return i;
+    visible++;
+  }
+  return line.length;
+}
+
+/** Like rawIndexAtVisibleIndex, but lands *before* any escapes preceding the char. */
+export function rawIndexBeforeVisibleIndex(line: string, target: number): number {
+  let visible = 0;
+  for (let i = 0; i < line.length; i++) {
+    if (visible === target) return i;
+    const ansiEnd = ansiEndIndex(line, i);
+    if (ansiEnd !== undefined) {
+      i = ansiEnd;
+      continue;
+    }
+    visible++;
+  }
+  return line.length;
+}

--- a/extensions/_lib/style.ts
+++ b/extensions/_lib/style.ts
@@ -4,6 +4,9 @@
 // exists and for the one tone pi's theme has no faithful role for ("running").
 
 import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { homedir } from "node:os";
+import { OSC_SEQUENCE, rawIndexAtVisibleIndex, stripAnsi } from "./ansi.ts";
 
 /** Line-kind glyphs: one per line, gutter position (design language §1). */
 export const GLYPH = {
@@ -83,6 +86,102 @@ export function ink(theme: Theme | undefined, tone: Tone, text: string): string 
   const open = RAW[tone];
   return open ? `${open}${text}${RESET}` : text;
 }
+
+// --- layout helpers (design language §5) -----------------------------------------------
+
+export const ELLIPSIS = "\u2026"; // …
+
+const MIN_HEAD_COLS = 6;
+const TAIL_RATIO = 0.55;
+const SNAP_WINDOW = 8;
+
+// Replace an absolute home-directory prefix with ~ so boilerplate path heads stop eating
+// width (e.g. bash `cd /Users/me/... && ...` -> `cd ~/... && ...`). OSC sequences are
+// skipped: a read row's OSC 8 hyperlink carries a file:// URL containing the home path,
+// and tildifying *that* would corrupt the click target. The pattern is built once —
+// tildify runs for every visible row on every frame.
+const TILDIFY_PATTERN = (() => {
+  const home = homedir();
+  if (!home) return undefined;
+  return new RegExp(`${OSC_SEQUENCE.source}|${home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "g");
+})();
+
+export function tildify(text: string): string {
+  if (!TILDIFY_PATTERN) return text;
+  return text.replace(TILDIFY_PATTERN, (match) => (match.startsWith("\x1b") ? match : "~"));
+}
+
+function isVisibleBoundary(ch: string): boolean {
+  return ch === "/" || ch === " ";
+}
+
+// ANSI-aware middle truncation that protects the *tail* of the line — the basename +
+// :line-range for a path, or the operative end of a command — because that is where the
+// information distinguishing one row from the next lives. The cut snaps to a nearby "/"
+// or space boundary, and the ellipsis is dimmed so it reads as a UI marker rather than as
+// part of the path/command. Falls back to tail truncation only when the width is too
+// small to keep both ends.
+export function middleTruncate(line: string, width: number, theme?: Theme): string {
+  const maxWidth = Math.max(1, width);
+  if (visibleWidth(line) <= maxWidth) return line;
+
+  const vis = stripAnsi(line);
+  const visLen = vis.length;
+  const ellipsisWidth = visibleWidth(ELLIPSIS);
+  const budget = Math.max(1, maxWidth - ellipsisWidth); // reserve columns for the ellipsis
+
+  const maxTail = Math.min(budget - MIN_HEAD_COLS, Math.max(12, Math.floor(budget * TAIL_RATIO)));
+  if (maxTail < 1) return truncateToWidth(line, maxWidth, ELLIPSIS);
+
+  // Longest tail that fits `maxTail` and starts at a separator, so it reads as `.../seg`.
+  let tailStart = -1;
+  for (let i = Math.max(0, visLen - maxTail); i < visLen; i++) {
+    if (isVisibleBoundary(vis[i]!)) {
+      tailStart = i;
+      break;
+    }
+  }
+  if (tailStart < 0) tailStart = visLen - maxTail; // no boundary in range: keep the end
+
+  const dimEllipsis = ink(theme, "dim", ELLIPSIS);
+  const tailRaw = line.slice(rawIndexAtVisibleIndex(line, tailStart));
+
+  let headEnd = budget - (visLen - tailStart);
+  if (headEnd <= 0) return `${dimEllipsis}${tailRaw}`;
+
+  // Snap the head back to a nearby boundary so the ellipsis lands on a clean edge: keep a
+  // trailing "/" on the head side, drop a trailing space. Search from the last kept char
+  // inward so keeping the "/" can never push the head past its budget.
+  for (let i = headEnd - 1; i >= Math.max(0, headEnd - SNAP_WINDOW); i--) {
+    if (isVisibleBoundary(vis[i]!)) {
+      headEnd = vis[i] === "/" ? i + 1 : i;
+      break;
+    }
+  }
+  headEnd = Math.min(headEnd, tailStart);
+  if (headEnd <= 0) return `${dimEllipsis}${tailRaw}`;
+
+  const headRaw = line.slice(0, rawIndexAtVisibleIndex(line, headEnd));
+  return `${headRaw}${RESET}${dimEllipsis}${tailRaw}`;
+}
+
+/** Quantities right (design language §5): body left, right-aligned suffix, ≥1-space gap;
+ * the body middle-truncates and the suffix wins when the width is starved. */
+export function rightAlignSuffix(body: string, suffix: string, width: number, theme?: Theme): string {
+  const maxWidth = Math.max(1, width);
+  const bodyText = body.trimEnd();
+  if (!suffix) return middleTruncate(bodyText, maxWidth, theme);
+
+  const suffixWidth = visibleWidth(suffix);
+  if (suffixWidth >= maxWidth) return truncateToWidth(suffix, maxWidth, ELLIPSIS);
+
+  const bodyWidth = Math.max(0, maxWidth - suffixWidth - 1);
+  const fittedBody = bodyWidth > 0 ? middleTruncate(bodyText, bodyWidth, theme) : "";
+  const gapWidth = Math.max(1, maxWidth - visibleWidth(fittedBody) - suffixWidth);
+  return `${fittedBody}${" ".repeat(gapWidth)}${suffix}`;
+}
+
+// --- severity (design language §6) -------------------------------------------------------
 
 /** Severity thresholds for tool result sizes, in chars (design language §6). */
 export type SizeThresholds = { warning: number; error: number };

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -22,11 +22,35 @@ When tool rows are collapsed, each one renders as a single line:
 
 - **The arc of the turn** - every tool call in order, one line each, so you see the path Pi took.
 - **What context Pi got** - which files it read and how much of them (`read ... :1-20`), which skills it invoked (`[skill] ...`), which subagents ran.
-- **Which outputs were massive** - a right-aligned, dimmed result-size suffix per row (`1.4k ch`, in the family number grammar shared with `pi-contextimate` and `pi-cachemire`) makes an over-large tool output (often a sign of a tool or guidance issue) jump out.
+- **Which outputs were massive** - a right-aligned result-size suffix per row (`1.4k ch`, in the family number grammar shared with `pi-contextimate` and `pi-cachemire`). The suffix is **severity-tinted**: dim while healthy, warning-coloured at ≥10k ch, error-coloured at ≥50k ch — so an over-large tool output (often a sign of a tool or guidance issue) jumps out of the column. Thresholds are overridable via the family config convention (`~/.pi/agent/pi-traceline.json` or `<cwd>/.pi/pi-traceline.json`: `{ "sizeWarningChars": 10000, "sizeErrorChars": 50000 }`).
 - **A status colour** on each row's bullet (`›`): green = success, blue = running, red = error.
 - **Selective expansion** - arm a one-shot click and then click a tool row to expand or collapse only that row, without flipping every tool result in the turn.
 
-Rendering reuses Pi's own tool-call renderer, so the visual grammar (bold command name, accented paths/backticks, warning line ranges, custom-tool renderers) tracks Pi's defaults. On top of that sits an **ink hierarchy**: shell plumbing in bash rows (`&&`, `|`, `;`, `2>/dev/null`, heredoc markers) is dimmed so the command segments carry the brightness, and the boilerplate `(timeout Ns)` suffix is dropped — the full invocation is one Ctrl+T or click away. One blank line precedes a group of tool calls; consecutive tool calls stay tight, and a tool row sits tight under the collapsed `Thinking...` line that motivated it, so each thought→action couplet reads as one unit.
+Rendering reuses Pi's own tool-call renderer, so the visual grammar (bold command name, accented paths/backticks, warning line ranges, custom-tool renderers) tracks Pi's defaults, and traceline's own ink is **theme-derived** (the family `ink()` helper — see `docs/design-language.md`), so it follows your active theme. On top of that sits an **ink hierarchy**: shell plumbing in bash rows (`&&`, `|`, `;`, `2>/dev/null`, heredoc markers) is dimmed so the command segments carry the brightness, and the boilerplate `(timeout Ns)` suffix is dropped — the full invocation is one Ctrl+T or click away. One blank line precedes a group of tool calls; consecutive tool calls stay tight, and a tool row sits tight under the collapsed `Thinking...` line that motivated it, so each thought→action couplet reads as one unit.
+
+### Repetition folds instead of re-printing (issue #14)
+
+The information-dense diff between adjacent rows is often small — the command tail, a line
+range — while a shared prefix dominates. Three folds keep the trace skimmable:
+
+- **Repeated `cd <dir> && ` preambles** — pi's bash tool is stateless per call, so agents
+  working outside the session cwd re-`cd` on *every* call (90% of bash rows in a measured
+  session). When a row's preamble repeats the previous bash row's, it renders as a dim
+  `⋯`, giving the width back to the part of the command that differs. The first
+  occurrence always keeps the full path, and a `⋯` never points across visible prose.
+- **Paginated reads** — consecutive reads of the same file (paging past the read cap)
+  fold into one row with the combined ranges, call count, and total size. Anything
+  visible between the reads breaks the fold, and clicking the folded row open restores
+  the individual rows.
+- **Doubled `Thinking...` lines** — pi renders the collapsed label once per thinking
+  *block*, so a message with adjacent reasoning segments prints two identical labels;
+  traceline coalesces them into one.
+
+```
+  › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5      1.4k ch
+  › $ ⋯ && npm run typecheck                                            14.2k ch
+  › read ~/projects/pine-of-gl…index.ts:1-200,201-400,401-600 3 calls · 51.1k ch
+```
 
 ### The tool surface
 
@@ -95,7 +119,7 @@ The collapse state is read from a live assistant row (falling back to `~/.pi/age
 
 ## How it works
 
-- On `session_start` it captures the real TUI and wraps `requestRender`, then patches the shared tool-row component prototype's `render` the moment a tool row exists. The patch is versioned and idempotent across reloads and session resumes.
+- On `session_start` it captures the real TUI and wraps `requestRender`, then patches the shared tool-row component prototype's `render` the moment a tool row exists (and the assistant-row prototype, for the doubled-`Thinking...` coalesce). The patches are versioned and idempotent across reloads and session resumes.
 - It also wraps the captured TUI render path to build a row-to-tool hit map. One-shot click mode briefly enables SGR mouse reporting and consumes SGR click events through Pi's public raw-input hook, then disables mouse reporting again so terminal scrolling works normally.
 - While reasoning is shown, `render` defers to Pi's original implementation unchanged. While reasoning is hidden, it emits the single trace line unless that individual row has been clicked open.
 - Any failure inside the one-line path falls back to Pi's original `render`, so the extension can never break a frame.

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -1,12 +1,26 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
 import { isKeyRelease, isKeyRepeat, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { OSC_SEQUENCE, stripAnsi } from "../_lib/ansi.ts";
+import { OSC_SEQUENCE, rawIndexAtVisibleIndex, rawIndexBeforeVisibleIndex, stripAnsi } from "../_lib/ansi.ts";
 import { captureTui } from "../_lib/capture.ts";
 import { findChatContainer, isAssistantRow, isToolRow } from "../_lib/chat.ts";
+import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount } from "../_lib/fmt.ts";
+import {
+  ELLIPSIS,
+  GLYPH,
+  SEP,
+  SIZE_THRESHOLDS,
+  ink,
+  middleTruncate,
+  rightAlignSuffix,
+  sizeTone,
+  tildify,
+  type SizeThresholds,
+  type Tone,
+} from "../_lib/style.ts";
 
 /**
  * pi-traceline — collapse each tool call to one scannable trace line so the full arc of
@@ -27,17 +41,28 @@ import { compactCount } from "../_lib/fmt.ts";
  * one shaded slab per tool group. Multiline bash commands are flattened into the one
  * trace line with a dim ↵ marking each original break, so heredocs and inline scripts
  * keep their operative tail instead of collapsing to `$ python3 -c "`.
- * The ink follows an information hierarchy: shell plumbing (`&&`, `|`, `2>/dev/null`,
- * heredoc markers) is dimmed so command segments pop, and the boilerplate `(timeout Ns)`
- * suffix is dropped — the full invocation is one Ctrl+T away. Home-dir prefixes are
- * tildified, and over-long invocations are *middle*-truncated with a
- * dimmed `…` so the tail survives — the basename + `:line-range` for a path, or the
+ * The ink follows the family hierarchy (docs/design-language.md): shell plumbing (`&&`,
+ * `|`, `2>/dev/null`, heredoc markers) is dimmed so command segments pop, and the
+ * boilerplate `(timeout Ns)` suffix is dropped — the full invocation is one Ctrl+T away.
+ * Home-dir prefixes are tildified, and over-long invocations are *middle*-truncated with
+ * a dimmed `…` so the tail survives — the basename + `:line-range` for a path, or the
  * operative end of a command — because that is where the discriminating information lives;
  * the cut snaps to a nearby `/` or space. Plain file reads additionally dim the directory
- * so the basename stands out. Once a result exists, a right-aligned dimmed `1.2k ch`
- * result-size suffix is reserved at the end. Spacing: one blank line before a tool group
- * (restoring the spacer pi drops), none between consecutive tools. One-shot click mode
- * toggles a clicked row only, without changing Pi's global tool expansion state.
+ * so the basename stands out. Once a result exists, a right-aligned `1.2k ch` result-size
+ * suffix is reserved at the end — dim while healthy, warning-/error-tinted when an output
+ * balloons past the size thresholds, so "what flooded the context" pops out of the column.
+ * All ink is theme-derived (style.ts ink()), with raw-ANSI fallbacks before a theme exists.
+ *
+ * Repetition the model emits is folded rather than re-printed (issue #14): a bash row
+ * whose `cd <dir> && ` preamble repeats the previous bash row's renders it as a dim `⋯`,
+ * giving the width back to the part of the command that differs; consecutive reads paging
+ * through one file collapse into a single `read path:1-200,201-400 · 2 calls` row; and an
+ * assistant message whose adjacent thinking blocks would print two collapsed `Thinking...`
+ * labels gets them coalesced into one.
+ *
+ * Spacing: one blank line before a tool group (restoring the spacer pi drops), none
+ * between consecutive tools. One-shot click mode toggles a clicked row only, without
+ * changing Pi's global tool expansion state.
  *
  * Nothing in pi's node_modules is modified, so this survives `pi update`.
  */
@@ -66,28 +91,40 @@ type TracelineGlobal = typeof globalThis & {
   __tracelineClickOneShot?: boolean;
   __tracelineClickArmTimer?: ReturnType<typeof setTimeout>;
   __tracelineMouseReportingEnabled?: boolean;
+  __tracelineGetTheme?: () => Theme | undefined;
+  __tracelineAssistantPatchVersion?: number;
 };
 const g = globalThis as TracelineGlobal;
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
 const BOLD_OFF = "\x1b[22m";
-const RED = "\x1b[31m";
-const GREEN = "\x1b[32m";
-const BLUE = "\x1b[34m";
-const MUTED_GREY = "\x1b[38;2;128;128;128m";
 const TOOL_GUTTER = "  ";
-const TOOL_BULLET = "›";
+const TOOL_BULLET = GLYPH.tool;
 const TOOL_AFTER_BULLET = " ";
 const TOOL_PREFIX_VISIBLE_WIDTH = TOOL_GUTTER.length + 1 + TOOL_AFTER_BULLET.length;
 const ONE_LINE_CAPTURE_WIDTH = 10_000;
-const ONE_LINE_ELLIPSIS = "\u2026";
 const LINE_BREAK_MARK = "\u21b5"; // ↵ — marks a real newline in a flattened invocation
-const TRACELINE_PATCH_VERSION = 11;
+const PREAMBLE_MARK = "\u22ef"; // ⋯ — stands in for a preamble identical to the row above
+const TRACELINE_PATCH_VERSION = 12;
 const TRACELINE_CONTAINER_PATCH_VERSION = 1;
-const MIN_HEAD_COLS = 6;
-const TAIL_RATIO = 0.55;
-const SNAP_WINDOW = 8;
+const TRACELINE_ASSISTANT_PATCH_VERSION = 1;
+
+// --- theme-derived ink (design language §3) --------------------------------------------
+// The live Theme handle is captured at session_start; before that (and in unit tests
+// without one) ink() falls back to basic raw ANSI.
+
+function currentTheme(): Theme | undefined {
+  try {
+    return g.__tracelineGetTheme?.();
+  } catch {
+    return undefined;
+  }
+}
+
+function dim(text: string): string {
+  return ink(currentTheme(), "dim", text);
+}
 const MOUSE_REPORTING_ENABLE = "\x1b[?1000h\x1b[?1006h";
 const MOUSE_REPORTING_DISABLE = "\x1b[?1000l\x1b[?1006l";
 
@@ -364,23 +401,45 @@ function toolStatus(comp: any): ToolStatus {
   return "running";
 }
 
-function statusColor(comp: any): string {
+function statusTone(comp: any): Tone {
   const status = toolStatus(comp);
-  if (status === "error") return RED;
-  if (status === "success") return GREEN;
-  return BLUE;
+  if (status === "error") return "error";
+  if (status === "success") return "success";
+  return "running";
 }
 
-function hiddenToolPrefixColor(color: string): string {
-  return `${TOOL_GUTTER}${color}${TOOL_BULLET}${RESET}${TOOL_AFTER_BULLET}`;
+function toolPrefix(tone: Tone): string {
+  return `${TOOL_GUTTER}${ink(currentTheme(), tone, TOOL_BULLET)}${TOOL_AFTER_BULLET}`;
 }
 
 function hiddenToolPrefix(comp: any): string {
-  return hiddenToolPrefixColor(statusColor(comp));
+  return toolPrefix(statusTone(comp));
 }
 
 function formatCharCount(value: number): string {
   return compactCount(Math.max(0, Math.floor(value)));
+}
+
+// Severity thresholds (design language §6): dim while healthy, warning/error when an
+// output balloons. Overridable via the family config convention
+// (~/.pi/agent/pi-traceline.json / <cwd>/.pi/pi-traceline.json).
+let sizeThresholds: SizeThresholds = SIZE_THRESHOLDS;
+
+function configureSizeThresholds(config: { sizeWarningChars?: unknown; sizeErrorChars?: unknown } | undefined): void {
+  const warning =
+    typeof config?.sizeWarningChars === "number" && config.sizeWarningChars > 0
+      ? Math.floor(config.sizeWarningChars)
+      : SIZE_THRESHOLDS.warning;
+  const error =
+    typeof config?.sizeErrorChars === "number" && config.sizeErrorChars > 0
+      ? Math.floor(config.sizeErrorChars)
+      : SIZE_THRESHOLDS.error;
+  sizeThresholds = { warning, error: Math.max(error, warning) };
+}
+
+function charSuffix(chars: number | undefined): string {
+  if (chars === undefined) return "";
+  return ink(currentTheme(), sizeTone(chars, sizeThresholds), `${formatCharCount(chars)} ch`);
 }
 
 function resultTextCharCount(comp: any): number | undefined {
@@ -394,93 +453,11 @@ function resultTextCharCount(comp: any): number | undefined {
 }
 
 function resultCharSuffix(comp: any): string {
-  const chars = resultTextCharCount(comp);
-  return chars === undefined ? "" : `${MUTED_GREY}${formatCharCount(chars)} ch${RESET}`;
+  return charSuffix(resultTextCharCount(comp));
 }
 
-// Replace an absolute home-directory prefix with ~ so boilerplate path heads stop eating
-// width (e.g. bash `cd /Users/me/... && ...` -> `cd ~/... && ...`). OSC sequences are
-// skipped: a read row's OSC 8 hyperlink carries a file:// URL containing the home path,
-// and tildifying *that* would corrupt the click target. The pattern is built once —
-// tildify runs for every visible row on every frame.
-const TILDIFY_PATTERN = (() => {
-  const home = homedir();
-  if (!home) return undefined;
-  return new RegExp(`${OSC_SEQUENCE.source}|${home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "g");
-})();
-
-function tildify(text: string): string {
-  if (!TILDIFY_PATTERN) return text;
-  return text.replace(TILDIFY_PATTERN, (match) => (match.startsWith("\x1b") ? match : "~"));
-}
-
-function isVisibleBoundary(ch: string): boolean {
-  return ch === "/" || ch === " ";
-}
-
-// ANSI-aware middle truncation that protects the *tail* of the line — the basename +
-// :line-range for a path, or the operative end of a command — because that is where the
-// information distinguishing one row from the next lives. The cut snaps to a nearby "/"
-// or space boundary, and the ellipsis is dimmed so it reads as a UI marker rather than as
-// part of the path/command. Falls back to tail truncation only when the width is too
-// small to keep both ends.
-function middleTruncate(line: string, width: number): string {
-  const maxWidth = Math.max(1, width);
-  if (visibleWidth(line) <= maxWidth) return line;
-
-  const vis = stripAnsi(line);
-  const visLen = vis.length;
-  const ellipsisWidth = visibleWidth(ONE_LINE_ELLIPSIS);
-  const budget = Math.max(1, maxWidth - ellipsisWidth); // reserve columns for the ellipsis
-
-  const maxTail = Math.min(budget - MIN_HEAD_COLS, Math.max(12, Math.floor(budget * TAIL_RATIO)));
-  if (maxTail < 1) return truncateToWidth(line, maxWidth, ONE_LINE_ELLIPSIS);
-
-  // Longest tail that fits `maxTail` and starts at a separator, so it reads as `.../seg`.
-  let tailStart = -1;
-  for (let i = Math.max(0, visLen - maxTail); i < visLen; i++) {
-    if (isVisibleBoundary(vis[i])) {
-      tailStart = i;
-      break;
-    }
-  }
-  if (tailStart < 0) tailStart = visLen - maxTail; // no boundary in range: keep the end
-
-  const dimEllipsis = `${MUTED_GREY}${ONE_LINE_ELLIPSIS}${RESET}`;
-  const tailRaw = line.slice(rawIndexAtVisibleIndex(line, tailStart));
-
-  let headEnd = budget - (visLen - tailStart);
-  if (headEnd <= 0) return `${dimEllipsis}${tailRaw}`;
-
-  // Snap the head back to a nearby boundary so the ellipsis lands on a clean edge: keep a
-  // trailing "/" on the head side, drop a trailing space. Search from the last kept char
-  // inward so keeping the "/" can never push the head past its budget.
-  for (let i = headEnd - 1; i >= Math.max(0, headEnd - SNAP_WINDOW); i--) {
-    if (isVisibleBoundary(vis[i])) {
-      headEnd = vis[i] === "/" ? i + 1 : i;
-      break;
-    }
-  }
-  headEnd = Math.min(headEnd, tailStart);
-  if (headEnd <= 0) return `${dimEllipsis}${tailRaw}`;
-
-  const headRaw = line.slice(0, rawIndexAtVisibleIndex(line, headEnd));
-  return `${headRaw}${RESET}${dimEllipsis}${tailRaw}`;
-}
-
-function fitOneLineAndSuffix(invocation: string, suffix: string, width: number): string {
-  const maxWidth = Math.max(1, width);
-  const invocationText = invocation.trimEnd();
-  if (!suffix) return middleTruncate(invocationText, maxWidth);
-
-  const suffixWidth = visibleWidth(suffix);
-  if (suffixWidth >= maxWidth) return truncateToWidth(suffix, maxWidth, ONE_LINE_ELLIPSIS);
-
-  const invocationWidth = Math.max(0, maxWidth - suffixWidth - 1);
-  const fittedInvocation = invocationWidth > 0 ? middleTruncate(invocationText, invocationWidth) : "";
-  const gapWidth = Math.max(1, maxWidth - visibleWidth(fittedInvocation) - suffixWidth);
-  return `${fittedInvocation}${" ".repeat(gapWidth)}${suffix}`;
-}
+// tildify / middleTruncate / rightAlignSuffix live in _lib/style.ts — traceline's rules,
+// promoted to family rules (design language §5).
 
 function displayPath(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
@@ -516,7 +493,7 @@ function flattenInvocationLines(lines: string[]): string | undefined {
     .filter((line) => stripAnsi(line).trim().length > 0)
     .map((line) => trimLeadingVisibleWhitespace(line.trimEnd()));
   if (visible.length === 0) return undefined;
-  return visible.join(` ${MUTED_GREY}${LINE_BREAK_MARK}${RESET} `);
+  return visible.join(` ${dim(LINE_BREAK_MARK)} `);
 }
 
 function filterSgrParams(
@@ -565,48 +542,7 @@ function stripSgrForegrounds(text: string): string {
   });
 }
 
-function ansiEndIndex(line: string, i: number): number | undefined {
-  if (line[i] !== "\x1b") return undefined;
-  if (line[i + 1] === "[") {
-    const end = line.slice(i).search(/[A-Za-z~]/);
-    return end >= 0 ? i + end : undefined;
-  }
-  if (line[i + 1] === "]") {
-    const bel = line.indexOf("\x07", i + 2);
-    const st = line.indexOf("\x1b\\", i + 2);
-    const end = bel === -1 ? st : st === -1 ? bel : Math.min(bel, st);
-    return end >= 0 ? end + (line[end] === "\x1b" ? 1 : 0) : undefined;
-  }
-  return undefined;
-}
-
-function rawIndexAtVisibleIndex(line: string, target: number): number {
-  let visible = 0;
-  for (let i = 0; i < line.length; i++) {
-    const ansiEnd = ansiEndIndex(line, i);
-    if (ansiEnd !== undefined) {
-      i = ansiEnd;
-      continue;
-    }
-    if (visible === target) return i;
-    visible++;
-  }
-  return line.length;
-}
-
-function rawIndexBeforeVisibleIndex(line: string, target: number): number {
-  let visible = 0;
-  for (let i = 0; i < line.length; i++) {
-    if (visible === target) return i;
-    const ansiEnd = ansiEndIndex(line, i);
-    if (ansiEnd !== undefined) {
-      i = ansiEnd;
-      continue;
-    }
-    visible++;
-  }
-  return line.length;
-}
+// ansiEndIndex / rawIndexAtVisibleIndex / rawIndexBeforeVisibleIndex live in _lib/ansi.ts.
 
 function trimLeadingVisibleWhitespace(line: string): string {
   const visible = stripAnsi(line);
@@ -644,7 +580,7 @@ const SHELL_PLUMBING =
   / (&&|\|\||\||;|2>&1|[&12]?>>?\s?\/dev\/null|<<-?\s?'?[A-Za-z_][A-Za-z0-9_]*'?)(?= |$)/g;
 
 function dimShellPlumbing(line: string): string {
-  return line.replace(SHELL_PLUMBING, (_m, op: string) => ` ${MUTED_GREY}${op}${RESET}`);
+  return line.replace(SHELL_PLUMBING, (_m, op: string) => ` ${dim(op)}`);
 }
 
 function commandPrefixLength(comp: any, line: string): number {
@@ -672,7 +608,7 @@ function colourCommandPrefix(comp: any, line: string): string {
   const rawEnd = rawIndexBeforeVisibleIndex(trimmed, prefixLen);
   const prefix = stripSgrForegrounds(trimmed.slice(0, rawEnd));
   const rest = trimmed.slice(rawEnd);
-  return `${statusColor(comp)}${BOLD}${prefix}${BOLD_OFF}${RESET}${rest}`;
+  return `${ink(currentTheme(), statusTone(comp), `${BOLD}${prefix}${BOLD_OFF}`)}${rest}`;
 }
 
 // Prefer pi's own renderCall output for one-line mode. This borrows the native visual
@@ -721,7 +657,7 @@ function pathEmphasisLine(comp: any, nativeColored: string): string | undefined 
   const dir = tildePath.slice(0, lastSlash + 1);
   const base = tildePath.slice(lastSlash + 1);
   const range = lineRange(comp?.args);
-  return `${statusColor(comp)}${BOLD}read${BOLD_OFF}${RESET} ${MUTED_GREY}${dir}${RESET}${base}${MUTED_GREY}${range}${RESET}`;
+  return `${ink(currentTheme(), statusTone(comp), `${BOLD}read${BOLD_OFF}`)} ${dim(dir)}${base}${dim(range)}`;
 }
 
 // The shaded tool surface, borrowed live from the row itself. pi keeps contentBox.bgFn
@@ -752,12 +688,135 @@ function oneLine(comp: any, width: number): string {
   const lineWidth = Math.max(1, width);
   const available = Math.max(1, lineWidth - TOOL_PREFIX_VISIBLE_WIDTH);
   const native = nativeInvocationLine(comp);
-  const base = (native && pathEmphasisLine(comp, native)) ?? native ?? `${statusColor(comp)}${fallbackInvocationLine(comp)}${RESET}`;
+  const base =
+    (native && pathEmphasisLine(comp, native)) ??
+    native ??
+    ink(currentTheme(), statusTone(comp), fallbackInvocationLine(comp));
   const tilded = tildify(base);
-  const invocation = toolLabel(comp?.toolName) === "bash" ? dimShellPlumbing(tilded) : tilded;
-  const fitted = fitOneLineAndSuffix(invocation, resultCharSuffix(comp), available);
-  const row = truncateToWidth(`${hiddenToolPrefix(comp)}${fitted}`, lineWidth, ONE_LINE_ELLIPSIS);
+  let invocation = tilded;
+  if (toolLabel(comp?.toolName) === "bash") {
+    if (repeatsPreviousCdPreamble(comp)) invocation = elideCdPreamble(invocation);
+    invocation = dimShellPlumbing(invocation);
+  }
+  const fitted = rightAlignSuffix(invocation, resultCharSuffix(comp), available, currentTheme());
+  const row = truncateToWidth(`${hiddenToolPrefix(comp)}${fitted}`, lineWidth, ELLIPSIS);
   const bgFn = rowBackground(comp);
+  return bgFn ? shadeRow(row, lineWidth, bgFn) : row;
+}
+
+// --- repetition folding (issue #14, design language §9/traceline 3+5) -------------------
+
+// pi's bash tool is stateless per call, so agents working outside the session cwd re-`cd`
+// on every call — measured at 90% of bash rows in a live session. When a row's
+// `cd <dir> && ` preamble repeats the previous bash row's, the repeated head carries no
+// information and its ~half-row width starves middle truncation of the part that
+// *differs*; render it as a dim `⋯` instead.
+const CD_PREAMBLE = /^cd\s+("[^"]*"|'[^']*'|\S+)\s*&&\s/;
+
+function cdPreambleDir(comp: any): string | undefined {
+  if (toolLabel(comp?.toolName) !== "bash") return undefined;
+  const command = comp?.args?.command;
+  if (typeof command !== "string") return undefined;
+  return CD_PREAMBLE.exec(command)?.[1];
+}
+
+// The previous bash row within the same visual group: reads and other tools interleave
+// freely, but visible prose opens a new paragraph — a `⋯` must never point across one.
+function previousBashRow(comp: any): any | undefined {
+  const found = componentLocation(comp);
+  if (!found) return undefined;
+  for (let j = found.index - 1; j >= 0; j--) {
+    const prev = found.sibs[j];
+    if (isToolRow(prev)) {
+      if (toolLabel(prev?.toolName) === "bash") return prev;
+      continue;
+    }
+    if (isEmptyConnector(prev) || isCollapsedThinkingRow(prev)) continue;
+    return undefined;
+  }
+  return undefined;
+}
+
+function repeatsPreviousCdPreamble(comp: any): boolean {
+  const dir = cdPreambleDir(comp);
+  if (dir === undefined) return false;
+  return cdPreambleDir(previousBashRow(comp)) === dir;
+}
+
+function elideCdPreamble(line: string): string {
+  const visible = stripAnsi(line);
+  if (!visible.startsWith("$ cd ")) return line;
+  const ampIndex = visible.indexOf(" && ");
+  if (ampIndex < 0) return line;
+  const head = line.slice(0, rawIndexAtVisibleIndex(line, 2)); // `$ ` with its styling
+  const rest = line.slice(rawIndexAtVisibleIndex(line, ampIndex + 1)); // from `&& …`
+  return `${head}${dim(PREAMBLE_MARK)} ${rest}`;
+}
+
+// Consecutive reads paging through one file (read → truncation notice → read with offset)
+// differ only in the range; fold the run into one row —
+// `read path:1-200,201-400 · 2 calls` with the combined result size — carried by the
+// run's first row while the later rows render nothing. Runs are broken by anything
+// visible between the reads (prose, a collapsed Thinking… line, another tool), so the
+// fold never reorders what the transcript shows; clicking the folded row open restores
+// the individual rows.
+function readPath(comp: any): string | undefined {
+  if (toolLabel(comp?.toolName) !== "read") return undefined;
+  const path = comp?.args?.path;
+  return typeof path === "string" && path.length > 0 ? path : undefined;
+}
+
+function readRun(comp: any): { rows: any[]; index: number } | undefined {
+  const path = readPath(comp);
+  if (path === undefined) return undefined;
+  const found = componentLocation(comp);
+  if (!found) return undefined;
+  const { sibs, index } = found;
+  const rows: any[] = [comp];
+  let selfIndex = 0;
+  for (let j = index - 1; j >= 0; j--) {
+    const prev = sibs[j];
+    if (isEmptyConnector(prev)) continue;
+    if (readPath(prev) !== path) break;
+    rows.unshift(prev);
+    selfIndex++;
+  }
+  for (let j = index + 1; j < sibs.length; j++) {
+    const next = sibs[j];
+    if (isEmptyConnector(next)) continue;
+    if (readPath(next) !== path) break;
+    rows.push(next);
+  }
+  return rows.length > 1 ? { rows, index: selfIndex } : undefined;
+}
+
+function foldedReadLine(rows: any[], width: number): string {
+  const lineWidth = Math.max(1, width);
+  const available = Math.max(1, lineWidth - TOOL_PREFIX_VISIBLE_WIDTH);
+  const theme = currentTheme();
+  const last = rows[rows.length - 1];
+  const tone = statusTone(last);
+  const path = tildify(String(rows[0]?.args?.path ?? ""));
+  const lastSlash = path.lastIndexOf("/");
+  const dir = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : "";
+  const base = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
+  const ranges = rows
+    .map((row) => lineRange(row?.args).slice(1))
+    .filter(Boolean)
+    .join(",");
+  const body = `${ink(theme, tone, `${BOLD}read${BOLD_OFF}`)} ${dim(dir)}${base}${dim(ranges ? `:${ranges}` : "")}`;
+  let total: number | undefined;
+  for (const row of rows) {
+    const chars = resultTextCharCount(row);
+    if (chars !== undefined) total = (total ?? 0) + chars;
+  }
+  // Call count rides the right-aligned suffix (fact order: what · how many · how big),
+  // so middle truncation protects the discriminating basename+ranges tail of the body.
+  const calls = `${rows.length} calls`;
+  const suffix = total === undefined ? dim(calls) : `${dim(`${calls}${SEP}`)}${charSuffix(total)}`;
+  const fitted = rightAlignSuffix(body, suffix, available, theme);
+  const row = truncateToWidth(`${toolPrefix(tone)}${fitted}`, lineWidth, ELLIPSIS);
+  const bgFn = rowBackground(last);
   return bgFn ? shadeRow(row, lineWidth, bgFn) : row;
 }
 
@@ -817,6 +876,77 @@ function leadingBlank(comp: any): boolean {
   return true;
 }
 
+// One row's worth of one-line output: folded-run handling plus the group-spacing rule.
+// Shared by the prototype patch and the test suites.
+function renderTraceRow(comp: any, width: number): string[] {
+  const run = readRun(comp);
+  if (run && !run.rows.some((row) => toolIsIndividuallyExpanded(row))) {
+    if (run.index > 0) return []; // a later page: the run's first row carries the fold
+    const line = foldedReadLine(run.rows, width);
+    return leadingBlank(comp) ? ["", line] : [line];
+  }
+  const line = oneLine(comp, width);
+  return leadingBlank(comp) ? ["", line] : [line];
+}
+
+// --- doubled Thinking… labels (issue #14, pi-native rendering) --------------------------
+
+// pi renders the collapsed thinking label once per thinking *block*, not per message, so
+// a message with adjacent thinking blocks prints consecutive identical `Thinking...`
+// lines that carry no more information than one. Coalesce them at render time. Dropped
+// lines can carry OSC 133 zone marks (pi marks the message's first and last line), so
+// any control sequences on dropped lines are transplanted onto the last kept line.
+function oscSequences(line: string): string {
+  return (line.match(OSC_SEQUENCE) ?? []).join("");
+}
+
+function dedupeThinkingLabels(comp: any, lines: string[]): string[] {
+  const label =
+    typeof comp?.hiddenThinkingLabel === "string" && comp.hiddenThinkingLabel.length > 0
+      ? comp.hiddenThinkingLabel
+      : "Thinking...";
+  const out: string[] = [];
+  let lastLabelAt = -1; // index in `out` of the last kept label, with only blanks after it
+  let salvaged = "";
+  for (const line of lines) {
+    const visible = stripAnsi(line).trim();
+    if (visible === label) {
+      if (lastLabelAt >= 0) {
+        while (out.length > lastLabelAt + 1) salvaged += oscSequences(out.pop()!);
+        salvaged += oscSequences(line);
+        continue;
+      }
+      lastLabelAt = out.length;
+      out.push(line);
+      continue;
+    }
+    if (visible.length > 0) lastLabelAt = -1;
+    out.push(line);
+  }
+  if (salvaged && out.length > 0) out[out.length - 1] = `${salvaged}${out[out.length - 1]}`;
+  return out;
+}
+
+function patchAssistantRowPrototype(proto: any): void {
+  if (!proto || typeof proto.render !== "function") return;
+  if (proto.__tracelineAssistantPatchVersion === TRACELINE_ASSISTANT_PATCH_VERSION) return;
+  const original = proto.__tracelineOriginalAssistantRender ?? proto.render;
+  proto.__tracelineOriginalAssistantRender = original;
+  proto.render = function (width: number) {
+    const lines = original.call(this, width);
+    try {
+      if (this.hideThinkingBlock === true && Array.isArray(lines)) {
+        return dedupeThinkingLabels(this, lines);
+      }
+    } catch {
+      /* never let pi-traceline break a render */
+    }
+    return lines;
+  };
+  proto.__tracelineAssistantPatchVersion = TRACELINE_ASSISTANT_PATCH_VERSION;
+  g.__tracelineAssistantPatchVersion = TRACELINE_ASSISTANT_PATCH_VERSION;
+}
+
 // --- prototype patch (shared by every current + future tool row, applied once) --------
 
 function currentPatchInstalled(): boolean {
@@ -844,8 +974,7 @@ function patchToolRowPrototype(proto: any): void {
       return original.call(this, width);
     }
     try {
-      const line = oneLine(this, width);
-      return leadingBlank(this) ? ["", line] : [line];
+      return renderTraceRow(this, width);
     } catch {
       return original.call(this, width); // never let pi-traceline break a render
     }
@@ -854,12 +983,23 @@ function patchToolRowPrototype(proto: any): void {
   g.__tracelinePatchVersion = TRACELINE_PATCH_VERSION;
 }
 
+function assistantPatchInstalled(): boolean {
+  return g.__tracelineAssistantPatchVersion === TRACELINE_ASSISTANT_PATCH_VERSION;
+}
+
 function tryPatch(): void {
-  if (currentPatchInstalled() || !g.__tracelineTui) return;
+  if ((currentPatchInstalled() && assistantPatchInstalled()) || !g.__tracelineTui) return;
   try {
     const sibs = chatChildren();
-    const row = Array.isArray(sibs) ? sibs.find(isToolRow) : undefined;
-    if (row) patchToolRowPrototype(Object.getPrototypeOf(row));
+    if (!Array.isArray(sibs)) return;
+    if (!currentPatchInstalled()) {
+      const row = sibs.find(isToolRow);
+      if (row) patchToolRowPrototype(Object.getPrototypeOf(row));
+    }
+    if (!assistantPatchInstalled()) {
+      const assistant = sibs.find(isAssistantRow);
+      if (assistant) patchAssistantRowPrototype(Object.getPrototypeOf(assistant));
+    }
   } catch {
     /* never let pi-traceline break a render */
   }
@@ -879,7 +1019,7 @@ export const internals = {
   rawIndexAtVisibleIndex,
   rawIndexBeforeVisibleIndex,
   middleTruncate,
-  fitOneLineAndSuffix,
+  rightAlignSuffix,
   tildify,
   stripTimeoutSuffix,
   dimShellPlumbing,
@@ -888,11 +1028,22 @@ export const internals = {
   shadeRow,
   // row grammar
   formatCharCount,
+  charSuffix,
+  configureSizeThresholds,
   lineRange,
   toolStatus,
   fallbackInvocationLine,
   oneLine,
   leadingBlank,
+  renderTraceRow,
+  // repetition folding + thinking-label dedupe (issue #14)
+  cdPreambleDir,
+  repeatsPreviousCdPreamble,
+  elideCdPreamble,
+  readRun,
+  foldedReadLine,
+  dedupeThinkingLabels,
+  patchAssistantRowPrototype,
   // mouse / click state machine
   parseSgrMouse,
   isLeftMousePress,
@@ -938,6 +1089,21 @@ export default function piTraceline(pi: ExtensionAPI) {
     // Capture the real TUI (passed synchronously to the widget factory), then patch only
     // extension-visible seams: render for hit-map capture, requestRender for delayed
     // tool-row patching, and raw terminal input for SGR mouse click events.
+    g.__tracelineGetTheme = () => {
+      try {
+        return (ctx.ui as any).theme;
+      } catch {
+        return undefined;
+      }
+    };
+    configureSizeThresholds(
+      Object.assign(
+        {},
+        ...configPaths("pi-traceline", process.cwd()).map(
+          (path) => readJsonConfig<Record<string, unknown>>(path) ?? {},
+        ),
+      ),
+    );
     captureTui(ctx.ui, "__pi_traceline_capture", (tui) => {
       const t = tui as any;
       g.__tracelineTui = t;

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -194,6 +194,33 @@ test("real AssistantMessageComponent satisfies traceline's assistant duck type",
   assert.equal(peek.hideThinkingBlock, true, "hideThinkingBlock no longer mirrors setHideThinkingBlock — collapse state desyncs");
 });
 
+test("adjacent thinking blocks double the collapsed label natively; traceline coalesces them", () => {
+  pi.initTheme(undefined, false);
+  const component = new pi.AssistantMessageComponent({
+    role: "assistant",
+    content: [
+      { type: "thinking", thinking: "first reasoning segment" },
+      { type: "thinking", thinking: "second reasoning segment" },
+    ],
+  } as never);
+  component.setHideThinkingBlock(true);
+
+  const native = component.render(80);
+  const labelCount = (lines: string[]) =>
+    lines.filter((line) => traceline.stripAnsi(line).trim() === "Thinking...").length;
+  // The seam itself (issue #14 №3): pi renders one collapsed label per thinking *block*.
+  // If this drops to 1, pi fixed it upstream — retire dedupeThinkingLabels.
+  assert.equal(labelCount(native), 2, "adjacent thinking blocks no longer double the label — dedupe may be retirable");
+
+  const deduped = traceline.dedupeThinkingLabels(component, native);
+  assert.equal(labelCount(deduped), 1, "dedupe must coalesce the doubled labels");
+
+  // pi marks the message's first and last lines with OSC 133 zone marks; the dedupe must
+  // never lose control sequences from dropped lines.
+  const zoneMarks = (lines: string[]) => (lines.join("").match(/\x1b\]133;[^\x07\x1b]*(?:\x07|\x1b\\)/g) ?? []).length;
+  assert.equal(zoneMarks(deduped), zoneMarks(native), "OSC 133 zone marks must survive the dedupe");
+});
+
 test("chat-rebuild surface cachemire's line persistence depends on", () => {
   // Ctrl+T (and compaction/navigation) rebuild the chat container from session messages:
   // clear() + re-render drops raw appended children. Cachemire re-attaches its lines

--- a/tests/fixtures/goldens/traceline-rows-120.txt
+++ b/tests/fixtures/goldens/traceline-rows-120.txt
@@ -1,0 +1,14 @@
+
+Let me look at the failing suite.
+
+  › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5                                              1.4k ch
+
+Thinking...
+  › $ ⋯ && npm run typecheck                                                                                    14.2k ch
+  › read ~/projects/pine-of-glass/extensions/pi-cachemire/index.ts:1-200,201-400,401-600              3 calls · 51.1k ch
+  › $ ⋯ && rm -f /tmp/pog-scratch.txt                                                                            0.0k ch
+
+The typecheck output looks wrong — checking the runner script.
+
+  › $ python3 -c ' ↵ import json ↵ print(json.dumps(cfg)) ↵ ' | tail -2                                         56.3k ch
+  › $ git status --short

--- a/tests/fixtures/goldens/traceline-rows-80.txt
+++ b/tests/fixtures/goldens/traceline-rows-80.txt
@@ -1,0 +1,14 @@
+
+Let me look at the failing suite.
+
+  › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5      1.4k ch
+
+Thinking...
+  › $ ⋯ && npm run typecheck                                            14.2k ch
+  › read ~/projects/pine-of-gl…index.ts:1-200,201-400,401-600 3 calls · 51.1k ch
+  › $ ⋯ && rm -f /tmp/pog-scratch.txt                                    0.0k ch
+
+The typecheck output looks wrong — checking the runner script.
+
+  › $ python3 -c ' ↵ import json ↵ print(json.dumps(cfg)) ↵ ' | tail -2 56.3k ch
+  › $ git status --short

--- a/tests/traceline/goldens.test.ts
+++ b/tests/traceline/goldens.test.ts
@@ -1,0 +1,109 @@
+// Visual regression net for the one-line trace grammar (design language §9/traceline):
+// a realistic scripted sequence — repeated cd preambles, a paginated read run, healthy
+// and ballooned outputs, a flattened multiline command — rendered at 80 and 120 columns.
+// Colour is not under test (see docs/testing.md); structure, alignment, folding, and
+// wording are. Regenerate with UPDATE_GOLDENS=1 npm test and review the diff like code.
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+
+import { internals } from "../../extensions/pi-traceline/index.ts";
+import { expectGolden } from "../helpers.ts";
+
+const { renderTraceRow, stripAnsi, isToolRow } = internals;
+
+const g = globalThis as Record<string, unknown>;
+
+function bash(command: string, options: { rendered?: string[]; chars?: number; error?: boolean; running?: boolean } = {}) {
+  return {
+    toolName: "bash",
+    args: { command },
+    result: options.running
+      ? undefined
+      : { content: [{ type: "text", text: "x".repeat(options.chars ?? 200) }], isError: options.error === true },
+    isPartial: options.running === true,
+    render: () => [],
+    setExpanded: () => {},
+    callRendererComponent: { render: () => options.rendered ?? [`$ ${command} (timeout 30s)`] },
+  };
+}
+
+function read(path: string, offset: number, limit: number, chars: number) {
+  return {
+    toolName: "read",
+    args: { path, offset, limit },
+    result: { content: [{ type: "text", text: "x".repeat(chars) }], isError: false },
+    isPartial: false,
+    render: () => [],
+    setExpanded: () => {},
+    callRendererComponent: { render: () => [`read ${path}:${offset}-${offset + limit - 1}`] },
+  };
+}
+
+function prose(text: string) {
+  return {
+    setHideThinkingBlock: () => {},
+    hideThinkingBlock: false,
+    lastMessage: { content: [{ type: "text", text }] },
+    __prose: text,
+  };
+}
+
+function thinking() {
+  return {
+    setHideThinkingBlock: () => {},
+    hideThinkingBlock: true,
+    lastMessage: { content: [{ type: "thinking", thinking: "..." }] },
+    __thinking: true,
+  };
+}
+
+beforeEach(() => {
+  g.__tracelineChat = undefined;
+  g.__tracelineGetTheme = undefined;
+});
+
+test("one-line trace goldens at 80 and 120 columns", () => {
+  const repo = `${homedir()}/projects/pine-of-glass`;
+  const children = [
+    prose("Let me look at the failing suite."),
+    bash(`cd ${repo} && npm test 2>/dev/null | tail -5`, { chars: 1_437 }),
+    thinking(),
+    bash(`cd ${repo} && npm run typecheck`, { chars: 14_200 }),
+    read(`${repo}/extensions/pi-cachemire/index.ts`, 1, 200, 18_400),
+    read(`${repo}/extensions/pi-cachemire/index.ts`, 201, 200, 18_400),
+    read(`${repo}/extensions/pi-cachemire/index.ts`, 401, 200, 14_300),
+    bash(`cd ${repo} && rm -f /tmp/pog-scratch.txt`, { chars: 0 }),
+    prose("The typecheck output looks wrong — checking the runner script."),
+    bash("python3 -c '...'", {
+      rendered: ["$ python3 -c '", "  import json", "  print(json.dumps(cfg))", "  ' | tail -2 (timeout 70s)"],
+      chars: 56_300,
+      error: true,
+    }),
+    bash("git status --short", { running: true }),
+  ];
+  g.__tracelineChat = { children };
+
+  const renderAt = (width: number): string => {
+    const lines: string[] = [];
+    for (const child of children) {
+      if (isToolRow(child)) {
+        for (const line of renderTraceRow(child, width)) lines.push(stripAnsi(line));
+        continue;
+      }
+      const marker = (child as { __prose?: string; __thinking?: boolean }).__prose ?? "Thinking...";
+      lines.push("", marker);
+    }
+    return `${lines.join("\n")}\n`;
+  };
+
+  expectGolden("traceline-rows-80.txt", renderAt(80));
+  expectGolden("traceline-rows-120.txt", renderAt(120));
+
+  // The golden never exceeds its width budget.
+  for (const width of [80, 120]) {
+    for (const line of renderAt(width).split("\n")) {
+      assert.ok(line.length <= width, `line exceeds ${width} cols: ${JSON.stringify(line)}`);
+    }
+  }
+});

--- a/tests/traceline/one-line.test.ts
+++ b/tests/traceline/one-line.test.ts
@@ -10,8 +10,10 @@ import { internals } from "../../extensions/pi-traceline/index.ts";
 
 const {
   oneLine,
-  fitOneLineAndSuffix,
+  rightAlignSuffix,
   formatCharCount,
+  charSuffix,
+  configureSizeThresholds,
   lineRange,
   tildify,
   toolStatus,
@@ -24,9 +26,17 @@ const {
   flattenInvocationLines,
   rowBackground,
   shadeRow,
+  renderTraceRow,
+  repeatsPreviousCdPreamble,
+  elideCdPreamble,
+  readRun,
+  dedupeThinkingLabels,
 } = internals;
 
 const g = globalThis as Record<string, unknown>;
+
+// Without a theme handle, all family ink falls back to basic raw ANSI (style.ts):
+const DIM = "\x1b[90m";
 
 type SyntheticComp = Record<string, unknown>;
 
@@ -45,6 +55,8 @@ function toolComp(overrides: SyntheticComp = {}): SyntheticComp {
 
 beforeEach(() => {
   g.__tracelineChat = undefined;
+  g.__tracelineGetTheme = undefined;
+  configureSizeThresholds(undefined);
 });
 
 test("row grammar units", () => {
@@ -73,7 +85,7 @@ test("suffix fitting: right-aligned, never overlapping, suffix wins when starved
   const invocation = "read ~/projects/demo/some/deeply/nested/path/file.ts:1-40";
   const suffix = "9.9k ch";
   for (let width = 1; width <= 120; width++) {
-    const out = fitOneLineAndSuffix(invocation, suffix, width);
+    const out = rightAlignSuffix(invocation, suffix, width);
     assert.ok(visibleWidth(out) <= width, `width ${width}: ${visibleWidth(out)} cols`);
     if (width > suffix.length + 2) {
       assert.ok(stripAnsi(out).endsWith(suffix), `width ${width} must keep the suffix`);
@@ -89,7 +101,38 @@ test("one-line read row: emphasized path, range kept, suffix right-aligned", () 
   assert.ok(visible.endsWith("1.4k ch"), visible);
   // Emphasis dims the directory separately from the basename: the raw line must restyle
   // the directory span, not just pass the native text through.
-  assert.ok(line.includes("\x1b[38;2;128;128;128m~/projects/demo/\x1b[0m"), "directory must be dimmed");
+  assert.ok(line.includes(`${DIM}~/projects/demo/\x1b[0m`), "directory must be dimmed");
+});
+
+test("result-size suffix severity: dim while healthy, warning ≥10k ch, error ≥50k ch", () => {
+  assert.ok(charSuffix(1_437).startsWith(DIM), "healthy sizes stay dim");
+  assert.ok(charSuffix(10_000).startsWith("\x1b[33m"), "≥10k ch must tint warning");
+  assert.ok(charSuffix(50_000).startsWith("\x1b[31m"), "≥50k ch must tint error");
+  assert.equal(charSuffix(undefined), "");
+  assert.equal(stripAnsi(charSuffix(50_000)), "50.0k ch");
+
+  // Thresholds follow the family config convention (~/.pi/agent/pi-traceline.json).
+  configureSizeThresholds({ sizeWarningChars: 100, sizeErrorChars: 1_000 });
+  assert.ok(charSuffix(500).startsWith("\x1b[33m"));
+  assert.ok(charSuffix(2_000).startsWith("\x1b[31m"));
+  configureSizeThresholds(undefined);
+  assert.ok(charSuffix(500).startsWith(DIM));
+});
+
+test("ink derives from the theme when one is active", () => {
+  // A theme whose palette is distinguishable from every raw-ANSI fallback: 256-colour
+  // codes per role (real escape sequences, so width math stays honest).
+  const codes: Record<string, number> = { dim: 245, muted: 246, text: 255, success: 41, warning: 220, error: 196, accent: 214 };
+  g.__tracelineGetTheme = () => ({
+    fg: (color: string, text: string) => `\x1b[38;5;${codes[color] ?? 250}m${text}\x1b[39m`,
+    bold: (text: string) => text,
+    bg: (_color: string, text: string) => text,
+  });
+  const line = oneLine(toolComp(), 80);
+  assert.ok(line.includes("\x1b[38;5;245m~/projects/demo/"), `directory must use theme dim: ${JSON.stringify(line)}`);
+  assert.ok(line.includes("\x1b[38;5;41m"), "status ink must use the theme success role");
+  assert.ok(line.includes("\x1b[38;5;245m1.4k ch"), "healthy suffix must use theme dim");
+  assert.ok(!line.includes(DIM), "no raw fallback grey may leak while a theme is active");
 });
 
 test("error status colours the bullet red; running is blue; success green", () => {
@@ -119,12 +162,12 @@ test("bash rows: timeout boilerplate stripped, shell plumbing dimmed, segments b
   const visible = stripAnsi(line);
   assert.ok(!visible.includes("timeout"), `timeout boilerplate must be stripped: ${visible}`);
   // Plumbing is dimmed; the command segments around it keep full brightness.
-  assert.ok(line.includes("\x1b[38;2;128;128;128m&&\x1b[0m"), "&& must be dimmed");
-  assert.ok(line.includes("\x1b[38;2;128;128;128m2>/dev/null\x1b[0m"), "2>/dev/null must be dimmed");
-  assert.ok(line.includes("\x1b[38;2;128;128;128m|\x1b[0m"), "pipe must be dimmed");
+  assert.ok(line.includes(`${DIM}&&\x1b[0m`), "&& must be dimmed");
+  assert.ok(line.includes(`${DIM}2>/dev/null\x1b[0m`), "2>/dev/null must be dimmed");
+  assert.ok(line.includes(`${DIM}|\x1b[0m`), "pipe must be dimmed");
 
   // Unit edges: heredoc markers dim; quoted near-misses and SGR params stay untouched.
-  assert.ok(dimShellPlumbing("cat <<'EOF'").includes("\x1b[38;2;128;128;128m<<'EOF'\x1b[0m"));
+  assert.ok(dimShellPlumbing("cat <<'EOF'").includes(`${DIM}<<'EOF'\x1b[0m`));
   assert.equal(dimShellPlumbing("echo 'a&&b'"), "echo 'a&&b'", "unspaced operators are left alone");
   assert.equal(stripTimeoutSuffix("$ ls (timeout 10s)"), "$ ls\x1b[0m");
   assert.equal(stripTimeoutSuffix("$ ls"), "$ ls");
@@ -150,7 +193,7 @@ test("multiline bash flattens to one line: tail survives, breaks marked, timeout
   assert.ok(visible.startsWith('  › $ python3 -c "'), visible);
   assert.ok(visible.includes("capture-pane"), `operative tail must survive: ${visible}`);
   assert.ok(visible.includes("\u21b5"), `original line breaks must be marked: ${visible}`);
-  assert.ok(line.includes("\x1b[38;2;128;128;128m\u21b5\x1b[0m"), "break marks must be dimmed");
+  assert.ok(line.includes(`${DIM}\u21b5\x1b[0m`), "break marks must be dimmed");
   assert.ok(!visible.includes("timeout"), `timeout boilerplate stays stripped after flatten: ${visible}`);
 
   // Narrow widths middle-truncate but still keep both ends of the flattened command.
@@ -198,7 +241,7 @@ test("hyperlinked read rows (OSC 8, ST-terminated): text survives stripAnsi, URL
   const comp = toolComp({ callRendererComponent: { render: () => [linked] } });
   const line = oneLine(comp, 80);
   assert.ok(
-    line.includes("\x1b[38;2;128;128;128m~/projects/demo/\x1b[0m"),
+    line.includes(`${DIM}~/projects/demo/\x1b[0m`),
     `path emphasis must apply on hyperlink terminals: ${JSON.stringify(line)}`,
   );
 });

--- a/tests/traceline/repetition.test.ts
+++ b/tests/traceline/repetition.test.ts
@@ -1,0 +1,200 @@
+// Repetition folding (issue #14): repeated `cd <dir> && ` preambles elide to a dim ⋯,
+// consecutive same-file reads fold into one row, and doubled collapsed Thinking...
+// labels coalesce. Comps are synthetic duck-type stand-ins; the contract suite proves
+// the duck types (and the doubled-label seam itself) against the real installed pi.
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+
+import { internals } from "../../extensions/pi-traceline/index.ts";
+
+const {
+  stripAnsi,
+  oneLine,
+  renderTraceRow,
+  repeatsPreviousCdPreamble,
+  elideCdPreamble,
+  readRun,
+  dedupeThinkingLabels,
+} = internals;
+
+const g = globalThis as Record<string, unknown>;
+
+const DIM = "\x1b[90m"; // raw-ANSI fallback for the family dim tone (no theme in tests)
+const FOLD_MARK = "\u22ef";
+
+function bashComp(command: string, rendered?: string): Record<string, unknown> {
+  return {
+    toolName: "bash",
+    args: { command },
+    result: { content: [{ type: "text", text: "ok" }], isError: false },
+    isPartial: false,
+    render: () => [],
+    setExpanded: () => {},
+    callRendererComponent: { render: () => [rendered ?? `$ ${command}`] },
+  };
+}
+
+function readComp(path: string, offset: number, limit: number, resultChars = 1_000): Record<string, unknown> {
+  return {
+    toolName: "read",
+    args: { path, offset, limit },
+    result: { content: [{ type: "text", text: "x".repeat(resultChars) }], isError: false },
+    isPartial: false,
+    render: () => [],
+    setExpanded: () => {},
+    callRendererComponent: { render: () => [`read ${path}:${offset}-${offset + limit - 1}`] },
+  };
+}
+
+const prose = {
+  setHideThinkingBlock: () => {},
+  hideThinkingBlock: false,
+  lastMessage: { content: [{ type: "text", text: "now let me check" }] },
+};
+
+const collapsedThinking = {
+  setHideThinkingBlock: () => {},
+  hideThinkingBlock: true,
+  lastMessage: { content: [{ type: "thinking", thinking: "hmm" }] },
+};
+
+const connector = {
+  setHideThinkingBlock: () => {},
+  hideThinkingBlock: false,
+  lastMessage: { content: [{ type: "toolCall" }] },
+};
+
+beforeEach(() => {
+  g.__tracelineChat = undefined;
+  g.__tracelineGetTheme = undefined;
+});
+
+test("repeated cd preamble elides to a dim ⋯; the first occurrence keeps the full path", () => {
+  const first = bashComp("cd /tmp/pog-demo && npm test");
+  const second = bashComp("cd /tmp/pog-demo && npm run typecheck");
+  g.__tracelineChat = { children: [prose, first, second] };
+
+  assert.equal(repeatsPreviousCdPreamble(first), false, "first occurrence is not a repeat");
+  assert.equal(repeatsPreviousCdPreamble(second), true);
+
+  const firstVisible = stripAnsi(oneLine(first, 120));
+  const secondVisible = stripAnsi(oneLine(second, 120));
+  assert.ok(firstVisible.includes("cd /tmp/pog-demo"), firstVisible);
+  assert.ok(secondVisible.includes(`$ ${FOLD_MARK} && npm run typecheck`), secondVisible);
+  assert.ok(!secondVisible.includes("cd /tmp"), `repeated preamble must not re-print: ${secondVisible}`);
+  assert.ok(oneLine(second, 120).includes(`${DIM}${FOLD_MARK}\x1b[0m`), "the ⋯ must be dimmed");
+});
+
+test("elision scans past interleaved non-bash tools but never across visible prose", () => {
+  const a = bashComp("cd /tmp/pog-demo && ls");
+  const read = readComp(`${homedir()}/projects/demo/file.ts`, 1, 40);
+  const b = bashComp("cd /tmp/pog-demo && cat out.txt");
+  const c = bashComp("cd /tmp/pog-demo && rm out.txt");
+  g.__tracelineChat = { children: [a, read, b, prose, c] };
+
+  assert.equal(repeatsPreviousCdPreamble(b), true, "a read between bash rows does not break the group");
+  assert.equal(repeatsPreviousCdPreamble(c), false, "visible prose opens a new paragraph — ⋯ must not point across it");
+});
+
+test("elision requires the same directory, a real `&&` tail, and a thinking line does not break it", () => {
+  const a = bashComp("cd /tmp/one && ls");
+  const b = bashComp("cd /tmp/two && ls");
+  g.__tracelineChat = { children: [a, b] };
+  assert.equal(repeatsPreviousCdPreamble(b), false, "different directory is information, not repetition");
+
+  const cdOnlyPrev = bashComp("cd /tmp/one && ls");
+  const cdOnly = bashComp("cd /tmp/one");
+  g.__tracelineChat = { children: [cdOnlyPrev, cdOnly] };
+  assert.equal(repeatsPreviousCdPreamble(cdOnly), false, "a bare cd has no tail to elide to");
+
+  const c = bashComp("cd /tmp/one && ls");
+  const d = bashComp("cd /tmp/one && pwd");
+  g.__tracelineChat = { children: [c, collapsedThinking, d] };
+  assert.equal(repeatsPreviousCdPreamble(d), true, "a collapsed Thinking... line keeps the couplet in-group");
+
+  // Unit edges: lines that are not `$ cd … && …` pass through unchanged.
+  assert.equal(elideCdPreamble("$ ls -la"), "$ ls -la");
+  assert.equal(elideCdPreamble("read ~/x.ts:1-2"), "read ~/x.ts:1-2");
+});
+
+test("consecutive reads of one file fold into a single row with combined ranges and size", () => {
+  const path = `${homedir()}/projects/demo/big-file.ts`;
+  const r1 = readComp(path, 1, 200, 12_000);
+  const r2 = readComp(path, 201, 200, 12_000);
+  const r3 = readComp(path, 401, 200, 13_000);
+  g.__tracelineChat = { children: [prose, r1, connector, r2, r3] };
+
+  const run = readRun(r2);
+  assert.ok(run, "middle page must see the run");
+  assert.equal(run!.rows.length, 3);
+  assert.equal(run!.index, 1);
+
+  const first = renderTraceRow(r1, 120);
+  assert.equal(first.length, 2, "first row carries the fold (with its leading blank)");
+  const visible = stripAnsi(first[1]!);
+  assert.ok(visible.includes("read ~/projects/demo/big-file.ts:1-200,201-400,401-600"), visible);
+  assert.ok(visible.endsWith("3 calls · 37.0k ch"), `call count and combined size ride the suffix: ${visible}`);
+  assert.ok(first[1]!.includes("\x1b[33m37.0k ch"), "combined size keeps severity tinting (≥10k warning)");
+
+  assert.deepEqual(renderTraceRow(r2, 120), [], "later pages render nothing");
+  assert.deepEqual(renderTraceRow(r3, 120), [], "later pages render nothing");
+});
+
+test("a running last page keeps the fold live: running bullet, no premature size", () => {
+  const path = `${homedir()}/projects/demo/big-file.ts`;
+  const r1 = readComp(path, 1, 200, 9_000);
+  const r2 = { ...readComp(path, 201, 200), result: undefined, isPartial: true };
+  g.__tracelineChat = { children: [r1, r2] };
+
+  const folded = renderTraceRow(r1, 120);
+  const line = folded[folded.length - 1]!;
+  assert.ok(line.includes("\x1b[34m\u203a"), "bullet must reflect the in-flight last call");
+  const visible = stripAnsi(line);
+  assert.ok(visible.trimEnd().endsWith("2 calls · 9.0k ch"), `only landed results count: ${visible}`);
+});
+
+test("runs break on anything visible between the reads — and on a different file", () => {
+  const path = `${homedir()}/projects/demo/big-file.ts`;
+  const other = `${homedir()}/projects/demo/other.ts`;
+
+  g.__tracelineChat = { children: [readComp(path, 1, 200), collapsedThinking, readComp(path, 201, 200)] };
+  const [r1, , r2] = (g.__tracelineChat as { children: unknown[] }).children;
+  assert.equal(readRun(r1), undefined, "a visible Thinking... line breaks the run");
+  assert.equal(readRun(r2), undefined);
+
+  g.__tracelineChat = { children: [readComp(path, 1, 200), readComp(other, 1, 200)] };
+  const [p1, p2] = (g.__tracelineChat as { children: unknown[] }).children;
+  assert.equal(readRun(p1), undefined, "different files never fold");
+  assert.equal(readRun(p2), undefined);
+
+  // A single read renders exactly as before — folding is strictly n>1.
+  g.__tracelineChat = { children: [readComp(path, 1, 200)] };
+  const single = (g.__tracelineChat as { children: unknown[] }).children[0];
+  assert.equal(readRun(single), undefined);
+  const visible = stripAnsi(renderTraceRow(single, 120).at(-1)!);
+  assert.ok(visible.includes("read ~/projects/demo/big-file.ts:1-200"), visible);
+  assert.ok(!visible.includes("calls"), visible);
+});
+
+test("doubled Thinking... labels coalesce; distinct paragraphs and prose survive", () => {
+  const comp = { hiddenThinkingLabel: "Thinking..." };
+  const L = "\x1b[3mThinking...\x1b[23m";
+
+  assert.deepEqual(dedupeThinkingLabels(comp, ["", L, "", L]), ["", L]);
+  assert.deepEqual(dedupeThinkingLabels(comp, ["", L, "", L, "", L]), ["", L]);
+  assert.deepEqual(dedupeThinkingLabels(comp, ["", L, "", "prose", "", L]), ["", L, "", "prose", "", L]);
+  assert.deepEqual(dedupeThinkingLabels(comp, ["", L, "", L, "", "prose"]), ["", L, "", "prose"]);
+  assert.deepEqual(dedupeThinkingLabels(comp, ["just prose"]), ["just prose"]);
+
+  // OSC sequences on dropped lines (pi's zone marks live on the message's last line)
+  // are transplanted, never lost.
+  const marked = `\x1b]133;C\x07${L}`;
+  const out = dedupeThinkingLabels(comp, ["", L, "", marked]);
+  assert.equal(out.length, 2);
+  assert.ok(out[1]!.startsWith("\x1b]133;C\x07"), `zone mark must survive the dedupe: ${JSON.stringify(out)}`);
+
+  // A custom hiddenThinkingLabel is respected.
+  const custom = { hiddenThinkingLabel: "Pondering…" };
+  assert.deepEqual(dedupeThinkingLabels(custom, ["Pondering…", "", "Pondering…"]), ["Pondering…"]);
+});


### PR DESCRIPTION
Pass 2 of the design-language rollout (`docs/design-language.md` §9/traceline): the collapsed trace gets skimmable, theme-faithful, and stops re-printing what the model repeated. Closes #14.

## What

**1. All ink theme-derived** — `MUTED_GREY`/raw status ANSI replaced with `_lib/style.ts` `ink()` (raw-ANSI fallback before a theme exists; tests pin that no fallback grey leaks while a theme is active). The layout helpers traceline pioneered — `tildify`, `middleTruncate`, `rightAlignSuffix` — move to `_lib/style.ts`, and the ANSI index machinery to `_lib/ansi.ts`, as family property.

**2. Severity-tinted size suffixes** (design language §6) — dim while healthy, warning ≥ 10k ch, error ≥ 50k ch, so "which output ballooned" pops out of the column. Thresholds overridable via the family config convention (`~/.pi/agent/pi-traceline.json`: `sizeWarningChars`/`sizeErrorChars`).

**3. Repetition folds instead of re-printing** (issue #14, all three items):
- *cd preambles*: a bash row whose `cd <dir> && ` head repeats the previous bash row's renders it as a dim `⋯` — full width back to the part that differs. First occurrence keeps the full path; a `⋯` never points across visible prose.
- *Paginated reads*: consecutive same-file reads fold into one row — `read …/index.ts:1-200,201-400,401-600` with `3 calls · 51.1k ch` riding the right-aligned suffix (so middle truncation protects the discriminating basename+ranges tail). Anything visible between reads breaks the fold; clicking the folded row open restores the individual rows; a still-running last page keeps the fold live (blue bullet, landed-results-only size).
- *Doubled `Thinking...` labels*: an assistant-row prototype patch coalesces adjacent collapsed labels within one message. OSC 133 zone marks from dropped lines are transplanted, never lost. The seam itself (pi rendering one label per thinking *block*) is contract-tested against the installed pi — if pi fixes it upstream, the test says "retire the dedupe".

From the new 80-col golden:

```
  › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5      1.4k ch
  › $ ⋯ && npm run typecheck                                            14.2k ch
  › read ~/projects/pine-of-gl…index.ts:1-200,201-400,401-600 3 calls · 51.1k ch
  › $ ⋯ && rm -f /tmp/pog-scratch.txt                                    0.0k ch
```

## Verification

- `npm run typecheck` clean; `npm test` 126/126 (new `tests/traceline/repetition.test.ts`, contract test for the doubled-label seam against the real `AssistantMessageComponent`, one-line goldens at 80/120 cols per the doc's testing section).
- `npm run test:smoke` passes (real pi startup with the extensions loaded, /reload + Ctrl+T rebuild).
- Tool-row patch version bumped (11→12); assistant patch new at v1 — both versioned/idempotent across reloads.

## Notes

- Conformance item 4 ("body ink one step down") is implemented to the separable extent: verb L0-bold, basename/tail L1, directories/ranges/plumbing/meta L3-dim. Bash argument text has no reliable mid-line separability; revisit if slabs still pass the squint test against prose in live use.
- Passes 3 (contextimate) and 4 (cachemire) follow.
