### PR TITLE
traceline: reclaim leading bash preamble width (drop set, fold repeated context)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.5.19 — 2026-07-05
+
+`pi-traceline` reclaims the width that leading shell preambles used to spend.
+Dimming a `set -euo pipefail ↵ cd <dir> ↵` preamble was only half the job: dim
+ink still consumes the shared truncation budget (§9.8), so the real command was
+middle-truncated behind boilerplate that carries no signal. Measured on a
+script-heavy session, 82% of bash rows opened with a preamble eating a median of
+61 columns (two-thirds of the row); the old `cd <dir> && ` fold fired on 1 of 49
+rows because it missed `set`-first, `↵`-separated forms. Design language §9.4.
+
+- A bash row's *leading preamble run* — `set -…` hygiene, `cd <dir>`, and bare
+  `VAR=…`/`export` assignments, across `&&`, `;` and `↵` breaks — is now
+  reclaimed, not just dimmed. A leading `set -…` run drops outright the way the
+  `(timeout Ns)` suffix does; the remaining `cd`/assignment context folds to a
+  dim `⋯` when it repeats the previous bash row's, whatever separator either row
+  used to write it.
+- The `⋯` now absorbs the whole run and its trailing separator (`⋯ npm test`,
+  not `⋯ && npm test`); it still never points across visible prose, and never
+  lands on a row with no real command after it (that row keeps its context, so no
+  row goes dark). A distinct context prints once, on its first appearance.
+- The narrow `cd <dir> && ` detector (`CD_PREAMBLE`/`repeatsPreviousCdPreamble`/
+  `elideCdPreamble`) is replaced by a quote/substitution-aware segment splitter
+  (`bashPreambleRun`/`foldBashPreamble`). Validated across the 51k-invocation
+  bash corpus: zero exceptions, and the crown census is byte-identical (the crown
+  grammar is untouched; 2.38 crowns/row holds). Goldens regenerated to gain a
+  `set`-drop + newline-preamble-fold scene mirroring the reported case.
+
 ## 0.5.18 — 2026-07-04
 
 Click-to-expand is removed from `pi-traceline`. It shipped behind careful

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -295,9 +295,23 @@ are validated against a corpus of 51k real invocations
   first operative head (plumbing before preamble), so no row goes dark.
   Classification reads through parentheses, so a subshell edge cannot smuggle
   glue past the vocabulary
-- a bash row whose `cd <dir> && ` preamble repeats the previous bash row's
-  elides it to a dim `⋯`, which neither crowns nor consumes. The elision is
-  block-scoped: a `⋯` never points across visible prose
+- dim is not enough: a demoted preamble still spends width, and the shared
+  truncation budget (§9.8) then eats the real command behind boilerplate that
+  carries no signal (`set -euo pipefail ↵ cd <dir> ↵` alone runs two-thirds of a
+  row). So a row's *leading preamble run* — the opening sequence of situating
+  segments (`set -…` hygiene, `cd <dir>`, and bare `VAR=…`/`export`
+  assignments) across `&&`, `;` and `↵` breaks — is reclaimed, not just dimmed:
+  - a leading `set -…` hygiene run drops outright, the way the `(timeout Ns)`
+    suffix does (§9.3): errexit/pipefail/nounset never discriminate one row from
+    another, and the status bullet already carries the outcome. The drop is
+    scoped to the *leading* run, so an interior `set` stays
+  - the remaining situating context (`cd`, assignments) folds to a dim `⋯` when
+    it repeats the previous bash row's context, whatever separator either row was
+    written with. The `⋯` stands in for the whole run and its trailing separator
+    (`⋯ npm test`, never `⋯ && npm test`), neither crowns nor consumes. It is
+    block-scoped: a `⋯` never points across visible prose, and never lands on a
+    row with no real command after it — that row keeps its context, so no row
+    goes dark. A distinct context prints once, on its first appearance
 
 ### 9.5 Path rows
 

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -71,11 +71,11 @@ A bash row anchors on a bold `$`, then bolds the head word of every command that
 
 The bold is rationed to commands that carry signal (measured over a 51k-invocation corpus; see [`scripts/dev/bash-corpus/`](../../scripts/dev/bash-corpus/)):
 
-- `cd … &&` and `set -…` preambles, and `echo`/`true`/`false`/`printf`/`exit` plumbing (`|| true`, `&& echo done`), stay dim whenever a real command is present; a row that is *nothing but* preamble or plumbing keeps its first head, so `$ cd /tmp` never goes dark
+- `cd … &&` preambles and `echo`/`true`/`false`/`printf`/`exit` plumbing (`|| true`, `&& echo done`) stay dim whenever a real command is present (a leading `set -…` hygiene run drops outright, reclaiming its width; see below); a row that is *nothing but* preamble or plumbing keeps its first head, so `$ cd /tmp` never goes dark
 - `&&`, `||`, `;` and flattened line breaks start new commands whose heads bold; pipes and redirects continue one (`| head -240` is a filter and stays dim)
 - sequencers inside quoted scripts are data (`python3 -c '…'` bolds `python3` once and nothing inside the string), and heredoc bodies stay inert
 
