### PR TITLE
cachemire: design-language conformance — [Cachemire] panel, family glyphs, theme-derived ink

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ npm run test:smoke      # launches real pi in tmux with an isolated HOME (local-
 ```
 
 Extensions share code through [`extensions/_lib`](./extensions/_lib) (number grammar,
-ANSI helpers, chat-container detection, config convention). pi resolves extension-relative
+family style — glyphs, theme-derived ink, panel headers — ANSI helpers, chat-container
+detection, config convention). The visual grammar all three speak is specified in
+[`docs/design-language.md`](./docs/design-language.md); when a renderer and that document
+disagree, one of them is wrong. pi resolves extension-relative
 imports against the symlink path, so local installs must link the extension *directories*
 plus `_lib` — `npm run link-extensions` does exactly that. `_lib` has no `index.ts`, so
 pi's extension discovery skips it.
@@ -43,7 +46,6 @@ The contract suite pins every structural assumption about pi internals, so after
 *Note: A nice side benefit of 1. is that tools like `traceline` can help agents running interactive pi subagents in tmux to monitor them without risking context bloat from tool outputs.*
 
 **Status:** There are several things left to do in 1., including
-- maturing [`cachemire`](./extensions/pi-cachemire) (currently WIP/PoC: implemented and live-tested, but local/unpublished while the UX settles — see issue #6),
-- UI improvements for `traceline` (filepath/multi-read UI, tool result size)
+- maturing [`cachemire`](./extensions/pi-cachemire) (implemented, live-tested, and conformant with the family design language, but local/unpublished while the UX settles — see issue #6),
 - making `contextimate` more useful beyond upfront context (for example, are my MCP servers and skills efficient when loaded?)
 - and other refinements tracked in issues.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -5,9 +5,12 @@ One visual grammar for the extension family — `pi-contextimate`, `pi-traceline
 is its implementation. When a renderer and this document disagree, one of them is wrong —
 fix whichever it is, deliberately.
 
-**Status: agreed 2026-06-12.** Decisions marked `[D]` were proposed-by-default and
-confirmed; the former open questions are resolved in §11. Changes to this language are
-fine — but they are design decisions, made here first, then implemented.
+**Status: agreed 2026-06-12; implemented 2026-06-12** across the shared-library pass
+(#18), the traceline pass (#19, #20), the contextimate pass (#21), and the cachemire
+pass (#22). Decisions marked `[D]` were proposed-by-default and confirmed; the former
+open questions are resolved in §11. Changes to this language are fine — but they are
+design decisions, made here first, then implemented. §9's per-extension lists are the
+as-built conformance record.
 
 ## Why
 
@@ -178,7 +181,7 @@ ledger) share one header form:
 - `[D]` Panels brand with the **extension name** (`[Contextimate]`, `[Cachemire]`), not
   descriptive titles (`[Context Estimator]`, `Cachemire — cache & loop ledger`). One
   naming system; the descriptive part can live in the dim hint line. This renames a
-  documented surface (README, tests) — flagged for explicit approval. `[Q]`
+  documented surface (README, tests) — approved and applied (§11.1).
 
 ### Proportion
 
@@ -259,8 +262,8 @@ export function sizeTone(chars: number, overrides?): Tone;             // dim | 
    across modes.
 4. Proportion: percent-of-window on the two total rows + one stacked bar under
    `Total request`; optional per-row share of harness in summary. `[D]`
-5. Header becomes `[Contextimate]` + pips (pending the `[Q]` naming call); the pips
-   pattern moves to `style.ts` for reuse.
+5. Header becomes `[Contextimate]` + pips (naming resolved, §11.1); the pips pattern
+   moves to `style.ts` for reuse.
 6. Hardcoded `ORANGE` constant deleted; brand/figure/total highlights move to
    `ink(theme, "accent", …)` — the orange was an arbitrary pick and is not retained.
 
@@ -283,13 +286,13 @@ export function sizeTone(chars: number, overrides?): Tone;             // dim | 
 6. `›`, `↵`, middle-truncation, tildify: unchanged in behaviour; implementation moves
    to `_lib` so the family shares it.
 
-### pi-cachemire (WIP — apply before first publish)
+### pi-cachemire (applied before first publish, #22)
 
 1. Delete `formatTokensK`; use fixed-k `compactCount` (ledger `out 400` becomes
    `out 0.4k`). `formatUsd`/`formatDuration` move to `_lib/fmt.ts` (call sites
    unchanged).
 2. `/cache` ledger adopts the panel-header grammar (`[Cachemire]` + dim profile/hint
-   line, pending `[Q]`).
+   line; naming resolved, §11.1).
 3. Status glyphs `○ ● ◑ ◌` and `◍` move to `style.SCALE`/`style.GLYPH` — promoted to
    family vocabulary, behaviour unchanged.
 4. Clock/notice tones (green/yellow/grey) become theme-derived via `ink()`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -159,6 +159,11 @@ and compares against checked-in golden files (`tests/fixtures/goldens/*.txt`).
   renderer fallback) at width 80 — this pins the row grammar without touching Pi's
   renderer (comps are synthetic stand-ins satisfying the duck type, which the contract
   suite separately proves matches real Pi).
