### PR TITLE
Traceline: error reads never fold; quote-aware cd elision (review fixes for #19)

### DIFF
--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -745,11 +745,16 @@ function repeatsPreviousCdPreamble(comp: any): boolean {
 
 function elideCdPreamble(line: string): string {
   const visible = stripAnsi(line);
-  if (!visible.startsWith("$ cd ")) return line;
-  const ampIndex = visible.indexOf(" && ");
-  if (ampIndex < 0) return line;
+  if (!visible.startsWith("$ ")) return line;
+  // Find the separator with the same quote-aware parse used to detect the repeat: a
+  // plain indexOf(" && ") would cut inside a quoted directory (`cd "/tmp/a && b" && …`)
+  // and corrupt the command. The match tail is `\s*&&\s`, so its last `&&` *is* the
+  // separator, after any quoted segment.
+  const preamble = CD_PREAMBLE.exec(visible.slice(2));
+  if (!preamble) return line;
+  const ampIndex = 2 + preamble[0].lastIndexOf("&&");
   const head = line.slice(0, rawIndexAtVisibleIndex(line, 2)); // `$ ` with its styling
-  const rest = line.slice(rawIndexAtVisibleIndex(line, ampIndex + 1)); // from `&& …`
+  const rest = line.slice(rawIndexAtVisibleIndex(line, ampIndex)); // from `&& …`
   return `${head}${dim(PREAMBLE_MARK)} ${rest}`;
 }
 
@@ -766,8 +771,17 @@ function readPath(comp: any): string | undefined {
   return typeof path === "string" && path.length > 0 ? path : undefined;
 }
 
-function readRun(comp: any): { rows: any[]; index: number } | undefined {
+// A read row that may participate in a fold: error rows never fold — a failed page must
+// keep its own red row, not vanish into a folded one whose tone reflects only the last
+// call. An error therefore also breaks the run on both sides.
+function foldableReadPath(comp: any): string | undefined {
   const path = readPath(comp);
+  if (path === undefined) return undefined;
+  return toolStatus(comp) === "error" ? undefined : path;
+}
+
+function readRun(comp: any): { rows: any[]; index: number } | undefined {
+  const path = foldableReadPath(comp);
   if (path === undefined) return undefined;
   const found = componentLocation(comp);
   if (!found) return undefined;
@@ -777,14 +791,14 @@ function readRun(comp: any): { rows: any[]; index: number } | undefined {
   for (let j = index - 1; j >= 0; j--) {
     const prev = sibs[j];
     if (isEmptyConnector(prev)) continue;
-    if (readPath(prev) !== path) break;
+    if (foldableReadPath(prev) !== path) break;
     rows.unshift(prev);
     selfIndex++;
   }
   for (let j = index + 1; j < sibs.length; j++) {
     const next = sibs[j];
     if (isEmptyConnector(next)) continue;
-    if (readPath(next) !== path) break;
+    if (foldableReadPath(next) !== path) break;
     rows.push(next);
   }
   return rows.length > 1 ? { rows, index: selfIndex } : undefined;

--- a/tests/traceline/repetition.test.ts
+++ b/tests/traceline/repetition.test.ts
@@ -116,6 +116,22 @@ test("elision requires the same directory, a real `&&` tail, and a thinking line
   // Unit edges: lines that are not `$ cd … && …` pass through unchanged.
   assert.equal(elideCdPreamble("$ ls -la"), "$ ls -la");
   assert.equal(elideCdPreamble("read ~/x.ts:1-2"), "read ~/x.ts:1-2");
+  assert.equal(elideCdPreamble("$ cd /tmp"), "$ cd /tmp", "a bare cd has no tail");
+});
+
+test("elision is quote-aware: an && inside a quoted directory never becomes the cut point", () => {
+  const quotedDir = '"/tmp/a && b"';
+  const a = bashComp(`cd ${quotedDir} && ls`);
+  const b = bashComp(`cd ${quotedDir} && npm test`);
+  g.__tracelineChat = { children: [a, b] };
+  assert.equal(repeatsPreviousCdPreamble(b), true, "quoted dirs still detect as repeats");
+
+  const visible = stripAnsi(oneLine(b, 120));
+  assert.ok(visible.includes(`$ ${FOLD_MARK} && npm test`), visible);
+  assert.ok(!visible.includes('b"'), `the quoted directory must not leak past the cut: ${visible}`);
+
+  // Unit edge: the raw helper cuts after the quoted segment, not inside it.
+  assert.equal(stripAnsi(elideCdPreamble('$ cd "/tmp/a && b" && npm test')), `$ ${FOLD_MARK} && npm test`);
 });
 
 test("consecutive reads of one file fold into a single row with combined ranges and size", () => {
@@ -152,6 +168,28 @@ test("a running last page keeps the fold live: running bullet, no premature size
   assert.ok(line.includes("\x1b[34m\u203a"), "bullet must reflect the in-flight last call");
   const visible = stripAnsi(line);
   assert.ok(visible.trimEnd().endsWith("2 calls · 9.0k ch"), `only landed results count: ${visible}`);
+});
+
+test("error pages never fold: the red row survives and breaks the run on both sides", () => {
+  const path = `${homedir()}/projects/demo/big-file.ts`;
+  const err = {
+    ...readComp(path, 201, 200),
+    result: { content: [{ type: "text", text: "line 201 out of range" }], isError: true },
+  };
+  // ok · ERR · ok · ok — the error renders individually; only the trailing pair folds.
+  const r1 = readComp(path, 1, 200);
+  const r3 = readComp(path, 201, 200);
+  const r4 = readComp(path, 401, 200);
+  g.__tracelineChat = { children: [r1, err, r3, r4] };
+
+  assert.equal(readRun(r1), undefined, "an error after a single ok page leaves it unfolded");
+  assert.equal(readRun(err), undefined, "the error row itself never folds");
+  const tail = readRun(r3);
+  assert.ok(tail && tail.rows.length === 2, "ok pages after the error fold among themselves");
+
+  const errLine = renderTraceRow(err, 120);
+  assert.ok(errLine.length > 0, "the error row must render its own line");
+  assert.ok(errLine.at(-1)!.includes("\x1b[31m›"), "the error row keeps its red bullet");
 });
 
 test("runs break on anything visible between the reads — and on a different file", () => {


### PR DESCRIPTION
Fixes the two P2 findings from the post-merge gpt-5.5 review of #19:

1. **Error reads never fold.** `readRun` folded any adjacent same-path read and the folded row's tone came from the last call only — a failed `read` could disappear into a healthy-looking folded row. Error rows now render individually and break the run on both sides (ok pages on either side still fold among themselves).
2. **Quote-aware `cd` elision.** `elideCdPreamble` cut at the first `' && '`, which corrupted commands whose quoted directory contains `&&` (`cd "/tmp/a && b" && npm test` → `$ ⋯ && b" && npm test`). The cut now derives from `CD_PREAMBLE`'s quote-aware match, so the separator after the quoted segment is used.

Both regression-tested in `tests/traceline/repetition.test.ts`. Typecheck clean; 128/128 tests pass.