-Multiline commands (heredocs, inline scripts, chained pipelines) flatten into the one trace line with a dim `↵` marking each original break, and the near-constant `(timeout Ns)` suffix is dropped; the full invocation is one `Ctrl+T` away.
+Multiline commands (heredocs, inline scripts, chained pipelines) flatten into the one trace line with a dim `↵` marking each original break. Two kinds of near-constant boilerplate are dropped so the real command keeps the width: the `(timeout Ns)` suffix, and a leading `set -…` hygiene run (`set -euo pipefail`, `set -e`) that never discriminates one row from another. The full invocation is one `Ctrl+T` away.
 
 ## Repetition folds instead of re-printing
 
@@ -83,11 +83,11 @@ The informative diff between adjacent rows is often small while a shared prefix 
 
 ```
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5  1.4k ch
-  ▏ › $ ⋯ && npm run typecheck                                        14.2k ch
+  ▏ › $ ⋯ npm run typecheck                                           14.2k ch
   ▏ › read ~/projects/pine-of…dex.ts:1-200,201-400,401-600  3 calls · 51.1k ch
 ```
 
-- **Repeated `cd <dir> && ` preambles** render as a dim `⋯` when they repeat the previous bash row's (pi's bash tool is stateless per call, so agents re-`cd` on every call). The first occurrence keeps the full path, and a `⋯` never points across visible prose.
+- **Repeated situating preambles** collapse to a dim `⋯`. A bash row's *leading preamble run* is the situating throat-clearing at its head: `cd <dir>`, bare `VAR=…`/`export` assignments, and `set -…` hygiene, across `&&`, `;` or `↵` breaks (pi's bash tool is stateless per call, so agents re-`cd` on every call). The `set -…` part drops outright, and the remaining `cd`/assignment context folds to a `⋯` when it repeats the previous bash row's, whatever separator either row was written with. The `⋯` absorbs the whole run and its separator (`⋯ npm test`, not `⋯ && npm test`), a distinct context prints once, and a `⋯` never points across visible prose.
 - **Paginated reads** of one file fold into a single row with the combined ranges, call count, and total size. Anything visible between the reads breaks the fold; `Ctrl+T`'s native view restores the individual rows.
 - **Collapsed thinking previews** render as `Thinking: <first reasoning line> ... (N lines)`, with adjacent label runs coalesced, and each tool row sits tight under the preview that motivated it, so each thought→action couplet reads as one unit.
 

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -1275,8 +1275,7 @@ function invocationInk(comp: any): string {
   if (toolLabel(comp?.toolName) === "bash") {
     const plain = bashInvocationText(comp);
     if (plain === undefined) return inkedFallbackLine(comp);
-    const tilded = tildify(plain);
-    return inkBashRow(comp, repeatsPreviousCdPreamble(comp) ? elideCdPreamble(tilded) : tilded);
+    return inkBashRow(comp, foldBashPreamble(comp, tildify(plain)));
   }
   const native = nativeInvocationLine(comp);
   const base = (native && pathEmphasisLine(comp, native)) ?? native;
@@ -1316,20 +1315,138 @@ function oneLine(comp: any, width: number): string {
   );
 }
 
-// --- repetition folding (issue #14, design language §9.9) -------------------
+// --- repetition folding + preamble reclaim (issue #14, design language §9.4/§9.9) ---
 
-// pi's bash tool is stateless per call, so agents working outside the session cwd re-`cd`
-// on every call — measured at 90% of bash rows in a live session. When a row's
-// `cd <dir> && ` preamble repeats the previous bash row's, the repeated head carries no
-// information and its ~half-row width starves middle truncation of the part that
-// *differs*; render it as a dim `⋯` instead.
-const CD_PREAMBLE = /^cd\s+("[^"]*"|'[^']*'|\S+)\s*&&\s/;
+// A demoted preamble still spends width: dim ink alone leaves `set -euo pipefail ↵ cd
+// <dir> ↵` eating two-thirds of a row, and the shared truncation budget (§9.8) then
+// cuts the real command behind it. So a bash row's *leading preamble run* — the opening
+// sequence of situating segments (`set -…` hygiene, `cd <dir>`, bare `VAR=…`/`export`
+// assignments) across `&&`, `;` and `↵` breaks — is reclaimed, not just dimmed: the
+// `set -…` hygiene drops like the `(timeout Ns)` suffix, and the `cd`/assignment context
+// folds to a dim `⋯` when it repeats the previous bash row's (§9.4).
 