+- Cachemire gets one combined golden (`tests/cachemire/goldens.test.ts` →
+  `cachemire-lines.txt`): the `/cache` ledger panel over a cold/hit/partial/miss
+  session plus every one-line `◍` surface — clock states, break notices, resolutions,
+  and the turn summary — pinning wording, glyphs, and fact order (colour excluded as
+  everywhere).
 
 ## Layer 4 — startup smoke (tmux, local-only)
 

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -162,13 +162,19 @@ bar if you want the old ≥2-calls behaviour):
 and `/cache` for the full per-call table:
 
 ```
-◍ Cachemire — cache & loop ledger   anthropic · 5m TTL · anthropic/claude-opus-4-8
-   call     gap    input     read    wrote     out    cost  event
-      1       —    12.1k     0.0k   138.2k    0.4k   $0.55  ○ cold start
-      2     14s     1.2k   150.3k     1.8k    1.1k   $0.04  ● hit
-   totals: 2 calls · input 13.3k · read 150.3k · wrote 140.0k · out 1.5k · $0.59
-   caching saved ~$0.65 vs uncached $0.91 (−71%) · API-priced; notional on subscription
+[Cachemire]
+  cache & loop ledger · anthropic · 5m TTL · anthropic/claude-opus-4-8
+  call     gap    input     read    wrote     out    cost  event
+     1       —    12.1k     0.0k   138.2k    0.4k   $0.55  ○ cold start
+     2     14s     1.2k   150.3k     1.8k    1.1k  $0.040  ● hit
+  totals: 2 calls · input 13.3k · read 150.3k · wrote 140.0k · out 1.5k · $0.59
+  caching saved ~$0.65 vs uncached $0.91 (−71%) · API-priced; notional on subscription
 ```
+
+The ledger opens with the family panel header (`docs/design-language.md` §5): `[Cachemire]`
+in the theme accent, with the descriptive title and provider profile on the dim hint line.
+Clock and notice tones are theme-derived through the shared `ink()` helper, and the `◍` /
+`○ ● ◑ ◌` glyphs come from the family vocabulary in `extensions/_lib/style.ts`.
 
 The savings line compares actual spend against the counterfactual where every token was
 billed at base input rates — the honest answer to "is caching working?".

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
 import { buildSessionContext } from "@earendil-works/pi-coding-agent";
 import { Spacer, Text } from "@earendil-works/pi-tui";
 import { createHash } from "node:crypto";
