### PR TITLE
Add agent coding-standard lint harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,10 @@ language. TypeScript, zero runtime dependencies, tests on `node:test`.
 ```bash
 npm run link-pi         # symlink the installed pi runtime into node_modules (types + contract tests); run first on a fresh clone
 npm run link-extensions # symlink the extensions (as directories) into ~/.pi/agent/extensions
+npm run lint            # deterministic agent coding-standard checks
 npm run typecheck       # tsc against the real installed pi
 npm test                # unit + golden + pi contract tests (zero deps, node:test)
+npm run check           # lint + typecheck + tests
 npm run test:smoke      # launches real pi in tmux with an isolated HOME (local-only)
 ```
 
@@ -34,6 +36,11 @@ npm run test:smoke      # launches real pi in tmux with an isolated HOME (local-
   [`scripts/dev/screenshots/`](./scripts/dev/screenshots/): real pi TUI in an isolated
   tmux/HOME; see its README for the recipe. The `cachemire` scenario makes live model
   calls (costs cents).
+- Agent coding standards live in [`docs/agent-coding-standard.md`](./docs/agent-coding-standard.md)
+  and are enforced by `scripts/dev/agent-lint.mjs`. Boundary uncertainty belongs at
+  Pi, JSON, config, provider-payload, and catch seams only. Do not add generic
+  `isRecord` or `isObject` helpers. Parse or refine at the edge, pass typed values
+  inward, and document real escape hatches with `SAFETY:` comments.
 
 ## Style
 