-function cdPreambleDir(comp: any): string | undefined {
-  if (toolLabel(comp?.toolName) !== "bash") return undefined;
-  const command = comp?.args?.command;
-  if (typeof command !== "string") return undefined;
-  return CD_PREAMBLE.exec(command)?.[1];
+// Top-level segments of a flattened bash body, split on `&&`/`||`/`;`/`↵` outside
+// quotes, command substitutions and backticks. Only the leading preamble run is read
+// (the walk stops at the first real command), so heredoc bodies — which live only in
+// real segments — need no handling here.
+function bashTopLevelSegments(body: string): { start: number; text: string }[] {
+  const segs: { start: number; text: string }[] = [];
+  let quote: "'" | '"' | undefined;
+  let paren = 0;
+  let backtick = false;
+  let segStart = 0;
+  const push = (end: number) => {
+    const raw = body.slice(segStart, end);
+    const lead = raw.length - raw.replace(/^\s+/, "").length;
+    const text = raw.trim();
+    if (text.length > 0) segs.push({ start: segStart + lead, text });
+  };
+  let i = 0;
+  while (i < body.length) {
+    const ch = body[i]!;
+    if (quote === "'") {
+      if (ch === "'") quote = undefined;
+      i++;
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === "\\") { i += 2; continue; }
+      if (ch === '"') quote = undefined;
+      i++;
+      continue;
+    }
+    if (backtick) {
+      if (ch === "`") backtick = false;
+      i++;
+      continue;
+    }
+    if (ch === "'") { quote = "'"; i++; continue; }
+    if (ch === '"') { quote = '"'; i++; continue; }
+    if (ch === "`") { backtick = true; i++; continue; }
+    if (ch === "\\") { i += 2; continue; }
+    if (ch === "(") { paren++; i++; continue; }
+    if (ch === ")") { if (paren > 0) paren--; i++; continue; }
+    if (paren === 0) {
+      if (body.startsWith("&&", i) || body.startsWith("||", i)) { push(i); i += 2; segStart = i; continue; }
+      if (ch === ";" || ch === LINE_BREAK_MARK) { push(i); i += 1; segStart = i; continue; }
+    }
+    i++;
+  }
+  push(body.length);
+  return segs;
+}
+
+// One env-assignment-only segment (`WORK=$(cat x)`, `A=1 B=2`) is setup, not a command,
+// so it situates; `FOO=bar cmd` is the command `cmd` and does not. Consumes each
+// `VAR=value` token quote/substitution-aware, then checks nothing but assignments remain.
+function isEnvAssignmentOnly(text: string): boolean {
+  let i = 0;
+  while (i < text.length) {
+    while (i < text.length && /\s/.test(text[i]!)) i++;
+    if (i >= text.length) return true;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*=/.test(text.slice(i))) return false;
+    let quote: "'" | '"' | undefined;
+    let paren = 0;
+    let backtick = false;
+    while (i < text.length) {
+      const ch = text[i]!;
+      if (quote === "'") { if (ch === "'") quote = undefined; i++; continue; }
+      if (quote === '"') { if (ch === "\\") { i += 2; continue; } if (ch === '"') quote = undefined; i++; continue; }
+      if (backtick) { if (ch === "`") backtick = false; i++; continue; }
+      if (ch === "'") { quote = "'"; i++; continue; }
+      if (ch === '"') { quote = '"'; i++; continue; }
+      if (ch === "`") { backtick = true; i++; continue; }
+      if (ch === "\\") { i += 2; continue; }
+      if (ch === "(") { paren++; i++; continue; }
+      if (ch === ")") { if (paren > 0) paren--; i++; continue; }
+      if (paren === 0 && /\s/.test(ch)) break;
+      i++;
+    }
+  }
+  return true;
+}
+
+type BashSegmentClass = "hygiene" | "context" | "real";
+
+// `set -…` is hygiene (drop-always); `cd`, `export …` and bare assignments situate
+// (fold-on-repeat); everything else is the reason the row exists and stops the run.
+function classifyBashSegment(text: string): BashSegmentClass {
+  if (/^set(\s|$)/.test(text)) return "hygiene";
+  if (/^cd(\s|$)/.test(text)) return "context";
+  if (/^export\s+[A-Za-z_]/.test(text)) return "context";
+  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(text)) return isEnvAssignmentOnly(text) ? "context" : "real";
+  return "real";
+}
+
+type BashPreambleRun = {
+  contextText: string; // situating context, joined; "" when the run has none
+  firstRealStart?: number; // body index of the first real command, if any
+  dropStart?: number; // body index just past a leading `set -…` run, when a drop applies
+};
+
+// The leading preamble run of a flattened bash body. contextText compares context
+// across rows (both computed from tildified bodies, so `cd ~/x` matches `cd ~/x`);
+// firstRealStart is where the `⋯` fold would point; dropStart marks where a leading
+// `set -…` run ends. dropStart stays undefined when the whole body is hygiene, so a
+// `set -e`-only row keeps its head and no row goes dark (§9.4).
+function bashPreambleRun(body: string): BashPreambleRun {
+  const contextParts: string[] = [];
+  let firstRealStart: number | undefined;
+  let dropStart: number | undefined;
+  for (const seg of bashTopLevelSegments(body)) {
+    const cls = classifyBashSegment(seg.text);
+    if (cls === "real") {
+      firstRealStart = seg.start;
+      if (dropStart === undefined) dropStart = seg.start;
+      break;
+    }
+    if (cls === "context") {
+      contextParts.push(seg.text);
+      if (dropStart === undefined) dropStart = seg.start;
+    }
+    // a leading hygiene (`set`) segment leaves dropStart pointing just past it
+  }
+  return { contextText: contextParts.join("\n"), firstRealStart, dropStart };
 }
 
 // The previous bash row within the same visual group: reads and other tools interleave