@@ -7,6 +7,7 @@ import { captureTui } from "../_lib/capture.ts";
 import { findChatContainer } from "../_lib/chat.ts";
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
+import { GLYPH, SCALE, SEP, ink, panelHeader, type Tone } from "../_lib/style.ts";
 
 /**
  * pi-cachemire — explains the cache and loop economics of a pi session.
@@ -226,13 +227,9 @@ const UNKNOWN_TTL_WARM_MS = 10 * 60 * 1000; // soft "likely cold" horizon for im
 const HIT_RATIO = 0.8;
 const MISS_RATIO = 0.2;
 
-// --- ANSI (family style: raw SGR like pi-traceline) ------------------------------------
-
-const RESET = "\x1b[0m";
-const GREEN = "\x1b[32m";
-const YELLOW = "\x1b[33m";
-const MUTED_GREY = "\x1b[38;2;128;128;128m";
-const GLYPH = "\u25cd"; // ◍
+// Glyphs and ink come from the family style (_lib/style.ts, design language §§1–3):
+// ◍ opens every loop-economics line, ○ ● ◑ ◌ are the status scale, and all colour
+// is theme-derived through ink() with raw-ANSI fallbacks before a Theme handle exists.
 
 // --- fingerprinting --------------------------------------------------------------------
 
@@ -556,14 +553,10 @@ export function sessionSavings(records: CallRecord[]): { actual: number; uncache
 }
 
 // --- formatting ------------------------------------------------------------------------
-// formatUsd / formatDuration live in _lib/fmt.ts (family number grammar); re-exported
-// here because the test suite reaches them through this module's internals surface.
+// All number formatting lives in _lib/fmt.ts (family number grammar); re-exported here
+// because the test suite reaches it through this module's internals surface.
 
-export { formatDuration, formatUsd } from "../_lib/fmt.ts";
-
-export function formatTokensK(value: number): string {
-  return compactCount(value);
-}
+export { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 
 // --- cache clock (pure state → text; tones applied by the widget layer) -----------------
 
@@ -594,14 +587,14 @@ export interface ClockInput {
 function rewriteSuffix(verb: string, cachedTokens?: number, rewriteUsd?: number, qualifier = ""): string {
   if (!cachedTokens) return "";
   const bill = rewriteUsd !== undefined ? ` (~${formatUsd(rewriteUsd)})` : "";
-  return ` \u00b7 next send ${verb} ~${formatTokensK(cachedTokens)}${qualifier}${bill}`;
+  return ` \u00b7 next send ${verb} ~${compactCount(cachedTokens)}${qualifier}${bill}`;
 }
 
 export function cacheClock(input: ClockInput): ClockState {
   if (input.lastRequestAt === undefined) return { phase: "idle", text: "" };
   if (input.modelSwitched) {
     const scale = input.cachedTokens && input.oldModelId
-      ? ` (~${formatTokensK(input.cachedTokens)} ${input.oldModelId} tokens)`
+      ? ` (~${compactCount(input.cachedTokens)} ${input.oldModelId} tokens)`
       : "";
     return { phase: "cold", text: `cache cold \u00b7 model switched \u00b7 next send re-writes the full prompt${scale}` };
   }
@@ -661,12 +654,12 @@ export function renderRunSummary(run: RunAggregate, endedAt: number): string {
   const parts = [
     `turn: ${run.calls} ${run.calls === 1 ? "call" : "calls"}`,
     formatDuration(endedAt - run.startedAt),
-    `read ${formatTokensK(run.cacheRead)} (${cachedPct >= 99.95 ? "100" : cachedPct.toFixed(1)}% cached)`,
-    `wrote ${formatTokensK(run.cacheWrite)}`,
-    `out ${formatTokensK(run.output)}`,
+    `read ${compactCount(run.cacheRead)} (${cachedPct >= 99.95 ? "100" : cachedPct.toFixed(1)}% cached)`,
+    `wrote ${compactCount(run.cacheWrite)}`,
+    `out ${compactCount(run.output)}`,
   ];
   if (run.costUsd > 0) parts.push(formatUsd(run.costUsd));
-  return parts.join(" \u00b7 ");
+  return parts.join(SEP);
 }
 
 // Tense grammar: in-flight predictions are progressive with ~estimates ("breaking ·
@@ -674,7 +667,7 @@ export function renderRunSummary(run: RunAggregate, endedAt: number): string {
 // 77.7k of 80.1k prompt (97%)").
 export function renderBreakingLine(prediction: BreakPrediction): string {
   const size = prediction.expectedRewriteTokens
-    ? ` \u00b7 re-writing ~${formatTokensK(prediction.expectedRewriteTokens)}${prediction.expectedUsd !== undefined ? ` (~${formatUsd(prediction.expectedUsd)})` : ""}`
+    ? ` \u00b7 re-writing ~${compactCount(prediction.expectedRewriteTokens)}${prediction.expectedUsd !== undefined ? ` (~${formatUsd(prediction.expectedUsd)})` : ""}`
     : prediction.cause.kind === "compaction"
       ? " \u00b7 re-writing the new prefix"
       : prediction.cause.kind === "thinking"
@@ -696,9 +689,9 @@ export function renderMissLine(record: CallRecord): string {
   const prompt = promptTokens(record.usage);
   const pct = prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}% of prompt)` : "";
   const what = record.classification.kind === "partial"
-    ? `cache partial \u00b7 read ${formatTokensK(record.usage.cacheRead)} of ${formatTokensK(record.expectedRead)} expected` +
-      ` \u00b7 re-wrote ${formatTokensK(record.rewroteTokens)}${pct}`
-    : `cache broke \u00b7 re-wrote ${formatTokensK(record.rewroteTokens)} of ${formatTokensK(prompt)} prompt` +
+    ? `cache partial \u00b7 read ${compactCount(record.usage.cacheRead)} of ${compactCount(record.expectedRead)} expected` +
+      ` \u00b7 re-wrote ${compactCount(record.rewroteTokens)}${pct}`
+    : `cache broke \u00b7 re-wrote ${compactCount(record.rewroteTokens)} of ${compactCount(prompt)} prompt` +
       `${prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}%)` : ""}` +
       `${record.costUsd !== undefined ? ` \u00b7 ${formatUsd(record.costUsd)}` : ""}`;
   return `${what} \u00b7 cause: ${record.classification.cause?.detail ?? "unknown"}`;
@@ -707,26 +700,30 @@ export function renderMissLine(record: CallRecord): string {
 // A predicted break that resolved into a hit — good news, and a small lesson about
 // shared-prefix warmth (another session with the same harness prefix kept it alive).
 export function renderHeldLine(record: CallRecord): string {
-  return `cache held \u00b7 read ${formatTokensK(record.usage.cacheRead)} of ${formatTokensK(record.expectedRead)} expected` +
+  return `cache held \u00b7 read ${compactCount(record.usage.cacheRead)} of ${compactCount(record.expectedRead)} expected` +
     " \u00b7 prefix stayed warm";
 }
 
+// The family status scale (design language §1): ○ cold · ● hit · ◑ partial · ◌ miss.
 const EVENT_GLYPHS: Record<CallClassification["kind"], string> = {
-  cold: "\u25cb", // ○
-  hit: "\u25cf", // ●
-  partial: "\u25d1", // ◑
-  miss: "\u25cc", // ◌
+  cold: SCALE.cold,
+  hit: SCALE.hit,
+  partial: SCALE.partial,
+  miss: SCALE.miss,
 };
 
 export function renderLedger(
   records: CallRecord[],
-  options: { providerLabel?: string; window?: CacheWindow; modelLabel?: string } = {},
+  options: { providerLabel?: string; window?: CacheWindow; modelLabel?: string; theme?: Theme } = {},
 ): string[] {
-  const profile: string[] = [];
+  // The family panel-header form (design language §5): [Cachemire] brand line, with the
+  // descriptive title and provider profile demoted to the dim hint. The appended chat
+  // line carries its own spacer, so panelHeader's leading blank is dropped.
+  const profile: string[] = ["cache & loop ledger"];
   if (options.providerLabel) profile.push(options.providerLabel);
   profile.push(windowLabel(options.window ?? UNKNOWN_WINDOW));
   if (options.modelLabel) profile.push(options.modelLabel);
-  const lines: string[] = [`Cachemire \u2014 cache & loop ledger   ${profile.join(" \u00b7 ")}`];
+  const lines: string[] = panelHeader(options.theme, "Cachemire", { hint: profile.join(SEP) }).slice(1);
   if (records.length === 0) {
     lines.push("  no model calls yet");
     return lines;
@@ -744,8 +741,8 @@ export function renderLedger(
         : `${record.classification.kind} \u2014 ${record.classification.cause?.detail ?? "unknown"}`;
     lines.push(
       `  ${col(String(record.index), 4)} ${col(record.gapMs !== undefined ? formatDuration(record.gapMs) : "\u2014", 7)}` +
-      ` ${col(formatTokensK(usage.input), 8)} ${col(formatTokensK(usage.cacheRead), 8)}` +
-      ` ${col(formatTokensK(usage.cacheWrite), 8)} ${col(formatTokensK(usage.output), 7)}` +
+      ` ${col(compactCount(usage.input), 8)} ${col(compactCount(usage.cacheRead), 8)}` +
+      ` ${col(compactCount(usage.cacheWrite), 8)} ${col(compactCount(usage.output), 7)}` +
       ` ${col(record.costUsd !== undefined ? formatUsd(record.costUsd) : "\u2014", 7)}` +
       `  ${EVENT_GLYPHS[record.classification.kind]} ${eventText}${record.restored ? " (restored)" : ""}`,
     );
@@ -762,8 +759,8 @@ export function renderLedger(
     { calls: 0, input: 0, read: 0, wrote: 0, out: 0, cost: 0 },
   );
   lines.push(
-    `  totals: ${totals.calls} calls \u00b7 input ${formatTokensK(totals.input)} \u00b7 read ${formatTokensK(totals.read)}` +
-    ` \u00b7 wrote ${formatTokensK(totals.wrote)} \u00b7 out ${formatTokensK(totals.out)} \u00b7 ${formatUsd(totals.cost)}`,
+    `  totals: ${totals.calls} calls \u00b7 input ${compactCount(totals.input)} \u00b7 read ${compactCount(totals.read)}` +
+    ` \u00b7 wrote ${compactCount(totals.wrote)} \u00b7 out ${compactCount(totals.out)} \u00b7 ${formatUsd(totals.cost)}`,
   );
   const savings = sessionSavings(records);
   if (savings && savings.saved > 0.001) {
@@ -932,6 +929,8 @@ interface CachemireState {
   /** In-flight break notice placed at request time; resolved in place when usage arrives. */
   pendingNotice?: Text;
   run?: RunAggregate;