--- a/docs/agent-coding-standard.md
+++ b/docs/agent-coding-standard.md
@@ -1,0 +1,128 @@
+# Agent coding standard
+
+This repository is maintained by agents as well as humans. The coding standard is
+therefore executable: deterministic checks should catch repeated agent failure modes
+before review. A lint failure is a just-in-time prompt, not just a compiler-style
+error.
+
+Run:
+
+```bash
+npm run lint
+npm run check
+```
+
+`npm run lint` runs `scripts/dev/agent-lint.mjs`, a zero-dependency source lint
+for repo-specific invariants. Existing violations are recorded in
+`scripts/dev/agent-lint-baseline.json` so the rule can prevent regressions while the
+codebase is migrated deliberately. Do not grow the baseline as a way to dodge the
+standard. Fix the code, add a precise `SAFETY:` comment for a real seam, or update a
+reviewed migration plan.
+
+## Boundary typing
+
+`unknown` belongs at true boundaries only:
+
+- Pi internals and TUI component seams
+- JSON config files
+- provider payloads and serialized session data
+- catch values or other external runtime input
+
+At the boundary, parse or refine the value into a domain type. After that, pass typed
+values inward. Core rendering, formatting, and economics logic should not repeatedly
+rediscover object shapes.
+
+Generic record guards are banned:
+
+```ts
+function isRecord(value: unknown): value is Record<string, unknown>;
+function isObject(value: unknown): value is object;
+```
+
+Use domain-named helpers instead:
+
+```ts
+isJsonObject(value)
+parseContextimateConfig(value)
+parseCachemireConfig(value)
+isToolSchemaObject(value)
+isPiComponentLike(value)
+```
+
+The shared generic JSON helpers live in `extensions/_lib/boundary.ts`. They are for
+boundary code and domain parsers, not an excuse to let `unknown` spread through core
+logic.
+
+## JSON and config
+
+Do not cast decoded JSON directly:
+
+```ts
+const config = JSON.parse(text) as ContextimateConfig; // banned
+```
+
+Use parser-driven config reads:
+
+```ts
+const config = readJsonConfig(filePath, parseContextimateConfig);
+```
+
+Config parsers should be permissive at the file boundary and precise at the call site:
+ignore invalid fields, sanitize numbers, and return a typed config object.
+
+## Escape hatches
+
+`any`, broad `Record<string, unknown>` casts, and TypeScript suppressions require a
+nearby `SAFETY:` comment unless a rule has a narrower local proof. Good comments state:
+
+1. why the escape hatch is necessary,
+2. the runtime shape being relied on,
+3. the contract test or source of evidence that pins the assumption.
+
+Example:
+
+```ts
+// SAFETY: Pi tool rows are not exported as a stable type. Contract tests pin the
+// render/setExpanded/toolName duck type used by traceline.
+function renderToolRow(comp: any): string[];
+```
+
+If the value is not a Pi seam, prefer `unknown` plus boundary parsing or a precise type.
+
+## Visual and repository invariants
+
+The lint also protects existing repo rules:
+
+- `_lib` must not grow an `index.ts`, because Pi extension discovery should skip it.
+- Runtime dependencies stay empty unless maintainers explicitly decide otherwise.
+- Raw ANSI colour constants live in the style or ANSI layers, not arbitrary render code.
+- Markdown docs avoid em dashes, except quoted or generated UI output with a local lint
+  exemption.
+- TypeScript files should stay context-sized. Existing oversized files have temporary
+  budgets in the baseline and should be split over time rather than grown.
+
+## Baseline policy
+
+The baseline is a migration ledger. It is allowed because this repo already has large Pi
+seam files and historical markdown style drift. It is not a waiver for new code.
+
+When touching a baselined area:
+
+1. Prefer reducing violations in the changed code.
+2. Do not add generic record guards.
+3. Add `SAFETY:` only for real Pi or runtime boundary seams.
+4. If a file is over its line budget, split by domain before adding unrelated logic.
+5. Regenerate the baseline only after review when current violations were intentionally
+   fixed, moved, or reclassified.
+
+To inspect the migration ledger:
+
+```bash
+npm run lint -- --show-baseline
+```
+
+To regenerate after reviewed fixes:
+
+```bash
+node scripts/dev/agent-lint.mjs --update-baseline
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,8 +44,10 @@ Deliberately **not** tested:
   same file) into an exported `internals` object consumed by tests. Pi imports only the
   default export (`jiti.import(path, { default: true })`), so named exports are
   runtime-inert. No file split until the code itself needs one.
-- **Scripts:** `npm run typecheck`, `npm test` (unit + render + contract),
-  `npm run test:smoke` (tmux startup smoke, local-only).
+- **Scripts:** `npm run lint` (agent coding-standard source checks),
+  `npm run typecheck`, `npm test` (unit + render + contract),
+  `npm run check` (lint + typecheck + tests), and `npm run test:smoke`
+  (tmux startup smoke, local-only).
 
 Layout:
 

--- a/extensions/_lib/boundary.ts
+++ b/extensions/_lib/boundary.ts
@@ -1,0 +1,27 @@
+// Boundary helpers for values that enter pine-of-glass from JSON, Pi internals,
+// provider payloads, or other untyped seams. Keep generic uncertainty here or in
+// domain-named parsers, not in rendering/core logic.
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function jsonObjectOrEmpty(value: unknown): JsonObject {
+  return isJsonObject(value) ? value : {};
+}
+
+export function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function positiveNumberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}

--- a/extensions/_lib/config.ts
+++ b/extensions/_lib/config.ts
@@ -11,13 +11,13 @@ export function expandHomePath(filePath: string): string {
   return filePath;
 }
 
-/** Read and parse a JSON object file; undefined on absence or any error. */
-export function readJsonConfig<T extends object>(filePath: string): T | undefined {
+/** Read JSON config through a domain parser; undefined on absence or any parse error. */
+export function readJsonConfig<T>(filePath: string, parse: (value: unknown) => T): T | undefined {
   try {
     const expanded = expandHomePath(filePath);
     if (!existsSync(expanded)) return undefined;
-    const parsed = JSON.parse(readFileSync(expanded, "utf8"));
-    return parsed && typeof parsed === "object" ? (parsed as T) : undefined;
+    const parsed: unknown = JSON.parse(readFileSync(expanded, "utf8"));
+    return parse(parsed);
   } catch {
     return undefined;
   }

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -3,6 +3,7 @@ import { buildSessionContext } from "@earendil-works/pi-coding-agent";
 import { Spacer, Text } from "@earendil-works/pi-tui";
 import { createHash } from "node:crypto";
 import { stripAnsi } from "../_lib/ansi.ts";
+import { booleanValue, isJsonObject, positiveNumberValue } from "../_lib/boundary.ts";
 import { captureTui } from "../_lib/capture.ts";
 import { findChatContainer, type ContainerLike } from "../_lib/chat.ts";
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
@@ -235,15 +236,13 @@ const MISS_RATIO = 0.2;
 // mutated" at the previous breakpoint.
 function stripCacheControl(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripCacheControl);
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-      if (key === "cache_control") continue;
-      out[key] = stripCacheControl(entry);
-    }
-    return out;
+  if (!isJsonObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "cache_control") continue;
+    out[key] = stripCacheControl(entry);
   }
-  return value;
+  return out;
 }
 
 function hashOf(value: unknown): string {
@@ -270,7 +269,7 @@ function findTtlMs(payload: Record<string, unknown>): number | undefined {
 }
 
 function fingerprintPayload(payload: unknown): RequestFingerprint {
-  const body = (payload ?? {}) as Record<string, unknown>;
+  const body = isJsonObject(payload) ? payload : {};
   if (Array.isArray(body.input) || typeof body.instructions === "string") {
     const tools = Array.isArray(body.tools) ? body.tools : [];
     return {
@@ -827,9 +826,27 @@ function restoreFromMessages(messages: Array<Record<string, unknown>>): CallReco
 
 // --- config ----------------------------------------------------------------------------
 
+function parseCachemireConfig(value: unknown): Partial<CachemireConfig> {
+  if (!isJsonObject(value)) return {};
+  const config: Partial<CachemireConfig> = {};
+  const widget = booleanValue(value.widget);
+  const turnSummary = booleanValue(value.turnSummary);
+  const turnSummaryMinCalls = positiveNumberValue(value.turnSummaryMinCalls);
+  const missWarnings = booleanValue(value.missWarnings);
+  const missWarnUsd = positiveNumberValue(value.missWarnUsd);
+  const missWarnTokens = positiveNumberValue(value.missWarnTokens);
+  if (widget !== undefined) config.widget = widget;
+  if (turnSummary !== undefined) config.turnSummary = turnSummary;
+  if (turnSummaryMinCalls !== undefined) config.turnSummaryMinCalls = Math.floor(turnSummaryMinCalls);
+  if (missWarnings !== undefined) config.missWarnings = missWarnings;
+  if (missWarnUsd !== undefined) config.missWarnUsd = missWarnUsd;
+  if (missWarnTokens !== undefined) config.missWarnTokens = Math.floor(missWarnTokens);
+  return config;
+}
+
 function loadConfig(cwd: string): CachemireConfig {
   return configPaths("pi-cachemire", cwd).reduce(
-    (config, filePath) => ({ ...config, ...readJsonConfig<Partial<CachemireConfig>>(filePath) }),
+    (config, filePath) => ({ ...config, ...readJsonConfig(filePath, parseCachemireConfig) }),
     { ...DEFAULT_CONFIG },
   );
 }

--- a/extensions/pi-contextimate/index.ts
+++ b/extensions/pi-contextimate/index.ts
@@ -4,6 +4,7 @@ import { buildSessionContext, convertToLlm, keyText } from "@earendil-works/pi-c
 import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { homedir } from "node:os";
 import { stripAnsi } from "../_lib/ansi.ts";
+import { isJsonObject, positiveNumberValue, stringValue, type JsonValue } from "../_lib/boundary.ts";
 import { findContainerBy, isResourceRow, RESOURCE_HEADER_RE } from "../_lib/chat.ts";
 import { configPaths, expandHomePath, readJsonConfig } from "../_lib/config.ts";
 import { compactCount } from "../_lib/fmt.ts";
@@ -455,6 +456,66 @@ function mergeContextimateConfig(base: ContextimateConfig, next?: ContextimateCo
   };
 }
 
+function parseHeuristicProfile(value: unknown): HeuristicProfile {
+  if (!isJsonObject(value)) return {};
+  const profile: HeuristicProfile = {};
+  const label = stringValue(value.label);
+  const textDenominator = positiveNumberValue(value.textDenominator);
+  const sessionDenominator = positiveNumberValue(value.sessionDenominator);
+  const toolDenominator = positiveNumberValue(value.toolDenominator);
+  const toolNumerator = stringValue(value.toolNumerator);
+  if (label) profile.label = label;
+  if (textDenominator) profile.textDenominator = textDenominator;
+  if (sessionDenominator) profile.sessionDenominator = sessionDenominator;
+  if (toolDenominator) profile.toolDenominator = toolDenominator;
+  if (toolNumerator) profile.toolNumerator = toolNumerator;
+  return profile;
+}
+
+function parseHeuristicRule(value: unknown): HeuristicRule | undefined {
+  if (!isJsonObject(value)) return undefined;
+  const rule: HeuristicRule = parseHeuristicProfile(value);
+  const profile = stringValue(value.profile);
+  if (profile) rule.profile = profile;
+  if (isJsonObject(value.match)) {
+    const match: NonNullable<HeuristicRule["match"]> = {};
+    const provider = stringValue(value.match.provider);
+    const model = stringValue(value.match.model);
+    const id = stringValue(value.match.id);
+    const api = stringValue(value.match.api);
+    if (provider) match.provider = provider;
+    if (model) match.model = model;
+    if (id) match.id = id;
+    if (api) match.api = api;
+    if (Object.keys(match).length > 0) rule.match = match;
+  }
+  return Object.keys(rule).length > 0 ? rule : undefined;
+}
+
+function parseContextimateConfig(value: unknown): ContextimateConfig {
+  if (!isJsonObject(value)) return {};
+  const config: ContextimateConfig = {};
+  if (isJsonObject(value.defaults)) {
+    const defaults: NonNullable<ContextimateConfig["defaults"]> = parseHeuristicProfile(value.defaults);
+    const profile = stringValue(value.defaults.profile);
+    if (profile) defaults.profile = profile;
+    if (Object.keys(defaults).length > 0) config.defaults = defaults;
+  }
+  if (isJsonObject(value.profiles)) {
+    const profiles: Record<string, HeuristicProfile> = {};
+    for (const [name, entry] of Object.entries(value.profiles)) {
+      const profile = parseHeuristicProfile(entry);
+      if (Object.keys(profile).length > 0) profiles[name] = profile;
+    }
+    if (Object.keys(profiles).length > 0) config.profiles = profiles;
+  }
+  if (Array.isArray(value.rules)) {
+    const rules = value.rules.map(parseHeuristicRule).filter((rule): rule is HeuristicRule => !!rule);
+    if (rules.length > 0) config.rules = rules;
+  }
+  return config;
+}
+
 function splitConfigPaths(value: string | undefined): string[] {
   return (value ?? "").split(":").map((entry) => expandHomePath(entry.trim())).filter(Boolean);
 }
@@ -462,7 +523,7 @@ function splitConfigPaths(value: string | undefined): string[] {
 function loadContextimateConfig(cwd: string): ContextimateConfig {
   const paths = [...configPaths("pi-contextimate", cwd), ...splitConfigPaths(process.env.PI_CONTEXTIMATE_CONFIG)];
   return paths.reduce<ContextimateConfig>(
-    (config, filePath) => mergeContextimateConfig(config, readJsonConfig<ContextimateConfig>(filePath)),
+    (config, filePath) => mergeContextimateConfig(config, readJsonConfig(filePath, parseContextimateConfig)),
     {},
   );
 }
@@ -787,50 +848,42 @@ function trimFinalPeriod(text: string): string {
 }
 
 function getSchemaProperties(schema: unknown): Record<string, unknown> {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return {};
-  const properties = (schema as { properties?: unknown }).properties;
-  if (!properties || typeof properties !== "object" || Array.isArray(properties)) return {};
-  return properties as Record<string, unknown>;
+  if (!isJsonObject(schema) || !isJsonObject(schema.properties)) return {};
+  return schema.properties;
 }
 
 function schemaPropertyType(property: unknown): string {
-  if (!property || typeof property !== "object" || Array.isArray(property)) return "object";
-  const typed = property as { type?: unknown; anyOf?: unknown; oneOf?: unknown; allOf?: unknown };
-  if (typeof typed.type === "string") return typed.type;
-  if (Array.isArray(typed.type)) return typed.type.join("|");
-  if (typed.anyOf) return "anyOf";
-  if (typed.oneOf) return "oneOf";
-  if (typed.allOf) return "allOf";
+  if (!isJsonObject(property)) return "object";
+  if (typeof property.type === "string") return property.type;
+  if (Array.isArray(property.type)) return property.type.filter((entry): entry is string => typeof entry === "string").join("|");
+  if (property.anyOf) return "anyOf";
+  if (property.oneOf) return "oneOf";
+  if (property.allOf) return "allOf";
   return "object";
 }
 
 function schemaPropertyDescription(property: unknown): string {
-  if (!property || typeof property !== "object" || Array.isArray(property)) return "";
-  const description = (property as { description?: unknown }).description;
-  return typeof description === "string" ? trimFinalPeriod(description) : "";
+  if (!isJsonObject(property)) return "";
+  return typeof property.description === "string" ? trimFinalPeriod(property.description) : "";
 }
 
-function schemaPropertyEnum(property: unknown): unknown[] {
-  if (!property || typeof property !== "object" || Array.isArray(property)) return [];
-  const enumValues = (property as { enum?: unknown }).enum;
-  return Array.isArray(enumValues) ? enumValues : [];
+function schemaPropertyEnum(property: unknown): JsonValue[] {
+  if (!isJsonObject(property) || !Array.isArray(property.enum)) return [];
+  return property.enum;
 }
 
 function schemaArrayItemProperties(property: unknown): Record<string, unknown> {
-  if (!property || typeof property !== "object" || Array.isArray(property)) return {};
-  const items = (property as { items?: unknown }).items;
-  return getSchemaProperties(items);
+  if (!isJsonObject(property)) return {};
+  return getSchemaProperties(property.items);
 }
 
 function getSchemaRequired(schema: unknown): string[] {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return [];
-  const required = (schema as { required?: unknown }).required;
-  return Array.isArray(required) ? required.filter((entry): entry is string => typeof entry === "string") : [];
+  if (!isJsonObject(schema) || !Array.isArray(schema.required)) return [];
+  return schema.required.filter((entry): entry is string => typeof entry === "string");
 }
 
 function arrayItemsSchema(property: unknown): unknown {
-  if (!property || typeof property !== "object" || Array.isArray(property)) return undefined;
-  return (property as { items?: unknown }).items;
+  return isJsonObject(property) ? property.items : undefined;
 }
 
 function collectToolFields(name: string, property: unknown, depth: number, required: boolean, out: ToolField[], maxDepth = 3): void {

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -11,6 +11,7 @@ import {
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { OSC_SEQUENCE, rawIndexAtVisibleIndex, rawIndexBeforeVisibleIndex, stripAnsi } from "../_lib/ansi.ts";
+import { positiveNumberValue, isJsonObject } from "../_lib/boundary.ts";
 import { captureTui } from "../_lib/capture.ts";
 import { findChatContainer, isAssistantRow, isToolRow } from "../_lib/chat.ts";
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
@@ -265,19 +266,23 @@ function formatCharCount(value: number): string {
 let sizeThresholds: SizeThresholds = SIZE_THRESHOLDS;
 
 type TracelineConfig = {
-  sizeWarningChars?: unknown;
-  sizeErrorChars?: unknown;
+  sizeWarningChars?: number;
+  sizeErrorChars?: number;
 };
 
+function parseTracelineConfig(value: unknown): TracelineConfig {
+  if (!isJsonObject(value)) return {};
+  const sizeWarningChars = positiveNumberValue(value.sizeWarningChars);
+  const sizeErrorChars = positiveNumberValue(value.sizeErrorChars);
+  return {
+    ...(sizeWarningChars !== undefined ? { sizeWarningChars: Math.floor(sizeWarningChars) } : {}),
+    ...(sizeErrorChars !== undefined ? { sizeErrorChars: Math.floor(sizeErrorChars) } : {}),
+  };
+}
+
 function configureSizeThresholds(config: TracelineConfig | undefined): void {
-  const warning =
-    typeof config?.sizeWarningChars === "number" && config.sizeWarningChars > 0
-      ? Math.floor(config.sizeWarningChars)
-      : SIZE_THRESHOLDS.warning;
-  const error =
-    typeof config?.sizeErrorChars === "number" && config.sizeErrorChars > 0
-      ? Math.floor(config.sizeErrorChars)
-      : SIZE_THRESHOLDS.error;
+  const warning = config?.sizeWarningChars ?? SIZE_THRESHOLDS.warning;
+  const error = config?.sizeErrorChars ?? SIZE_THRESHOLDS.error;
   sizeThresholds = { warning, error: Math.max(error, warning) };
 }
 
@@ -1818,7 +1823,7 @@ export default function piTraceline(pi: ExtensionAPI) {
     const config = Object.assign(
       {},
       ...configPaths("pi-traceline", process.cwd()).map(
-        (path) => readJsonConfig<Record<string, unknown>>(path) ?? {},
+        (path) => readJsonConfig(path, parseTracelineConfig) ?? {},
       ),
     );
     configureSizeThresholds(config);

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
   "scripts": {
     "link-pi": "scripts/dev/link-pi-runtime.sh",
     "link-extensions": "scripts/dev/link-extensions.sh",
+    "lint": "node scripts/dev/agent-lint.mjs",
+    "lint:agent": "node scripts/dev/agent-lint.mjs",
     "typecheck": "tsc -p tsconfig.json",
     "test": "node --test 'tests/**/*.test.ts'",
+    "check": "npm run lint && npm run typecheck && npm test",
     "test:smoke": "node tests/smoke/startup-smoke.mjs"
   },
   "pi": {

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -1,0 +1,221 @@
+{
+  "version": 1,
+  "generatedBy": "node scripts/dev/agent-lint.mjs --update-baseline",
+  "knownFindings": {
+    "POG003": {
+      "extensions/pi-contextimate/index.ts": {
+        "__piContextimateChat?: any;": 1,
+        "__piContextimateTui?: any;": 1,
+        "ctx.ui.setWidget(\"__pi_contextimate_capture\", (tui: any) => {": 1,
+        "function insertionIndexAfterResourceList(chat: any): number {": 1,
+        "function removeExistingPrefixBlocks(chat: any): void {": 1
+      },
+      "extensions/pi-traceline/index.ts": {
+        "(b: any) =>": 1,
+        "__tracelineChat?: any;": 1,
+        "__tracelineTui?: any;": 1,
+        "const breaksBlock = (c: any) => !isToolRow(c) && !isEmptyConnector(c);": 1,
+        "const rows: any[] = [];": 1,
+        "const rows: any[] = [comp];": 1,
+        "const t = tui as any;": 1,
+        "function bashInvocationText(comp: any): string | undefined {": 1,
+        "function blockFacts(rows: any[]): BlockFacts {": 1,
+        "function blockFactsOf(comp: any): BlockFacts {": 1,
+        "function blockSizeColumnLive(comp: any): boolean {": 1,
+        "function blockSuffixReserve(rows: any[], facts: BlockFacts, available: number): number {": 1,
+        "function blockToolRows(comp: any): any[] {": 1,
+        "function boringPrefix(comp: any, tildePath: string): string {": 1,
+        "function captureWriteSnapshot(comp: any): void {": 1,
+        "function cdPreambleDir(comp: any): string | undefined {": 1,
+        "function chatChildren(): any[] | undefined {": 1,
+        "function colourCommandPrefix(comp: any, line: string): string {": 1,
+        "function commandPrefixLength(comp: any, line: string): number {": 1,
+        "function componentLocation(comp: any): { sibs: any[]; index: number } | undefined {": 1,
+        "function cwdRelativePath(comp: any, rawPath: string): string {": 1,
+        "function dedupeThinkingLabels(comp: any, lines: string[], width?: number): string[] {": 1,
+        "function diffTextFromComp(comp: any): string | undefined {": 1,
+        "function discriminatorInk(comp: any, text: string): string {": 1,
+        "function fallbackInvocationLine(comp: any): string {": 1,
+        "function foldableReadPath(comp: any): string | undefined {": 1,
+        "function foldedReadLine(rows: any[], width: number): string {": 1,
+        "function foldedReadSuffix(rows: any[], facts: BlockFacts): string {": 1,
+        "function inkBashBody(body: string, comp?: any): string {": 1,
+        "function inkBashRow(comp: any, text: string): string {": 1,
+        "function inkedFallbackLine(comp: any): string {": 1,
+        "function invocationInk(comp: any): string {": 1,
+        "function isCollapsedThinkingRow(c: any): boolean {": 1,
+        "function isEmptyConnector(c: any): boolean {": 1,
+        "function isSpacerRow(comp: any): boolean {": 1,
+        "function isThinkingToggleStatusRow(comp: any): boolean {": 1,
+        "function leadingBlank(comp: any): boolean {": 1,
+        "function lineRange(args: any): string {": 1,
+        "function mutationDiffStats(comp: any): DiffStats | undefined {": 1,
+        "function nativeHiddenThinkingLabel(comp: any): string {": 1,
+        "function nativeInvocationLine(comp: any): string | undefined {": 1,
+        "function oneLine(comp: any, width: number): string {": 1,
+        "function patchAssistantRowPrototype(proto: any): void {": 1,
+        "function patchToolRowPrototype(proto: any): void {": 1,
+        "function patchWriteSnapshotHooks(proto: any): void {": 1,
+        "function pathEmphasisLine(comp: any, nativeColored: string): string | undefined {": 1,
+        "function previousBashRow(comp: any): any | undefined {": 1,
+        "function readPath(comp: any): string | undefined {": 1,
+        "function readRun(comp: any): { rows: any[]; index: number } | undefined {": 1,
+        "function recordCellData(comp: any): RecordCellData[] {": 1,
+        "function recordCells(comp: any): string[] {": 1,
+        "function recordFacts(comp: any): RecordFact[] {": 1,
+        "function recordSuffix(comp: any, available: number): string {": 1,
+        "function renderTraceRow(comp: any, width: number): string[] {": 1,
+        "function repeatsPreviousCdPreamble(comp: any): boolean {": 1,
+        "function resultCharSuffix(comp: any, facts: BlockFacts): string {": 1,
+        "function resultText(comp: any): string {": 1,
+        "function resultTextCharCount(comp: any): number | undefined {": 1,
+        "function statusTone(comp: any): Tone {": 1,
+        "function thinkingPreviewLines(comp: any): string[] {": 1,
+        "function toolFactSuffix(comp: any, available = Number.POSITIVE_INFINITY, facts: BlockFacts = blockFactsOf(comp)): string {": 1,
+        "function toolPathArg(c: any): string | undefined {": 1,
+        "function toolStatus(comp: any): ToolStatus {": 1,
+        "function verbInk(comp: any, verb: string): string {": 1,
+        "function verbTone(comp: any): Tone {": 1,
+        "function writeDiffStats(comp: any): DiffStats | undefined {": 1,
+        "function writeInput(comp: any): WriteInput | undefined {": 1,
+        "function writeSnapshot(comp: any): WriteSnapshot | undefined {": 1,
+        "proto.markExecutionStarted = function (...args: any[]) {": 1,
+        "proto.setArgsComplete = function (...args: any[]) {": 1,
+        "return (ctx.ui as any).theme;": 1,
+        "return content.reduce((sum: number, block: any) => {": 1
+      },
+      "scripts/dev/bash-corpus/report.ts": {
+        "(globalThis as any).__tracelineGetTheme = () => ({": 1
+      },
+      "tests/traceline/one-line.test.ts": {
+        "assert.equal(boringPrefix(p1, tildify(String(p1.args && (p1.args as any).path))), \"~/projects/site/src/\");": 1,
+        "assert.equal(cwdRelativePath(inRepo, String((inRepo.args as any).path)), \"./src/lib/util.ts\");": 1,
+        "const crowns = (body: string) => bashCrownedHeads(body).map((head: any) => body.slice(head.start, head.end));": 1,
+        "const g = globalThis as any;": 3
+      },
+      "tests/traceline/records.test.ts": {
+        "(comp as any).result = { content: [{ type: \"text\", text: \"[main b5e32d0] y\\n\" }], isError: false };": 1
+      }
+    },
+    "POG004": {
+      "extensions/pi-cachemire/index.ts": {
+        "ensureChatClearHook(chat as unknown as Record<string, unknown>);": 1
+      },
+      "tests/cachemire/forensics.test.ts": {
+        "const stripped = stripCacheControl(anthropicPayload()) as Record<string, unknown>;": 1
+      },
+      "tests/contract/pi-internals.test.ts": {
+        "const g = globalThis as Record<string, unknown>;": 1
+      },
+      "tests/traceline/goldens.test.ts": {
+        "const g = globalThis as Record<string, unknown>;": 1
+      },
+      "tests/traceline/one-line.test.ts": {
+        "const g = globalThis as Record<string, unknown>;": 1
+      },
+      "tests/traceline/records.test.ts": {
+        "const g = globalThis as Record<string, unknown>;": 1
+      },
+      "tests/traceline/repetition.test.ts": {
+        "const g = globalThis as Record<string, unknown>;": 1
+      },
+      "tests/traceline/status-suppression.test.ts": {
+        "const g = globalThis as Record<string, unknown>;": 1
+      }
+    },
+    "POG007": {
+      "AGENTS.md": {
+        "(Quoted UI output is exempt: cachemire's ledger genuinely prints — for absent values.)": 1,
+        "- No em dashes (—) in markdown docs. Use commas, colons, semicolons, or parentheses.": 1
+      },
+      "CHANGELOG.md": {
+        "## 0.4.0 — 2026-06-18": 1,
+        "## 0.4.1 — 2026-06-20": 1,
+        "## 0.4.2 — 2026-06-26": 1,
+        "## 0.4.3 — 2026-07-01": 1,
+        "## 0.5.0 — 2026-07-01": 1,
+        "## 0.5.1 — 2026-07-01": 1,
+        "## 0.5.10 — 2026-07-02": 1,
+        "## 0.5.11 — 2026-07-02": 1,
+        "## 0.5.12 — 2026-07-02": 1,
+        "## 0.5.13 — 2026-07-02": 1,
+        "## 0.5.14 — 2026-07-04": 1,
+        "## 0.5.15 — 2026-07-04": 1,
+        "## 0.5.16 — 2026-07-04": 1,
+        "## 0.5.17 — 2026-07-04": 1,
+        "## 0.5.18 — 2026-07-04": 1,
+        "## 0.5.2 — 2026-07-01": 1,
+        "## 0.5.3 — 2026-07-01": 1,
+        "## 0.5.4 — 2026-07-02": 1,
+        "## 0.5.5 — 2026-07-02": 1,
+        "## 0.5.6 — 2026-07-02": 1,
+        "## 0.5.7 — 2026-07-02": 1,
+        "## 0.5.8 — 2026-07-02": 1,
+        "## 0.5.9 — 2026-07-02": 1,
+        "(Spacer + Text) to the chat tail — a holdover from when the toggle's only visible": 1,
+        "- A path under the row's cwd renders as a dim `./` plus the cwd-relative tail — the": 1,
+        "- The cut is a column: middle truncation now cuts at exact positions — the tail is a": 1,
+        "Deliberately conservative — under-brightening is the family's bias.": 1,
+        "`-e`/`-c` script string — `↵ '` rendered a bold white quote. A candidate head": 1,
+        "assigned them — bold `text`, the same treatment as the verb — instead of the": 1,
+        "basename in bold error ink — a failure is more than one red glyph in a dim wall.": 1,
+        "bash-body level dissolved. Bash rows now speak the path-row grammar — bold `$`": 1,
+        "bold — the trace row's white — so it pops from the dim right edge the way a bash": 1,
+        "column as blank space, and the size cell pads left to the block's widest — so a": 1,
+        "longer. Divergent tails — directories included — render bold, so successive edits": 1,
+        "marker (yet always boring), while `./src/` is a meaningful shared prefix — blocks": 1,
+        "middle truncation — one frame now covers folded reads, size tints, dim pipes,": 1,
+        "terminal default — the old \"accepted quirk\", fixed family-wide.": 1,
+        "time — the countdown rolls back to the last billed request instead of counting a": 1,
+        "two sign-aligned columns — a dropped zero side (still dropped as ink) holds its": 1
+      },
+      "docs/testing.md": {
+        "## Layer 1 — contract tests against the installed Pi (drift)": 1,
+        "## Layer 2 — pure-logic unit tests": 1,
+        "## Layer 3 — render goldens": 1,
+        "## Layer 4 — startup smoke (tmux, local-only)": 1,
+        "(layer 3). It does **not** mean live-provider token accuracy — that claim only comes from": 1,
+        "- **Built-in rule matching**: boundary table — `claude-opus-4-8` → 4.7+ rule;": 1,
+        "1. **Pi drift** — both extensions reach into Pi internals (prototype patching, duck-typed": 1,
+        "2. **Silent regression of subtle pure logic** — ANSI-aware truncation, SGR filtering, token": 1,
+        "3. **Render regressions** — alignment, row order, and labels in the estimator views.": 1,
+        "OSC-8 links, and plain text — off-by-one here corrupts every truncated row.": 1,
+        "`buildToolNumerator` counts (per-tool vs aggregate) — this is also the invariant the": 1,
+        "`pi` in tmux in a fixture cwd, then assert on captured panes (no model call required —": 1,
+        "`~`/exact variants align — the invariant behind the recent column-alignment commits.": 1,
+        "and the turn summary — pinning wording, glyphs, and fact order (colour excluded as": 1,
+        "class/prototype from Pi's modules rather than a live TUI — still the real artifact, not a": 1,
+        "renderer fallback) at width 80 — this pins the row grammar without touching Pi's": 1,
+        "runtime — so a `pi update` followed by `npm test` is the drift detector.": 1,
+        "session plus every one-line `◍` surface — clock states, break notices, resolutions,": 1,
+        "user-configurable surface — precedence bugs misprice every row.": 1,
+        "would send — asserting the counted payload equals the displayed payload (shared shaping": 1,
+        "| A real Pi-built system prompt (constructed via Pi's own prompt assembly against a fixture project dir with an AGENTS.md and one skill) matches `PROJECT_INSTRUCTIONS_RE`, `AVAILABLE_SKILLS_RE`, `SKILL_RE`, and `getPromptRemainder` strips both blocks | contextimate section parsing — silently renders wrong buckets if the prompt format drifts |": 1
+      },
+      "docs/upstream-candidates.md": {
+        "# Upstream candidates — potential pi issues": 1,
+        "(`dist/modes/interactive/components/assistant-message.js` — the content loop emits a": 1,
+        "1. **Request side** — `convertTools` emits only name/description/schema/cache_control;": 1,
+        "2. **Response side** — the stream parser handles only `text` / `thinking` /": 1,
+        "3. **Beta headers** — only fine-grained-tool-streaming and interleaved-thinking are": 1,
+        "Entries pin the pi version inspected — internals drift, so re-verify before filing.": 1,
+        "cache-preserving alternative for sessions carrying large MCP catalogs — the prefix": 1,
+        "discovered on demand and appended inline as `tool_reference` blocks — documented to": 1,
+        "message is silently dropped — including **pi's own `showStatus` lines** (`/model`": 1,
+        "messages — so the doubling is intra-message block adjacency (models emitting multiple": 1,
+        "persistent non-message line into the scrollback — this repo's cachemire now carries its": 1,
+        "— not yet decided whether this is worth raising; it may be intended behaviour.": 1
+      }
+    }
+  },
+  "lineBudgets": {
+    "defaultTsMax": 350,
+    "files": {
+      "extensions/pi-cachemire/index.ts": 1409,
+      "extensions/pi-contextimate/index.ts": 1954,
+      "extensions/pi-traceline/index.ts": 1866,
+      "tests/cachemire/economics-and-render.test.ts": 352,
+      "tests/traceline/one-line.test.ts": 813
+    }
+  }
+}