@@ -1349,24 +1466,38 @@ function previousBashRow(comp: any): any | undefined {
   return undefined;
 }
 
-function repeatsPreviousCdPreamble(comp: any): boolean {
-  const dir = cdPreambleDir(comp);
-  if (dir === undefined) return false;
-  return cdPreambleDir(previousBashRow(comp)) === dir;
+// The preamble run of a rendered bash comp, read from the same tildified body the row
+// shows, so context keys compare like-for-like across rows.
+function bashPreambleRunOf(comp: any): BashPreambleRun | undefined {
+  if (!comp || toolLabel(comp?.toolName) !== "bash") return undefined;
+  const plain = bashInvocationText(comp);
+  if (plain === undefined || !plain.startsWith("$ ")) return undefined;
+  return bashPreambleRun(tildify(plain).slice(2));
 }
 
-// Operates on the plain-text invocation (see bashInvocationText); inkBashBody later
-// dims the ⋯ with the rest of the shell apparatus.
-function elideCdPreamble(line: string): string {
+// Reclaim the leading preamble of a `$ …` line (§9.4): fold the situating context to a
+// dim `⋯` when it repeats the previous bash row's, else drop a leading `set -…` run.
+// Operates on plain text (see bashInvocationText); inkBashBody later dims the `⋯` and
+// the surviving `cd`/assignment context with the rest of the shell apparatus.
+function foldBashPreamble(comp: any, line: string): string {
   if (!line.startsWith("$ ")) return line;
-  // Find the separator with the same quote-aware parse used to detect the repeat: a
-  // plain indexOf(" && ") would cut inside a quoted directory (`cd "/tmp/a && b" && …`)
-  // and corrupt the command. The match tail is `\s*&&\s`, so its last `&&` *is* the
-  // separator, after any quoted segment.
-  const preamble = CD_PREAMBLE.exec(line.slice(2));
-  if (!preamble) return line;
-  const ampIndex = 2 + preamble[0].lastIndexOf("&&");
-  return `$ ${PREAMBLE_MARK} ${line.slice(ampIndex)}`;
+  const body = line.slice(2);
+  const run = bashPreambleRun(body);
+  // A: the context folds only when a real command follows it (a `⋯` must point at
+  // something) and it repeats the previous bash row's — the `⋯` absorbs the whole run
+  // and its trailing separator.
+  if (run.firstRealStart !== undefined && run.contextText !== "") {
+    const prev = bashPreambleRunOf(previousBashRow(comp));
+    if (prev && prev.contextText === run.contextText) {
+      return `$ ${PREAMBLE_MARK} ${body.slice(run.firstRealStart)}`;
+    }
+  }
+  // B: otherwise drop a leading `set -…` hygiene run outright (dropStart > 0 means a
+  // set ran ahead of surviving context or a real command).
+  if (run.dropStart !== undefined && run.dropStart > 0) {
+    return `$ ${body.slice(run.dropStart)}`;
+  }
+  return line;
 }
 
 // Consecutive reads paging through one file (read → truncation notice → read with offset)
@@ -1792,9 +1923,11 @@ export const internals = {
   oneLine,
   leadingBlank,
   renderTraceRow,
-  // repetition folding + thinking-label preview/dedupe (issue #14)
-  repeatsPreviousCdPreamble,
-  elideCdPreamble,
+  // repetition folding + preamble reclaim + thinking-label preview/dedupe (issue #14)
+  bashPreambleRun,
+  bashPreambleRunOf,
+  foldBashPreamble,
+  previousBashRow,
   readRun,
   dedupeThinkingLabels,
   // Ctrl+T status-line suppression

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-of-glass",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Observability extensions for the Pi coding agent",
   "license": "MIT",
   "type": "module",

--- a/tests/fixtures/goldens/traceline-rows-120.txt
+++ b/tests/fixtures/goldens/traceline-rows-120.txt
@@ -4,9 +4,14 @@ Let me look at the failing suite.
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5                                          1.4k ch
 
 Thinking: Checking the typecheck before the next command. ... (2 lines)
-  ▏ › $ ⋯ && npm run typecheck                                                                                14.2k ch
+  ▏ › $ ⋯ npm run typecheck                                                                                   14.2k ch
   ▏ › read ~/projects/pine-of-glass/extensions/pi-cachemire/index.ts:1-200,201-400,401-600          3 calls · 51.1k ch
-  ▏ › $ ⋯ && rm -f /tmp/pog-scratch.txt                                                                        0.0k ch
+  ▏ › $ ⋯ rm -f /tmp/pog-scratch.txt                                                                           0.0k ch
+
+Measuring the bash-corpus census before and after the rule change.
+
+  ▏ › $ cd ~/projects/pine-of-glass ↵ uv run scripts/dev/bash-corpus/report.ts --census out/before.json        2.1k ch
+  ▏ › $ ⋯ uv run scripts/dev/bash-corpus/report.ts --census out/after.json                                     2.0k ch
 
 The typecheck output looks wrong — checking the runner script.
 

--- a/tests/fixtures/goldens/traceline-rows-80.txt
+++ b/tests/fixtures/goldens/traceline-rows-80.txt
@@ -4,9 +4,14 @@ Let me look at the failing suite.
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5  1.4k ch
 
 Thinking: Checking the typecheck before the next command. ... (2 lines)
-  ▏ › $ ⋯ && npm run typecheck                                        14.2k ch
+  ▏ › $ ⋯ npm run typecheck                                           14.2k ch
   ▏ › read ~/projects/pine-of…dex.ts:1-200,201-400,401-600  3 calls · 51.1k ch
-  ▏ › $ ⋯ && rm -f /tmp/pog-scratch.txt                                0.0k ch
+  ▏ › $ ⋯ rm -f /tmp/pog-scratch.txt                                   0.0k ch
+
+Measuring the bash-corpus census before and after the rule change.
+
+  ▏ › $ cd ~/projects/pine-of-glas…report.ts --census out/before.json  2.1k ch
+  ▏ › $ ⋯ uv run scripts/dev/bash-…/report.ts --census out/after.json  2.0k ch
 
 The typecheck output looks wrong — checking the runner script.
 

--- a/tests/traceline/goldens.test.ts
+++ b/tests/traceline/goldens.test.ts
@@ -1,6 +1,7 @@
 // Visual regression net for the one-line trace grammar (design language §10):
-// a realistic scripted sequence — repeated cd preambles, a paginated read run, healthy
-// and ballooned outputs, a flattened multiline command — rendered at 80 and 120 columns.
+// a realistic scripted sequence — repeated cd preambles, a dropped set-hygiene run, a
+// newline-preamble context fold, a paginated read run, healthy and ballooned outputs, a
+// flattened multiline command — rendered at 80 and 120 columns.
 // Colour is not under test (see docs/testing.md); structure, alignment, folding, and
 // wording are. Regenerate with UPDATE_GOLDENS=1 npm test and review the diff like code.
 import { test, beforeEach } from "node:test";
@@ -87,6 +88,15 @@ test("one-line trace goldens at 80 and 120 columns", () => {
     read(`${repo}/extensions/pi-cachemire/index.ts`, 201, 200, 18_400),
     read(`${repo}/extensions/pi-cachemire/index.ts`, 401, 200, 14_300),
     bash(`cd ${repo} && rm -f /tmp/pog-scratch.txt`, { chars: 0 }),
+    prose("Measuring the bash-corpus census before and after the rule change."),
+    bash(`set -euo pipefail\ncd ${repo}\nuv run scripts/dev/bash-corpus/report.ts --census out/before.json`, {
+      rendered: ["$ set -euo pipefail", `cd ${repo}`, "uv run scripts/dev/bash-corpus/report.ts --census out/before.json (timeout 120s)"],
+      chars: 2_100,
+    }),
+    bash(`set -euo pipefail\ncd ${repo}\nuv run scripts/dev/bash-corpus/report.ts --census out/after.json`, {
+      rendered: ["$ set -euo pipefail", `cd ${repo}`, "uv run scripts/dev/bash-corpus/report.ts --census out/after.json (timeout 120s)"],
+      chars: 2_050,
+    }),
     prose("The typecheck output looks wrong — checking the runner script."),
     bash("python3 -c '...'", {
       rendered: ["$ python3 -c '", "  import json", "  print(json.dumps(cfg))", "  ' | tail -2 (timeout 70s)"],

--- a/tests/traceline/one-line.test.ts
+++ b/tests/traceline/one-line.test.ts
@@ -38,8 +38,6 @@ const {
   dimUnstyledSpans,
   flattenInvocationLines,
   renderTraceRow,
-  repeatsPreviousCdPreamble,
-  elideCdPreamble,
   readRun,
   dedupeThinkingLabels,
 } = internals;

--- a/tests/traceline/repetition.test.ts
+++ b/tests/traceline/repetition.test.ts
@@ -1,7 +1,8 @@
-// Repetition folding (issue #14): repeated `cd <dir> && ` preambles elide to a dim ⋯,
-// consecutive same-file reads fold into one row, and doubled collapsed Thinking...
-// labels coalesce. Comps are synthetic duck-type stand-ins; the contract suite proves
-// the duck types (and the doubled-label seam itself) against the real installed pi.
+// Repetition folding + preamble reclaim (issue #14, design language §9.4): a leading
+// `set -…` hygiene run drops, the surviving `cd`/assignment context folds to a dim ⋯
+// when it repeats the previous bash row's, consecutive same-file reads fold into one
+// row, and doubled collapsed Thinking... labels coalesce. Comps are synthetic duck-type
+// stand-ins; the contract suite proves the duck types against the real installed pi.
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { homedir } from "node:os";
@@ -12,8 +13,8 @@ const {
   stripAnsi,
   oneLine,
   renderTraceRow,
-  repeatsPreviousCdPreamble,
-  elideCdPreamble,
+  bashPreambleRun,
+  foldBashPreamble,
   readRun,
   dedupeThinkingLabels,
 } = internals;
@@ -22,8 +23,14 @@ const g = globalThis as Record<string, unknown>;
 
 const DIM = "\x1b[90m"; // raw-ANSI fallback for the family dim tone (no theme in tests)
 const FOLD_MARK = "\u22ef";
+const NL = "\u21b5"; // the flattened line-break mark
 
+// pi's bash renderer returns one array element per visual line; traceline flattens them
+// with a dim ↵. A synthetic command with `\n` reproduces that multi-line render, so
+// preamble runs written across real breaks (`set …\ncd …\ncmd`) exercise the flatten.
 function bashComp(command: string, rendered?: string): Record<string, unknown> {
+  const lines = command.split("\n");
+  const renderedLines = rendered !== undefined ? [rendered] : lines.map((l, i) => (i === 0 ? `$ ${l}` : l));
   return {
     toolName: "bash",
     args: { command },
@@ -31,7 +38,7 @@ function bashComp(command: string, rendered?: string): Record<string, unknown> {
     isPartial: false,
     render: () => [],
     setExpanded: () => {},
-    callRendererComponent: { render: () => [rendered ?? `$ ${command}`] },
+    callRendererComponent: { render: () => renderedLines },
   };
 }
 
@@ -70,68 +77,118 @@ beforeEach(() => {
   g.__tracelineGetTheme = undefined;
 });
 
-test("repeated cd preamble elides to a dim ⋯; the first occurrence keeps the full path", () => {
-  const first = bashComp("cd /tmp/pog-demo && npm test");
-  const second = bashComp("cd /tmp/pog-demo && npm run typecheck");
+test("leading set drops on first appearance; repeated context folds to a dim ⋯", () => {
+  const first = bashComp("set -euo pipefail\ncd /tmp/pog-demo\nnpm test");
+  const second = bashComp("set -euo pipefail\ncd /tmp/pog-demo\nnpm run typecheck");
   g.__tracelineChat = { children: [prose, first, second] };
-
-  assert.equal(repeatsPreviousCdPreamble(first), false, "first occurrence is not a repeat");
-  assert.equal(repeatsPreviousCdPreamble(second), true);
 
   const firstVisible = stripAnsi(oneLine(first, 120));
   const secondVisible = stripAnsi(oneLine(second, 120));
+
+  // Lever B: the set -… hygiene drops even on the first row; context prints once.
+  assert.ok(!firstVisible.includes("set -euo pipefail"), `set hygiene drops: ${firstVisible}`);
   assert.ok(firstVisible.includes("cd /tmp/pog-demo"), firstVisible);
-  assert.ok(secondVisible.includes(`$ ${FOLD_MARK} && npm run typecheck`), secondVisible);
-  assert.ok(!secondVisible.includes("cd /tmp"), `repeated preamble must not re-print: ${secondVisible}`);
+  assert.ok(firstVisible.includes("npm test"), firstVisible);
+
+  // Lever A: the repeated context folds to ⋯, absorbing set + cd + both separators.
+  assert.ok(secondVisible.includes(`$ ${FOLD_MARK} npm run typecheck`), secondVisible);
+  assert.ok(!secondVisible.includes("cd /tmp"), `repeated context must not re-print: ${secondVisible}`);
+  assert.ok(!secondVisible.includes("set -"), `folded row carries no set: ${secondVisible}`);
   assert.ok(oneLine(second, 120).includes(`${DIM}${FOLD_MARK}`), "the ⋯ must open a dim run");
 });
 
-test("elision scans past interleaved non-bash tools but never across visible prose", () => {
+test("the ⋯ absorbs its trailing separator, and context folds across separator styles", () => {
+  // Inline `cd … && cmd` first, newline-form second: both establish `cd /tmp/z`.
+  const a = bashComp("cd /tmp/z && ls");
+  const b = bashComp("set -e\ncd /tmp/z\nnpm test");
+  g.__tracelineChat = { children: [a, b] };
+
+  const av = stripAnsi(oneLine(a, 120));
+  const bv = stripAnsi(oneLine(b, 120));
+  assert.ok(av.includes("cd /tmp/z && ls"), `the first context prints in full: ${av}`);
+  assert.ok(bv.includes(`$ ${FOLD_MARK} npm test`), `context folds whatever separator wrote it: ${bv}`);
+  assert.ok(!bv.includes("&&"), `the ⋯ absorbs the separator, no dangling &&: ${bv}`);
+  assert.ok(!bv.includes(NL), `no dangling ↵ after the ⋯: ${bv}`);
+});
+
+test("folding scans past interleaved reads but never across visible prose", () => {
   const a = bashComp("cd /tmp/pog-demo && ls");
   const read = readComp(`${homedir()}/projects/demo/file.ts`, 1, 40);
   const b = bashComp("cd /tmp/pog-demo && cat out.txt");
   const c = bashComp("cd /tmp/pog-demo && rm out.txt");
   g.__tracelineChat = { children: [a, read, b, prose, c] };
 
-  assert.equal(repeatsPreviousCdPreamble(b), true, "a read between bash rows does not break the group");
-  assert.equal(repeatsPreviousCdPreamble(c), false, "visible prose opens a new paragraph — ⋯ must not point across it");
+  assert.ok(stripAnsi(oneLine(b, 120)).includes(`$ ${FOLD_MARK} cat out.txt`), "a read between bash rows keeps the group");
+  const cv = stripAnsi(oneLine(c, 120));
+  assert.ok(cv.includes("cd /tmp/pog-demo"), `visible prose opens a new paragraph — no fold: ${cv}`);
+  assert.ok(!cv.includes(FOLD_MARK), `⋯ must not point across prose: ${cv}`);
+
+  // A collapsed Thinking... line keeps the couplet in-group (it is not prose).
+  const d = bashComp("cd /tmp/one && ls");
+  const e = bashComp("cd /tmp/one && pwd");
+  g.__tracelineChat = { children: [d, collapsedThinking, e] };
+  assert.ok(stripAnsi(oneLine(e, 120)).includes(`$ ${FOLD_MARK} pwd`), "a collapsed Thinking... line does not break the fold");
 });
 
-test("elision requires the same directory, a real `&&` tail, and a thinking line does not break it", () => {
+test("a different directory prints; an all-hygiene row keeps its head", () => {
   const a = bashComp("cd /tmp/one && ls");
   const b = bashComp("cd /tmp/two && ls");
   g.__tracelineChat = { children: [a, b] };
-  assert.equal(repeatsPreviousCdPreamble(b), false, "different directory is information, not repetition");
+  const bv = stripAnsi(oneLine(b, 120));
+  assert.ok(bv.includes("cd /tmp/two"), `a different directory is information, not repetition: ${bv}`);
+  assert.ok(!bv.includes(FOLD_MARK), bv);
 
-  const cdOnlyPrev = bashComp("cd /tmp/one && ls");
-  const cdOnly = bashComp("cd /tmp/one");
-  g.__tracelineChat = { children: [cdOnlyPrev, cdOnly] };
-  assert.equal(repeatsPreviousCdPreamble(cdOnly), false, "a bare cd has no tail to elide to");
-
-  const c = bashComp("cd /tmp/one && ls");
-  const d = bashComp("cd /tmp/one && pwd");
-  g.__tracelineChat = { children: [c, collapsedThinking, d] };
-  assert.equal(repeatsPreviousCdPreamble(d), true, "a collapsed Thinking... line keeps the couplet in-group");
-
-  // Unit edges: lines that are not `$ cd … && …` pass through unchanged.
-  assert.equal(elideCdPreamble("$ ls -la"), "$ ls -la");
-  assert.equal(elideCdPreamble("read ~/x.ts:1-2"), "read ~/x.ts:1-2");
-  assert.equal(elideCdPreamble("$ cd /tmp"), "$ cd /tmp", "a bare cd has no tail");
+  // A row that is nothing but hygiene keeps its head — no row goes dark (§9.4).
+  const setOnly = bashComp("set -e");
+  g.__tracelineChat = { children: [setOnly] };
+  assert.ok(stripAnsi(oneLine(setOnly, 120)).includes("set -e"), "an all-hygiene row keeps its head");
 });
 
-test("elision is quote-aware: an && inside a quoted directory never becomes the cut point", () => {
+test("bashPreambleRun classifies the leading run; foldBashPreamble reclaims it", () => {
+  const bash = { toolName: "bash" };
+
+  // No preamble: the whole body is the command.
+  const plain = bashPreambleRun("uv run x");
+  assert.equal(plain.contextText, "");
+  assert.equal(plain.firstRealStart, 0);
+
+  // set + cd + real: set is hygiene, cd is context, the run ends at the real head.
+  const full = bashPreambleRun(`set -euo pipefail ${NL} cd ~/x ${NL} uv run y`);
+  assert.equal(full.contextText, "cd ~/x");
+  assert.ok(full.firstRealStart! > 0);
+  // Lever B strips just the leading set, keeping the cd context and the command.
+  assert.equal(
+    foldBashPreamble(bash, `$ set -euo pipefail ${NL} cd ~/x ${NL} uv run y`),
+    `$ cd ~/x ${NL} uv run y`,
+  );
+
+  // All hygiene: nothing to point a ⋯ at and nothing safe to drop — the row is kept.
+  const hygiene = bashPreambleRun("set -e");
+  assert.equal(hygiene.contextText, "");
+  assert.equal(hygiene.firstRealStart, undefined);
+  assert.equal(hygiene.dropStart, undefined);
+  assert.equal(foldBashPreamble(bash, "$ set -e"), "$ set -e");
+
+  // A bare assignment is setup (context); an env-prefixed command is the command.
+  assert.equal(bashPreambleRun(`WORK=$(cat /tmp/x) ${NL} magick foo`).contextText, "WORK=$(cat /tmp/x)");
+  assert.equal(bashPreambleRun("FOO=bar cmd").contextText, "");
+
+  // Non-`$ ` lines pass through untouched.
+  assert.equal(foldBashPreamble({}, "read ~/x.ts:1-2"), "read ~/x.ts:1-2");
+});
+
+test("segment splitting is quote-aware: an && inside a quoted directory never splits", () => {
   const quotedDir = '"/tmp/a && b"';
   const a = bashComp(`cd ${quotedDir} && ls`);
   const b = bashComp(`cd ${quotedDir} && npm test`);
   g.__tracelineChat = { children: [a, b] };
-  assert.equal(repeatsPreviousCdPreamble(b), true, "quoted dirs still detect as repeats");
 
   const visible = stripAnsi(oneLine(b, 120));
-  assert.ok(visible.includes(`$ ${FOLD_MARK} && npm test`), visible);
+  assert.ok(visible.includes(`$ ${FOLD_MARK} npm test`), visible);
   assert.ok(!visible.includes('b"'), `the quoted directory must not leak past the cut: ${visible}`);
 
-  // Unit edge: the raw helper cuts after the quoted segment, not inside it.
-  assert.equal(stripAnsi(elideCdPreamble('$ cd "/tmp/a && b" && npm test')), `$ ${FOLD_MARK} && npm test`);
+  // Unit edge: the split keeps the quoted `&&` inside the cd segment.
+  assert.equal(bashPreambleRun('cd "/tmp/a && b" && npm test').contextText, 'cd "/tmp/a && b"');
 });
 
 test("consecutive reads of one file fold into a single row with combined ranges and size", () => {


### PR DESCRIPTION
## What & why

Dimming a `set -euo pipefail ↵ cd <dir> ↵` preamble was only half the job: dim ink still consumes the shared truncation budget (§9.8), so the **real command was middle-truncated behind boilerplate that carries no signal**. On a script-heavy session, most bash rows opened with a preamble eating ~two-thirds of the row, and the old `cd <dir> && ` fold missed the common `set`-first, `↵`-separated forms.

A bash row's **leading preamble run** — `set -…` hygiene, `cd <dir>`, and bare `VAR=…`/`export` assignments, across `&&` / `;` / `↵` breaks — is now **reclaimed, not just dimmed**:

- **Lever B — drop `set`:** a leading `set -…` hygiene run drops outright, the way the `(timeout Ns)` suffix already does. It never discriminates one row from another.
- **Lever A — fold repeated context:** the surviving `cd`/assignment context folds to a dim `⋯` when it repeats the previous bash row's, whatever separator either row was written with. The `⋯` absorbs the whole run **and its separator** (`⋯ npm test`, not `⋯ && npm test`), never points across visible prose, and never lands on a row with no real command after it (so no row goes dark; a distinct context prints once).

### The reported case, through the real render pipeline

```
$ cd ~/projects/pi-setup ↵ uv run ~/.pi/agent/…validate_skill.py skills/github-media-attachments  0.9k ch
$ ⋯ uv run ~/.pi/agent/git/github.com/…validate_skill.py skills/github-media-attachments          0.9k ch
$ ⋯ skills/github-media-attachments/scripts/upload-github-media.py --help | sed -n '1,120p'       0.7k ch
$ ⋯ git push origin main                                                                          0.1k ch
```

The `validate_skill.py skills/github-media-attachments` tail now survives in full instead of hiding behind `set -euo pipefail ↵ cd …`.

## Implementation

Replaces the narrow `CD_PREAMBLE` detector (`repeatsPreviousCdPreamble` / `elideCdPreamble`) with a quote/substitution/backtick-aware segment splitter (`bashPreambleRun` / `foldBashPreamble`) that reads only the leading run, so heredoc bodies need no special handling. Design language §9.4 updated first, then the renderer.

## Validation

- **Crown grammar untouched:** the 51k-invocation bash-corpus census is **byte-identical** before/after (2.38 crowns/row holds).
- **Parser robustness:** replayed across all **51,267 real commands — 0 exceptions**.
- `npm run typecheck` clean; **163/163** unit + golden + contract tests pass.
- Goldens regenerated with a new `set`-drop + newline-preamble-fold scene mirroring the reported case.
- **Real-pi tmux smoke passes** (extension loads and renders, no frame breakage).

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (163/163)
- [x] `npm run test:smoke`
- [x] bash-corpus census diff empty (no crown drift)

Bumps to **v0.5.19**; CHANGELOG + README + design language §9.4 updated.