+  /** Theme handle (captured at session_start) — all chat/widget ink flows through ink(). */
+  theme?: Theme;
   ui?: {
     setWidget: (key: string, content: string[] | undefined) => void;
     notify: (message: string, level?: "info" | "warning" | "error") => void;
@@ -964,16 +963,22 @@ function state(): CachemireState {
   return g.__piCachemire;
 }
 
-function toneFor(phase: ClockState["phase"]): string {
+function toneFor(phase: ClockState["phase"]): Tone {
   switch (phase) {
     case "fresh":
     case "warm-unknown":
-      return GREEN;
+      return "success";
     case "closing":
-      return YELLOW;
+      return "warning";
     default: // cold, stale, cold-unknown, idle
-      return MUTED_GREY;
+      return "dim";
   }
+}
+
+// One-line loop-economics facts (design language §§1, 6): ◍ opens the line; the status
+// tone is theme-derived. These are transient signals, so the tone covers the whole line.
+function econLine(tone: Tone, text: string): string {
+  return ink(state().theme, tone, `${GLYPH.econ} ${text}`);
 }
 
 function updateWidget(now = Date.now()): void {
@@ -990,7 +995,7 @@ function updateWidget(now = Date.now()): void {
     oldModelId: s.lastCallModelId,
     thinkingChanged: s.thinkingChanged,
   });
-  const text = clock.phase === "idle" ? "" : `${toneFor(clock.phase)}${GLYPH} ${clock.text}${RESET}`;
+  const text = clock.phase === "idle" ? "" : econLine(toneFor(clock.phase), clock.text);
   if (text === s.lastWidgetText) return;
   s.lastWidgetText = text;
   s.ui.setWidget("pi-cachemire", text === "" ? undefined : [text]);
@@ -1106,6 +1111,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     }
     if (!ctx.hasUI) return;
     s.ui = ctx.ui as unknown as CachemireState["ui"];
+    s.theme = (ctx.ui as { theme?: Theme }).theme;
     captureTui(ctx.ui, "__pi_cachemire_capture", (tui) => {
       s.tui = tui as CachemireState["tui"];
     });
@@ -1157,7 +1163,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
         (prediction.expectedUsd ?? 0) >= s.config.missWarnUsd
       );
       if (material) {
-        const text = `${YELLOW}${GLYPH} ${renderBreakingLine(prediction)}${RESET}`;
+        const text = econLine("warning", renderBreakingLine(prediction));
         if (s.pendingNotice) s.pendingNotice.setText(text); // provider retry: reuse the line
         else s.pendingNotice = appendChatLine(text);
       }