--- a/scripts/dev/agent-lint.mjs
+++ b/scripts/dev/agent-lint.mjs
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const ROOT = process.cwd();
+const BASELINE_PATH = join(ROOT, "scripts", "dev", "agent-lint-baseline.json");
+const DEFAULT_TS_MAX_LINES = 350;
+const NON_BASELINED_CODES = new Set(["POG008", "POG009", "POG010", "POG011"]);
+
+const RULE_MESSAGES = {
+  POG001: [
+    "generic record/object guard is banned.",
+    "Do not carry unknown inward behind a generic isRecord/isObject helper.",
+    "Parse or refine untrusted values at the Pi/JSON/config boundary, then pass a concrete type inward.",
+    "For Pi internals, use a domain-named guard and keep the uncertainty local.",
+  ],
+  POG002: [
+    "JSON.parse result was cast directly.",
+    "JSON.parse returns untrusted data. Store it as unknown, then parse/refine it at the boundary.",
+    "Prefer readJsonConfig(path, parseConfig) or a domain parser.",
+  ],
+  POG003: [
+    "any requires a SAFETY comment.",
+    "If this is a real Pi seam, document the runtime shape and the contract test that pins it.",
+    "Otherwise replace any with a precise type, or unknown plus boundary parsing.",
+  ],
+  POG004: [
+    "broad Record<string, unknown> cast needs local proof.",
+    "Before casting, prove non-null object and non-array in the same helper, or replace the cast with a named boundary parser.",
+    "Unknown should not leak into core logic.",
+  ],
+  POG005: [
+    "TypeScript suppression requires a SAFETY comment.",
+    "Explain the runtime invariant or contract-test coverage before suppressing the compiler.",
+  ],
+  POG006: [
+    "raw ANSI colour constant outside style layer.",
+    "Theme owns ink in this repo. Route colour through extensions/_lib/style.ts.",
+  ],
+  POG007: [
+    "markdown em dash is banned by AGENTS.md.",
+    "Use commas, colons, semicolons, or parentheses unless this is quoted/generated UI output with an explicit lint exemption.",
+  ],
+  POG008: [
+    "extensions/_lib/index.ts must not exist.",
+    "Pi discovers extension directories by convention. Keep _lib without an index.ts so it is never discovered as an extension.",
+  ],
+  POG009: [
+    "runtime dependencies are not allowed without an explicit repo decision.",
+    "This package ships zero runtime dependencies. Use dev tooling or repo-local scripts unless maintainers approve a dependency.",
+  ],
+  POG010: [
+    "TypeScript file is over its agent context budget.",
+    "Split code by domain before growing large files. Existing oversized files have temporary budgets that should only shrink.",
+  ],
+  POG011: [
+    "agent lint baseline is stale.",
+    "Prune fixed findings or lower shrunk line budgets instead of leaving old allowance behind.",
+  ],
+};
+
+function usage() {
+  console.log(`Usage: node scripts/dev/agent-lint.mjs [--update-baseline] [--show-baseline]\n\nDeterministic source checks for the pine-of-glass agent coding standard.`);
+}
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if ([".git", "node_modules", ".pi-subagents", "out", "coverage"].includes(entry.name)) continue;
+      walk(path, out);
+    } else {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function rel(path) {
+  return relative(ROOT, path).split(sep).join("/");
+}
+
+function readText(path) {
+  return readFileSync(path, "utf8");
+}
+
+function normalizeLine(line) {
+  return line.trim().replace(/\s+/g, " ");
+}
+
+function messageFor(code) {
+  return RULE_MESSAGES[code].join("\n");
+}
+
+function makeFinding(code, file, line, lineText) {
+  return { code, file, line, lineText, message: messageFor(code) };
+}
+
+function signature(finding) {
+  return `${finding.code}\u0000${finding.file}\u0000${normalizeLine(finding.lineText)}`;
+}
+
+function isTsLike(path) {
+  return /\.(?:ts|mts|cts|tsx|mjs|js)$/.test(path);
+}
+
+function isMarkdown(path) {
+  return /\.md$/.test(path);
+}
+
+function inPath(path, prefix) {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function hasDisable(lines, index, code) {
+  const current = lines[index] ?? "";
+  const previous = lines[index - 1] ?? "";
+  return current.includes(`agent-lint-disable-line ${code}`)
+    || current.includes("agent-lint-disable-line")
+    || previous.includes(`agent-lint-disable-next-line ${code}`)
+    || previous.includes("agent-lint-disable-next-line");
+}
+
+function hasSafety(lines, index) {
+  for (let offset = 0; offset <= 3; offset++) {
+    const line = lines[index - offset];
+    if (line && line.includes("SAFETY:")) return true;
+  }
+  return false;
+}
+
+function hasLocalRecordProof(lines, index) {
+  const window = lines.slice(Math.max(0, index - 5), index + 1).join("\n");
+  if (window.includes("isJsonObject(")) return true;
+  return window.includes("typeof") && window.includes("object") && window.includes("Array.isArray");
+}
+
+function scanTsFile(absPath, findings) {
+  const file = rel(absPath);
+  const lines = readText(absPath).split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    const lineNumber = index + 1;
+
+    if (!hasDisable(lines, index, "POG001") && /\b(?:function|const|let|var)\s+(?:isRecord|isObject)\b/.test(line)) {
+      findings.push(makeFinding("POG001", file, lineNumber, line));
+    }
+
+    if (!hasDisable(lines, index, "POG002") && /JSON\.parse\([^;]*\)\s+as\s+/.test(line)) {
+      findings.push(makeFinding("POG002", file, lineNumber, line));
+    }
+
+    const unsafeAnyType = /(:\s*any\b|as\s+any\b|<\s*any\s*>|\bany\s*\[\s*\]|\bArray\s*<\s*any\s*>|[<,]\s*any\s*[>,])/.test(line);
+    if (!trimmed.startsWith("//") && !trimmed.startsWith("/*") && !trimmed.startsWith("*") && unsafeAnyType) {
+      if (!hasDisable(lines, index, "POG003") && !hasSafety(lines, index)) {
+        findings.push(makeFinding("POG003", file, lineNumber, line));
+      }
+    }
+
+    if (/as\s+Record\s*<\s*string\s*,\s*unknown\s*>/.test(line)) {
+      if (!hasDisable(lines, index, "POG004") && !hasSafety(lines, index) && !hasLocalRecordProof(lines, index)) {
+        findings.push(makeFinding("POG004", file, lineNumber, line));
+      }
+    }
+
+    if (!hasDisable(lines, index, "POG005") && /@ts-(?:ignore|expect-error)/.test(line) && !hasSafety(lines, index)) {
+      findings.push(makeFinding("POG005", file, lineNumber, line));
+    }
+
+    if (inPath(file, "extensions") && file !== "extensions/_lib/style.ts" && file !== "extensions/_lib/ansi.ts") {
+      const rawAnsiColor = /\\x1b\[(?:3[0-7]|9[0-7]|38[;:]|48[;:]|4[0-7]|10[0-7])/.test(line);
+      if (!hasDisable(lines, index, "POG006") && rawAnsiColor) {
+        findings.push(makeFinding("POG006", file, lineNumber, line));
+      }
+    }
+  }
+}
+
+function scanMarkdownFile(absPath, findings) {
+  const file = rel(absPath);
+  const lines = readText(absPath).split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (line.includes("—") && !hasDisable(lines, index, "POG007")) {
+      findings.push(makeFinding("POG007", file, index + 1, line));
+    }
+  }
+}
+
+function scanFileBudgets(files, baseline, findings) {
+  const budgets = baseline.lineBudgets ?? {};
+  const defaultMax = budgets.defaultTsMax ?? DEFAULT_TS_MAX_LINES;
+  const fileBudgets = budgets.files ?? {};
+  const seenBudgetFiles = new Set();
+  for (const absPath of files) {
+    const file = rel(absPath);
+    if (!/\.ts$/.test(file)) continue;
+    if (!inPath(file, "extensions") && !inPath(file, "tests")) continue;
+    const lineCount = readText(absPath).split(/\r?\n/).length;
+    const storedBudget = fileBudgets[file];
+    if (storedBudget !== undefined) seenBudgetFiles.add(file);
+    const allowed = storedBudget ?? defaultMax;
+    if (lineCount > allowed) {
+      findings.push(makeFinding("POG010", file, 1, `line-count:${lineCount} budget:${allowed}`));
+    }
+    if (storedBudget !== undefined && lineCount < storedBudget) {
+      findings.push(makeFinding("POG011", file, 1, `line-count:${lineCount} stale-budget:${storedBudget}`));
+    }
+  }
+  for (const budgetFile of Object.keys(fileBudgets)) {
+    if (!seenBudgetFiles.has(budgetFile)) {
+      findings.push(makeFinding("POG011", budgetFile, 1, "missing file still has a line budget"));
+    }
+  }
+}
+
+function scanStructural(findings) {
+  if (existsSync(join(ROOT, "extensions", "_lib", "index.ts"))) {
+    findings.push(makeFinding("POG008", "extensions/_lib/index.ts", 1, "extensions/_lib/index.ts"));
+  }
+
+  const packagePath = join(ROOT, "package.json");
+  if (existsSync(packagePath)) {
+    const pkg = JSON.parse(readText(packagePath));
+    const deps = pkg.dependencies && typeof pkg.dependencies === "object" ? Object.keys(pkg.dependencies) : [];
+    if (deps.length > 0) {
+      findings.push(makeFinding("POG009", "package.json", 1, `dependencies:${deps.join(",")}`));
+    }
+  }
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE_PATH)) return { version: 1, knownFindings: {}, lineBudgets: { defaultTsMax: DEFAULT_TS_MAX_LINES, files: {} } };
+  return JSON.parse(readText(BASELINE_PATH));
+}
+
+function flattenKnownFindings(baseline) {
+  const map = new Map();
+  for (const [code, files] of Object.entries(baseline.knownFindings ?? {})) {
+    for (const [file, lines] of Object.entries(files ?? {})) {
+      for (const [lineText, count] of Object.entries(lines ?? {})) {
+        map.set(`${code}\u0000${file}\u0000${lineText}`, Number(count));
+      }
+    }
+  }
+  return map;
+}
+
+function buildKnownFindings(findings) {
+  const knownFindings = {};
+  for (const finding of findings) {
+    if (NON_BASELINED_CODES.has(finding.code)) continue;
+    const lineText = normalizeLine(finding.lineText);
+    knownFindings[finding.code] ??= {};
+    knownFindings[finding.code][finding.file] ??= {};
+    knownFindings[finding.code][finding.file][lineText] = (knownFindings[finding.code][finding.file][lineText] ?? 0) + 1;
+  }
+  return sortObjectDeep(knownFindings);
+}
+
+function buildLineBudgets(files) {
+  const budgets = {};
+  for (const absPath of files) {
+    const file = rel(absPath);
+    if (!/\.ts$/.test(file)) continue;
+    if (!inPath(file, "extensions") && !inPath(file, "tests")) continue;
+    const lineCount = readText(absPath).split(/\r?\n/).length;
+    if (lineCount > DEFAULT_TS_MAX_LINES) budgets[file] = lineCount;
+  }
+  return { defaultTsMax: DEFAULT_TS_MAX_LINES, files: sortObjectDeep(budgets) };
+}
+
+function sortObjectDeep(value) {
+  if (Array.isArray(value) || value === null || typeof value !== "object") return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sortObjectDeep(value[key])]));
+}
+
+function partitionFindings(findings, baseline) {
+  const knownMap = flattenKnownFindings(baseline);
+  const known = [];
+  const fresh = [];
+  for (const finding of findings) {
+    if (NON_BASELINED_CODES.has(finding.code)) {
+      fresh.push(finding);
+      continue;
+    }
+    const sig = signature(finding);
+    const remaining = knownMap.get(sig) ?? 0;
+    if (remaining > 0) {
+      known.push(finding);
+      knownMap.set(sig, remaining - 1);
+    } else {
+      fresh.push(finding);
+    }
+  }
+  const stale = Array.from(knownMap.entries()).filter(([, count]) => count > 0);
+  return { known, fresh, stale };
+}
+
+function formatFinding(finding) {
+  return `${finding.file}:${finding.line} ${finding.code} ${finding.message}\n  > ${finding.lineText.trim()}`;
+}
+
+function collectFiles() {
+  return walk(ROOT).filter((path) => {
+    const file = rel(path);
+    if (file.startsWith("scripts/dev/bash-corpus/out/")) return false;
+    return isTsLike(file) || isMarkdown(file) || file === "package.json";
+  });
+}
+
+function collectFindings(files, baseline) {
+  const findings = [];
+  for (const absPath of files) {
+    const file = rel(absPath);
+    if (isTsLike(file)) scanTsFile(absPath, findings);
+    if (isMarkdown(file)) scanMarkdownFile(absPath, findings);
+  }
+  scanFileBudgets(files, baseline, findings);
+  scanStructural(findings);
+  return findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.code.localeCompare(b.code));
+}
+
+function main() {
+  const args = new Set(process.argv.slice(2));
+  if (args.has("--help") || args.has("-h")) {
+    usage();
+    return;
+  }
+
+  const files = collectFiles();
+  const baseline = loadBaseline();
+  const findings = collectFindings(files, baseline);
+
+  if (args.has("--update-baseline")) {
+    const next = {
+      version: 1,
+      generatedBy: "node scripts/dev/agent-lint.mjs --update-baseline",
+      knownFindings: buildKnownFindings(findings),
+      lineBudgets: buildLineBudgets(files),
+    };
+    writeFileSync(BASELINE_PATH, `${JSON.stringify(next, null, 2)}\n`);
+    console.log(`Updated ${relative(ROOT, BASELINE_PATH)} with ${findings.length} current findings and line budgets.`);
+    return;
+  }
+
+  const { known, fresh, stale } = partitionFindings(findings, baseline);
+  if (args.has("--show-baseline")) {
+    for (const finding of known) console.log(`${formatFinding(finding)}\n`);
+    console.log(`Known baseline findings: ${known.length}`);
+    if (stale.length > 0) console.log(`Stale baseline signatures: ${stale.length}`);
+    return;
+  }
+
+  if (fresh.length > 0 || stale.length > 0) {
+    if (fresh.length > 0) {
+      console.error(`agent-lint found ${fresh.length} unbaselined finding(s):\n`);
+      for (const finding of fresh) console.error(`${formatFinding(finding)}\n`);
+    }
+    if (stale.length > 0) {
+      console.error(`agent-lint found ${stale.length} stale baseline signature(s):\n`);
+      for (const [sig, count] of stale) {
+        const [code, file, lineText] = sig.split("\u0000");
+        console.error(`${file} ${code} stale baseline entry (${count}):\n  > ${lineText}\n`);
+      }
+    }
+    console.error("Fix the issue, add a SAFETY comment for a real boundary seam, or update the reviewed baseline after deliberate fixes.");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`agent-lint passed: no new findings (${known.length} known baseline finding(s) remain).`);
+}
+
+main();