@@ -1295,25 +1301,25 @@ export default function piCachemire(pi: ExtensionAPI): void {
       // Resolve the in-flight notice with actuals — yellow when the break happened, green
       // when the prediction was wrong and the prefix held (shared-prefix warmth).
       resolveNotice(broke
-        ? `${YELLOW}${GLYPH} ${renderMissLine(record)}${RESET}`
-        : `${GREEN}${GLYPH} ${renderHeldLine(record)}${RESET}`);
+        ? econLine("warning", renderMissLine(record))
+        : econLine("success", renderHeldLine(record)));
     } else if (
       s.config.missWarnings && broke &&
       ((record.costUsd ?? 0) >= s.config.missWarnUsd || record.rewroteTokens >= s.config.missWarnTokens)
     ) {
       // Unpredicted break (e.g. provider-side eviction): append at resolution time.
-      appendChatLine(`${YELLOW}${GLYPH} ${renderMissLine(record)}${RESET}`);
+      appendChatLine(econLine("warning", renderMissLine(record)));
     }
     updateWidget(now);
   });
 
   pi.on("agent_end", async () => {
     // A notice whose call never produced usage (abort/error) must not dangle as "breaking".
-    resolveNotice(`${MUTED_GREY}${GLYPH} cache \u00b7 send ended without usage (aborted?) \u00b7 outcome unknown${RESET}`);
+    resolveNotice(econLine("dim", "cache \u00b7 send ended without usage (aborted?) \u00b7 outcome unknown"));
     const run = s.run;
     s.run = undefined;
     if (!run || !s.config.turnSummary || run.calls < s.config.turnSummaryMinCalls) return;
-    appendChatLine(`${MUTED_GREY}${GLYPH} ${renderRunSummary(run, Date.now())}${RESET}`);
+    appendChatLine(econLine("dim", renderRunSummary(run, Date.now())));
   });
 
   pi.registerCommand("cache", {
@@ -1324,8 +1330,9 @@ export default function piCachemire(pi: ExtensionAPI): void {
         providerLabel: s.providerLabel,
         window: s.window,
         modelLabel: s.modelLabel,
+        theme: s.theme,
       });
-      appendChatLine(`${MUTED_GREY}${GLYPH} ${lines[0]}${RESET}\n${lines.slice(1).join("\n")}`);
+      appendChatLine(lines.join("\n"));
     },
   });
 }