--- a/tests/agent-lint.test.ts
+++ b/tests/agent-lint.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const script = readFileSync(new URL("../scripts/dev/agent-lint.mjs", import.meta.url), "utf8");
+
+function fixtureRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pog-agent-lint-"));
+  mkdirSync(join(dir, "scripts", "dev"), { recursive: true });
+  mkdirSync(join(dir, "extensions", "demo"), { recursive: true });
+  writeFileSync(join(dir, "scripts", "dev", "agent-lint.mjs"), script);
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ type: "module" }, null, 2));
+  return dir;
+}
+
+function runLint(cwd: string, ...args: string[]) {
+  return spawnSync(process.execPath, ["scripts/dev/agent-lint.mjs", ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+test("agent lint gives instructional failures and supports a migration baseline", () => {
+  const dir = fixtureRepo();
+  const badGuard = ["function is", "Record(value) { return !!value; }"];
+  writeFileSync(join(dir, "extensions", "demo", "index.ts"), badGuard.join(""));
+
+  const failed = runLint(dir);
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stderr, /POG001/);
+  assert.match(failed.stderr, /Do not carry unknown inward/);
+
+  const updated = runLint(dir, "--update-baseline");
+  assert.equal(updated.status, 0, updated.stderr);
+
+  const passed = runLint(dir);
+  assert.equal(passed.status, 0, passed.stderr);
+  assert.match(passed.stdout, /no new findings/);
+});
+
+test("agent lint fails when the baseline keeps stale signatures", () => {
+  const dir = fixtureRepo();
+  writeFileSync(join(dir, "extensions", "demo", "index.ts"), "export const ok = true;\n");
+  const staleLine = ["function is", "Record(value) { return !!value; }"].join("");
+  writeFileSync(join(dir, "scripts", "dev", "agent-lint-baseline.json"), JSON.stringify({
+    version: 1,
+    knownFindings: {
+      POG001: {
+        "extensions/demo/index.ts": {
+          [staleLine]: 1,
+        },
+      },
+    },
+    lineBudgets: { defaultTsMax: 350, files: {} },
+  }, null, 2));
+
+  const failed = runLint(dir);
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stderr, /stale baseline/);
+});


### PR DESCRIPTION
## Summary
- add a zero-dependency agent lint harness with repo-specific rules for boundary typing, unsafe escape hatches, raw ANSI, markdown style, line budgets, and dependency/layout invariants
- add parser-driven JSON config reads plus shared boundary helpers, then migrate contextimate/cachemire/traceline config loading to domain parsers
- document the agent coding standard and baseline policy, wire lint/check scripts, and add tests for instructional lint output and stale-baseline failure

## Validation
- npm run check

## Notes
- The baseline records 167 current violations as a migration ledger so new regressions fail without pretending the existing Pi seam debt is fixed.
- A read-only PR review subagent found no blockers after fixes for stale baseline and scope issues.