@@ -1352,7 +1359,7 @@ export const internals = {
   uncachedCostUsd,
   rewriteCostUsd,
   sessionSavings,
-  formatTokensK,
+  compactCount,
   formatUsd,
   formatDuration,
   childAnchorKey,

--- a/tests/cachemire/economics-and-render.test.ts
+++ b/tests/cachemire/economics-and-render.test.ts
@@ -7,7 +7,7 @@ import type { CallRecord } from "../../extensions/pi-cachemire/index.ts";
 
 const {
   uncachedCostUsd, rewriteCostUsd, sessionSavings,
-  formatTokensK, formatUsd, formatDuration,
+  compactCount, formatUsd, formatDuration,
   cacheClock, renderRunSummary, renderMissLine, renderLedger, restoreFromMessages,
   inferAnthropicTtlMs, predictBreak, renderBreakingLine, renderHeldLine,
   windowForProvider, windowLabel, windowExpiry, OPENAI_WINDOW, thinkingLevelsDiffer, wireThinkingEffort,
@@ -42,8 +42,8 @@ test("session savings aggregate only over priced calls", () => {
 });
 
 test("formatting primitives", () => {
-  assert.equal(formatTokensK(940_100), "940.1k");
-  assert.equal(formatTokensK(312), "0.3k"); // one unit everywhere — design language §4
+  assert.equal(compactCount(940_100), "940.1k");
+  assert.equal(compactCount(312), "0.3k"); // one unit everywhere — design language §4
   assert.equal(formatUsd(0.523), "$0.52");
   assert.equal(formatUsd(0.0523), "$0.052");
   assert.equal(formatDuration(41_000), "41s");
@@ -293,13 +293,16 @@ test("ledger view: rows, totals, and the savings line", () => {
     },
   ];
   const lines = renderLedger(records, { providerLabel: "anthropic", window: CONTRACT_5M, modelLabel: "anthropic/claude-opus-4-8" });
-  assert.match(lines[0]!, /Cachemire — cache & loop ledger\s+anthropic · 5m TTL · anthropic\/claude-opus-4-8/);
-  assert.match(lines[2]!, /^\s+1\s+—\s+12\.1k\s+0\.0k\s+138\.2k\s+0\.4k\s+\$0\.55\s+○ cold start$/);
-  assert.match(lines[3]!, /14s.*150\.3k.*● hit$/);
-  assert.match(lines[4]!, /totals: 2 calls · input 13\.3k · read 150\.3k · wrote 140\.0k · out 1\.5k · \$0\.59/);
-  assert.match(lines[5]!, /caching saved ~\$2\.37 vs uncached \$2\.96 \(−80%\) · API-priced; notional on subscription/);
+  // Panel-header form (design language §5): [Cachemire] brand, then the dim hint line
+  // carrying the descriptive title and provider profile.
+  assert.match(lines[0]!, /\[Cachemire\]/);
+  assert.match(lines[1]!, /cache & loop ledger · anthropic · 5m TTL · anthropic\/claude-opus-4-8/);
+  assert.match(lines[3]!, /^\s+1\s+—\s+12\.1k\s+0\.0k\s+138\.2k\s+0\.4k\s+\$0\.55\s+○ cold start$/);
+  assert.match(lines[4]!, /14s.*150\.3k.*● hit$/);
+  assert.match(lines[5]!, /totals: 2 calls · input 13\.3k · read 150\.3k · wrote 140\.0k · out 1\.5k · \$0\.59/);
+  assert.match(lines[6]!, /caching saved ~\$2\.37 vs uncached \$2\.96 \(−80%\) · API-priced; notional on subscription/);
 
-  assert.match(renderLedger([], {})[1]!, /no model calls yet/);
+  assert.match(renderLedger([], {})[2]!, /no model calls yet/);
 });
 
 test("ledger restore from a continued session's assistant messages", () => {

--- a/tests/cachemire/goldens.test.ts
+++ b/tests/cachemire/goldens.test.ts
@@ -1,0 +1,77 @@
+// Visual regression net for cachemire's user-facing strings (design language §9/cachemire):
+// the /cache ledger panel (header, status-scale rows, totals, savings) and every one-line
+// ◍ surface — clock states, break notices, resolutions, and the turn summary. Colour is
+// not under test (see docs/testing.md); wording, glyphs, alignment, and fact order are.
+// Regenerate with UPDATE_GOLDENS=1 npm test and review the diff like code.
+import { test } from "node:test";
+
+import { internals } from "../../extensions/pi-cachemire/index.ts";
+import type { CallRecord } from "../../extensions/pi-cachemire/index.ts";
+import { stripAnsi } from "../../extensions/_lib/ansi.ts";
+import { expectGolden } from "../helpers.ts";
+
+const {
+  renderLedger, renderRunSummary, renderMissLine, renderHeldLine, renderBreakingLine, cacheClock,
+} = internals;
+
+const CONTRACT_5M = { kind: "contract", ttlMs: 5 * 60_000, source: "observed" } as const;
+const MIN = 60_000;
+
+// A realistic four-call session: cold start, warm hit, partial (stale replica), TTL miss.
+const RECORDS: CallRecord[] = [
+  {
+    index: 1, at: 0, usage: { input: 12_100, output: 400, cacheRead: 0, cacheWrite: 138_200 },
+    expectedRead: 0, classification: { kind: "cold", cause: { kind: "cold", detail: "cold start" } },
+    rewroteTokens: 138_200, costUsd: 0.55, uncachedUsd: 0.58,
+  },
+  {
+    index: 2, at: 14_000, gapMs: 14_000,
+    usage: { input: 1_200, output: 1_100, cacheRead: 150_300, cacheWrite: 1_800 },
+    expectedRead: 150_300, classification: { kind: "hit" },
+    rewroteTokens: 1_800, costUsd: 0.04, uncachedUsd: 2.38, restored: true,
+  },
+  {
+    index: 3, at: 2 * MIN, gapMs: 106_000,
+    usage: { input: 200, output: 900, cacheRead: 90_000, cacheWrite: 62_100 },
+    expectedRead: 152_100, classification: { kind: "partial", cause: { kind: "replica", detail: "read 59% of expected — stale replica or partial expiry" } },
+    rewroteTokens: 62_100, costUsd: 1.21, uncachedUsd: 2.41,
+  },
+  {
+    index: 4, at: 9 * MIN, gapMs: 7 * MIN,
+    usage: { input: 200, output: 1_400, cacheRead: 0, cacheWrite: 153_000 },
+    expectedRead: 153_200, classification: { kind: "miss", cause: { kind: "ttl", detail: "idle 7m00s > 5m TTL" } },
+    rewroteTokens: 153_000, costUsd: 2.97, uncachedUsd: 2.40,
+  },
+];
+
+test("cachemire ledger and one-line surfaces golden", () => {
+  const clock = (input: Parameters<typeof cacheClock>[0]) => {
+    const state = cacheClock(input);
+    return `[${state.phase}] \u25cd ${state.text}`;
+  };
+  const base = { lastRequestAt: 0, window: CONTRACT_5M, cachedTokens: 150_300, rewriteUsd: 2.82 };
+
+  const lines = [
+    "=== /cache ledger ===",
+    ...renderLedger(RECORDS, { providerLabel: "anthropic", window: CONTRACT_5M, modelLabel: "anthropic/claude-opus-4-8" }),
+    "",
+    "=== clock states (widget) ===",
+    clock({ now: 1 * MIN, ...base }),
+    clock({ now: 4.5 * MIN, ...base }),
+    clock({ now: 6 * MIN, ...base }),
+    clock({ now: 1 * MIN, ...base, compacted: true }),
+    clock({ now: 1 * MIN, ...base, thinkingChanged: true }),
+    clock({ now: 1 * MIN, ...base, modelSwitched: true, oldModelId: "claude-opus-4-8" }),
+    clock({ now: 70 * MIN, lastRequestAt: 0, window: { kind: "band", softMs: 5 * MIN, hardMs: 60 * MIN }, cachedTokens: 64_300, rewriteUsd: 0.12 }),
+    "",
+    "=== notices (chat lines) ===",
+    `\u25cd ${renderBreakingLine({ cause: { kind: "ttl", detail: "idle 7m00s > 5m TTL" }, expectedRewriteTokens: 150_300, expectedUsd: 2.82 })}`,
+    `\u25cd ${renderBreakingLine({ cause: { kind: "compaction", detail: "history compacted" } })}`,
+    `\u25cd ${renderMissLine(RECORDS[3]!)}`,
+    `\u25cd ${renderMissLine(RECORDS[2]!)}`,
+    `\u25cd ${renderHeldLine(RECORDS[1]!)}`,
+    `\u25cd ${renderRunSummary({ startedAt: 0, calls: 3, input: 2_400, cacheRead: 450_900, cacheWrite: 3_600, output: 1_200, costUsd: 0.18 }, 4 * MIN + 30_000)}`,
+  ];
+
+  expectGolden("cachemire-lines.txt", `${lines.map((line) => stripAnsi(line)).join("\n")}\n`);
+});

--- a/tests/fixtures/goldens/cachemire-lines.txt
+++ b/tests/fixtures/goldens/cachemire-lines.txt
@@ -1,0 +1,27 @@
+=== /cache ledger ===
+[Cachemire]
+  cache & loop ledger · anthropic · 5m TTL · anthropic/claude-opus-4-8
+  call     gap    input     read    wrote     out    cost  event
+     1       —    12.1k     0.0k   138.2k    0.4k   $0.55  ○ cold start
+     2     14s     1.2k   150.3k     1.8k    1.1k  $0.040  ● hit (restored)
+     3   1m46s     0.2k    90.0k    62.1k    0.9k   $1.21  ◑ partial — read 59% of expected — stale replica or partial expiry
+     4      7m     0.2k     0.0k   153.0k    1.4k   $2.97  ◌ miss — idle 7m00s > 5m TTL
+  totals: 4 calls · input 13.7k · read 240.3k · wrote 355.1k · out 3.8k · $4.77
+  caching saved ~$3.00 vs uncached $7.77 (−39%) · API-priced; notional on subscription
+
+=== clock states (widget) ===
+[fresh] ◍ cache 4m
+[closing] ◍ cache 30s
+[cold] ◍ cache cold · next send re-writes ~150.3k (~$2.82)
+[stale] ◍ cache stale · history compacted · next send re-writes the new prefix
+[stale] ◍ cache stale · thinking level changed · next send re-writes the prompt
+[cold] ◍ cache cold · model switched · next send re-writes the full prompt (~150.3k claude-opus-4-8 tokens)
+[cold] ◍ cache cold (idle 1h10m > 1h cap) · next send re-sends ~64.3k uncached (~$0.12)
+
+=== notices (chat lines) ===
+◍ cache breaking · re-writing ~150.3k (~$2.82) · cause: idle 7m00s > 5m TTL
+◍ cache breaking · re-writing the new prefix · cause: history compacted
+◍ cache broke · re-wrote 153.0k of 153.2k prompt (100%) · $2.97 · cause: idle 7m00s > 5m TTL
+◍ cache partial · read 90.0k of 152.1k expected · re-wrote 62.1k (41% of prompt) · cause: read 59% of expected — stale replica or partial expiry
+◍ cache held · read 150.3k of 150.3k expected · prefix stayed warm
+◍ turn: 3 calls · 4m30s · read 450.9k (99.5% cached) · wrote 3.6k · out 1.2k · $0.18


### PR DESCRIPTION
Pass 4 of the design-language rollout (`docs/design-language.md` §9, cachemire) — the last extension pass. Closes out the family conformance work started in #18/#19/#21.

## What changed

**Panel header.** `/cache` now opens with the family panel form:

```
[Cachemire]
  cache & loop ledger · anthropic · 5m TTL · anthropic/claude-opus-4-8
  call     gap    input     read    wrote     out    cost  event
     1       —    12.1k     0.0k   138.2k    0.4k   $0.55  ○ cold start
     2     14s     1.2k   150.3k     1.8k    1.1k  $0.040  ● hit
  ...
```

`[Cachemire]` renders in the theme accent; the old descriptive title and provider profile move to the dim hint line (resolved naming question §11.1).

**Theme-derived ink.** The raw `RESET`/`GREEN`/`YELLOW`/`MUTED_GREY` constants are gone; clock, notices, and turn summaries flow through `_lib/style.ts` `ink()` with the Theme handle captured at `session_start` (raw ANSI remains only as ink()'s own pre-theme fallback, per §3).

**Family vocabulary.** `◍` and the `○ ● ◑ ◌` status scale now come from `style.GLYPH` / `style.SCALE`; run-summary facts join via the shared `SEP`. Behaviour unchanged.

**Number grammar.** `formatTokensK` is deleted; every call site uses the shared fixed-k `compactCount` (§4). The internals surface re-exports `compactCount` so the delegation test keeps its hook.

## Tests

- New golden net per §10: `tests/cachemire/goldens.test.ts` → `cachemire-lines.txt` pins the ledger (cold/hit/partial/miss + totals + savings) and every one-line `◍` surface — seven clock states, break notices, resolutions, and the turn summary. Wording, glyphs, and fact order under test; colour excluded as everywhere.
- Ledger assertions updated for the panel-header line shift.
- `npm run typecheck` clean · 133/133 unit tests · startup smoke green against installed pi (including the `[Cachemire]` ledger surviving the Ctrl+T chat rebuild).
