### PR TITLE
traceline: inline mutation diffs and record-first bash outcomes

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -359,7 +359,10 @@ The right-aligned suffix carries facts in columns that align down the block:
   each row ending where its own fact does. A ragged right edge here is a legible
   asymmetry (reads flooded context, edits did not), not a misalignment. A rare
   non-mutation tool that reports a diff still right-aligns it in the suffix
-- the size cell keeps the rightmost berth; record facts join before it
+- the size cell keeps the rightmost berth. A record row (§9.10) suppresses its
+  size cell as noise unless the output reaches warning severity (§6): its result
+  is porcelain about the event, not pulled context, but an output that balloons
+  is a story of its own and re-earns the cell
 
 ### 9.8 Truncation
 
@@ -382,20 +385,34 @@ suffix in the block's reserve (§9.8).
 Some bash rows change shared state beyond the working tree: a commit, a push, a
 PR merged or closed, a release or package published. Their invocation says only
 what was attempted; the proof lives in the result, which one-line mode hides.
-These rows earn record facts in the suffix, stated verb-first from the porcelain
-the tool actually reported, never from the command's arguments:
-`committed a4f21c9 · pushed main · 0.3k ch`, `merged PR #87 · 0.1k ch`.
+A row whose output carries that proof graduates to a verb-led outcome row: the
+record leads, stated verb-first from the porcelain the tool actually reported,
+never from the command's arguments, and the command trails as provenance behind
+its `$`: `pushed main $ git push`, `merged PR #87 $ gh pr merge 87 --squash`.
 
+- the record is the headline because, once landed, the outcome is the row's
+  identity: it joins the verb-first family (`read`, `edit`, `write`, `$`), so
+  the left column scans as what happened. The `$` keeps its promise that what
+  follows ran in a shell, which is why a record may never sit between `$` and
+  the command (`$ pushed main git push` reads as a command named `pushed`)
+- the headline survives truncation: the middle cut (§9.8) lands in the command,
+  never in the record
+- a record row's size cell is suppressed (§9.7): the record is the row's story,
+  and a confirmation's length is not. At warning severity (§6) the cell
+  re-earns its berth
+- a bash row with no record keeps `$ command` at the left edge: rows lead with
+  an outcome exactly when there demonstrably was one
 - output-only honesty: a fact appears only when the command names the operation
   and its success porcelain appears in the output (`[main a4f21c9]`,
   `main -> main`, `Merged pull request #87`). A failed push after a good commit
-  shows `committed a4f21c9` on a red row: committed, demonstrably not landed.
+  still headlines `committed a4f21c9` on a red row: committed, demonstrably
+  not landed.
   `git tag` earns nothing; its success porcelain is silence
 - facts chain in output order with the `·` separator; consecutive same-verb
   facts merge their data (`pushed main, v0.5.9`) only when their tones agree,
   so a forced push never hides inside a routine one
 - overflow drops whole facts, oldest first. Records take at most about a third
-  of the row; a mangled sha is worse than none
+  of the row, so the command keeps its width; a mangled sha is worse than none
 - records wear the ink of what they state: the cell renders success-toned bold,
   verb and datum together (`pushed main`, `released v0.5.9`), because a refname,
   tag or PR number is the event's identity. A commit sha stays dim beside its

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -4,7 +4,7 @@
 
 ![One tool call per trace line, with a result-size suffix on the right](../../docs/img/pi-traceline-collapsed.png)
 
-Each row leads with its verb and target, file mutations carry a `+N -M` diff inline on the basename (the way a read carries its `:line-range`), commands that changed shared state carry a record of what they did, and completed rows end in a result-size cell on a shared right edge:
+Each row leads with its verb and target, file mutations carry a `+N -M` diff inline on the basename (the way a read carries its `:line-range`), commands that landed shared state lead with a record of what they did, and completed rows end in a result-size cell on a shared right edge:
 
 ```
   ▏ › read resource .pi/agent/AGENTS.md:1-20                 1.4k ch
@@ -13,6 +13,7 @@ Each row leads with its verb and target, file mutations carry a `+N -M` diff inl
   ▏ › edit ~/projects/demo/index.ts +3 -1
   ▏ › write /tmp/pi-extension-test-...-elephant.txt +5
   ▏ › $ rm /tmp/pi-extension-test-...-elephant.txt ...       0.0k ch
+  ▏ › pushed main $ git push
 ```
 
 ## Install
@@ -57,7 +58,7 @@ Size thresholds are overridable via the family config convention (`~/.pi/agent/p
 - **A dim `▏` rail** opens every row, and the block indents one gutter under the prose margin, so consecutive calls fuse into one visible block: block identity from indentation and one character of layout, not painted backgrounds.
 - **The result-size cell** (`1.4k ch`, in the family number grammar) is severity-tinted: dim while healthy, warning-coloured at ≥10k ch, error-coloured at ≥50k ch, so an over-large output jumps out of the column. Results under 100 ch show no cell, but the floor is block-scoped: if any row in a contiguous block clears it, every completed row in the block shows its cell, keeping the right edge aligned.
 - **Diff stats** on `edit` and `write` rows show `+N -M` with zero sides dropped (`+5`, not `+5 -0`), inline on the basename (§9.5) the way a read shows its `:line-range` (add-green / remove-red). The magnitude rides the file it changed rather than a right column, so no gap opens between path and change, and the near-noise size cell is dropped (a mutation opts out of the block's fact columns). `write` stats come from a pre-execution snapshot; restored rows not seen live may show no diff.
-- **Record facts** appear on bash rows that changed shared state beyond the working tree (`git commit`/`push`, `gh pr merge`/`close`/`create`, `gh issue close`, `gh release create`, `npm publish`): verb-first cells like `committed a4f21c9 · pushed main`, parsed from the success output the tool actually *reported*, never from the command's arguments. Each fact wears the ink of what it states (success-toned bold; a sha stays dim as audit data; a forced push tints warning), per fact rather than per row: a failed push after a good commit shows a green `committed` on a red row. On narrow rows whole facts drop oldest-first; the size cell keeps the rightmost column.
+- **Record facts** lead bash rows that changed shared state beyond the working tree (`git commit`/`push`, `gh pr merge`/`close`/`create`, `gh issue close`, `gh release create`, `npm publish`): the row graduates to a verb-led outcome (`pushed main $ git push`, `merged PR #87 $ gh pr merge 87 --squash`), with the command trailing as provenance behind its `$`. Facts are parsed from the success output the tool actually *reported*, never from the command's arguments, so a row leads with an outcome exactly when there demonstrably was one. Each fact wears the ink of what it states (success-toned bold; a sha stays dim as audit data; a forced push tints warning), per fact rather than per row: a failed push after a good commit shows a green `committed` on a red row. On narrow rows whole facts drop oldest-first, and the headline survives truncation: the middle cut lands in the command. A record row's size cell is suppressed as noise unless the output reaches warning severity.
 
 Rendering reuses Pi's own tool-call renderer for most tools, so accented paths, warning line ranges, and custom-tool renderers track Pi's defaults; traceline's own ink is theme-derived and its unstyled spans demote to one dim supporting grey. The full visual grammar is the family design language: see [`docs/design-language.md`](../../docs/design-language.md) §9.
 

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -94,6 +94,10 @@ import {
  * on the basename instead (§9.5), the way a read carries its `:line-range`: the near-noise size cell
  * (a confirmation's length, not the file's) is dropped, so a mutation's suffix stays empty and the
  * magnitude rides the file it changed (zero sides dropped: `+2 -0` → `+2`).
+ * Bash rows whose output proves they landed shared state graduate to verb-led outcome
+ * rows (§9.10): the record leads and the command trails behind its `$` —
+ * `pushed main $ git push` — and the size cell is suppressed below warning severity,
+ * because the record is the row's story and a confirmation's length is not.
  * All ink is theme-derived (style.ts ink()), with raw-ANSI fallbacks before a theme exists.
  *
  * Repetition the model emits is folded rather than re-printed (issue #14): a bash row
@@ -383,7 +387,11 @@ function blockFacts(rows: ToolRowLike[]): BlockFacts {
   const sizeColumnLive = rows.some((c) => {
     if (inlineMutationRow(c)) return false;
     const chars = resultTextCharCount(c);
-    return chars !== undefined && chars >= CHAR_SUFFIX_FLOOR;
+    if (chars === undefined) return false;
+    // Record rows (§9.10) suppress their size cell below warning severity, so only
+    // a ballooning record output lights the column.
+    if (recordRow(c)) return chars >= sizeThresholds.warning;
+    return chars >= CHAR_SUFFIX_FLOOR;
   });
   let plus = 0;
   let minus = 0;
@@ -395,7 +403,10 @@ function blockFacts(rows: ToolRowLike[]): BlockFacts {
       if (stats.added > 0) plus = Math.max(plus, 1 + String(stats.added).length);
       if (stats.removed > 0) minus = Math.max(minus, 1 + String(stats.removed).length);
     }
-    size = Math.max(size, visibleWidth(charSuffix(resultTextCharCount(row), sizeColumnLive)));
+    size = Math.max(
+      size,
+      visibleWidth(recordRow(row) ? recordCharSuffix(row) : charSuffix(resultTextCharCount(row), sizeColumnLive)),
+    );
   }
   return { sizeColumnLive, diffColumns: { plus, minus, size } };
 }
@@ -610,12 +621,12 @@ function mutationInlineDiffInk(comp: ToolRowDataLike): string {
 // Some bash rows change shared state beyond the working tree — a commit, a push, a PR
 // merged or closed, an issue closed, a release or package published. The invocation
 // says only what was *attempted*, and truncation may eat even that; the proof is
-// porcelain in the result, which one-line mode hides. These rows earn verb-first
-// record facts in the suffix — `committed a4f21c9 · pushed main · 0.3k ch` — stated
+// porcelain in the result, which one-line mode hides. Such a row graduates to a
+// verb-led outcome row (§9.10): the record leads — `pushed main $ git push` — stated
 // only from what the output reported: the command must name the operation *and* its
-// success porcelain must appear. A failed push after a good commit therefore shows
-// `committed a4f21c9` on a red row — committed, demonstrably not landed. `git tag`
-// earns nothing: its success porcelain is silence.
+// success porcelain must appear. A failed push after a good commit therefore still
+// headlines `committed a4f21c9` on a red row — committed, demonstrably not landed.
+// `git tag` earns nothing: its success porcelain is silence.
 type RecordTone = "success" | "warning";
 type RecordFact = { verb: string; datum: string; at: number; tone: RecordTone; opaque: boolean };
 
@@ -754,10 +765,10 @@ function recordCells(comp: ToolRowDataLike): string[] {
   return recordCellData(comp).map(recordCellText);
 }
 
-// Records may take at most roughly a third of the row (§9.10): overflow drops whole
-// facts oldest first — terminal state wins, a mangled sha is worse than none, and the
-// full output stays one Ctrl+T away.
-const RECORD_SUFFIX_SHARE = 1 / 3;
+// Records may take at most roughly a third of the row (§9.10), so the command keeps
+// its width: overflow drops whole facts oldest first — terminal state wins, a mangled
+// sha is worse than none, and the full output stays one Ctrl+T away.
+const RECORD_HEADLINE_SHARE = 1 / 3;
 
 // Records wear the ink of what they state (§9.10): the cell renders bold in its
 // fact's tone — success for landed state, warning for a forced push — verb and datum
@@ -776,24 +787,45 @@ function inkRecordCell(cell: RecordCellData): string {
   return ink(theme, cell.tone, `${BOLD}${recordCellText(cell)}${BOLD_OFF}`);
 }
 
-function recordSuffix(comp: ToolRowDataLike, available: number): string {
+// A bash row that landed real shared state graduates to a verb-led outcome row
+// (§9.10): the record leads — `pushed main $ git push` — joining the verb-first
+// family (read, edit, write, `$`), and the command trails as provenance behind its
+// `$`, which keeps its promise that what follows ran in a shell (a record never sits
+// between `$` and the command). Records exist only when success porcelain appeared,
+// so a row leads with an outcome exactly when there demonstrably was one; a partial
+// success on a red row still headlines what landed. The headline survives truncation:
+// the middle cut (§9.8) lands in the command, never in the record.
+function recordHeadline(comp: ToolRowDataLike, available: number): string {
   const cells = recordCellData(comp);
   if (!cells.length) return "";
-  const cap = Math.floor(available * RECORD_SUFFIX_SHARE);
+  const cap = Math.floor(available * RECORD_HEADLINE_SHARE);
   while (cells.length && cells.map(recordCellText).join(SEP).length > cap) cells.shift();
   return cells.map(inkRecordCell).join(dim(SEP));
+}
+
+function recordRow(comp: ToolRowDataLike): boolean {
+  return recordCellData(comp).length > 0;
+}
+
+// A record row's size cell is suppressed as noise (§9.10/§9.7): its result is
+// porcelain about the event, not pulled context. At warning severity (§6) the cell
+// re-earns its berth — an output that balloons is a story of its own.
+function recordCharSuffix(comp: ToolRowDataLike): string {
+  const chars = resultTextCharCount(comp);
+  if (chars === undefined || chars < sizeThresholds.warning) return "";
+  return charSuffix(chars);
 }
 
 function toolFactSuffix(comp: ToolRowLike, available = Number.POSITIVE_INFINITY, facts: BlockFacts = blockFactsOf(comp)): string {
   const theme = currentTheme();
   const parts: string[] = [];
-  const records = recordSuffix(comp, available);
-  if (records) parts.push(records);
   // Inline-diff mutations (§9.5) spend no right-column ink: the diff rides the
   // basename and the confirmation-size cell is dropped, so the suffix stays empty.
+  // Record rows (§9.10) headline their facts on the left and suppress the size cell
+  // below warning severity.
   const inline = inlineMutationRow(comp);
   const diff = inline ? undefined : mutationDiffStats(comp);
-  const chars = inline ? "" : resultCharSuffix(comp, facts);
+  const chars = inline ? "" : recordRow(comp) ? recordCharSuffix(comp) : resultCharSuffix(comp, facts);
   if (diff) {
     // The diff cell right-aligns within the block's sign columns, and the size cell
     // pads left to the block's widest, so each diff column's right edge and the `·`
@@ -1322,11 +1354,13 @@ function pathEmphasisLine(comp: ToolRowLike, nativeColored: string): string | un
 // The invocation body with family ink applied: bash rows rebuild from plain text, path
 // rows get the dim-directory emphasis, everything else keeps pi's native line with a
 // re-inked verb; tools without a renderer fall back to a plain verb+args line.
-function invocationInk(comp: ToolRowLike): string {
+function invocationInk(comp: ToolRowLike, available = Number.POSITIVE_INFINITY): string {
   if (toolLabel(comp?.toolName) === "bash") {
     const plain = bashInvocationText(comp);
     if (plain === undefined) return inkedFallbackLine(comp);
-    return inkBashRow(comp, foldBashPreamble(comp, tildify(plain)));
+    const body = inkBashRow(comp, foldBashPreamble(comp, tildify(plain)));
+    const headline = recordHeadline(comp, available);
+    return headline ? `${headline} ${body}` : body;
   }
   const native = nativeInvocationLine(comp);
   const base = (native && pathEmphasisLine(comp, native)) ?? native;
@@ -1359,7 +1393,7 @@ function oneLine(comp: ToolRowLike, width: number): string {
   const available = traceRowAvailable(width);
   return fitTraceRow(
     statusTone(comp),
-    invocationInk(comp),
+    invocationInk(comp, available),
     toolFactSuffix(comp, available, facts),
     blockSuffixReserve(rows, facts, available),
     width,
@@ -1966,7 +2000,7 @@ export const internals = {
   mutationDiffStats,
   toolFactSuffix,
   recordCells,
-  recordSuffix,
+  recordHeadline,
   configureSizeThresholds,
   lineRange,
   toolStatus,

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,7 +7,7 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 1419,
       "extensions/pi-contextimate/index.ts": 1959,
-      "extensions/pi-traceline/index.ts": 2051,
+      "extensions/pi-traceline/index.ts": 2085,
       "tests/cachemire/economics-and-render.test.ts": 352,
       "tests/traceline/one-line.test.ts": 808
     }

--- a/scripts/dev/agent-lint.mjs
+++ b/scripts/dev/agent-lint.mjs
@@ -71,6 +71,10 @@ function walk(dir, out = []) {
       if ([".git", "node_modules", ".pi-subagents", "out", "coverage"].includes(entry.name)) continue;
       walk(path, out);
     } else {
+      // *.local.md is the repo's gitignored local-scratch convention (.gitignore):
+      // those files never reach a clean checkout, so linting them only makes local
+      // runs diverge from CI.
+      if (entry.name.endsWith(".local.md")) continue;
       out.push(path);
     }
   }

--- a/tests/fixtures/goldens/traceline-rows-120.txt
+++ b/tests/fixtures/goldens/traceline-rows-120.txt
@@ -25,6 +25,6 @@ The runner mangles the config — patching it and logging the pass.
 
 Fixed — committing and shipping the release.
 
-  ▏ › $ cd ~/projects/pine-of-glass &…: records of consequence" && git push  committed a4f21c9 · pushed main · 0.2k ch
-  ▏ › $ gh pr merge 87 --squash --delete-branch                                                merged PR #87 · 0.1k ch
+  ▏ › committed a4f21c9 · pushed main $ cd ~/projects/pi…com commit -m "traceline: records of consequence" && git push
+  ▏ › merged PR #87 $ gh pr merge 87 --squash --delete-branch
   ▏ › $ git status --short

--- a/tests/fixtures/goldens/traceline-rows-80.txt
+++ b/tests/fixtures/goldens/traceline-rows-80.txt
@@ -25,6 +25,6 @@ The runner mangles the config — patching it and logging the pass.
 
 Fixed — committing and shipping the release.
 
-  ▏ › $ cd ~/projects/pine-… consequence" && git push    pushed main · 0.2k ch
-  ▏ › $ gh pr merge 87 --squash --delete-branch        merged PR #87 · 0.1k ch
+  ▏ › pushed main $ cd ~/projects/pine…ne: records of consequence" && git push
+  ▏ › merged PR #87 $ gh pr merge 87 --squash --delete-branch
   ▏ › $ git status --short

--- a/tests/traceline/records.test.ts
+++ b/tests/traceline/records.test.ts
@@ -1,15 +1,16 @@
 // Records of consequence (design language §9.10): bash rows that change shared
-// state — commit, push, PR merge/close/create, issue close, release/publish — earn
-// verb-first record facts in the suffix, parsed from the *success porcelain the tool
-// reported*, never from the command's arguments. These tests pin the exact porcelain
-// shapes and the fact-toned ink.
+// state — commit, push, PR merge/close/create, issue close, release/publish —
+// graduate to verb-led outcome rows: the record leads and the command trails as
+// provenance behind its `$`, parsed from the *success porcelain the tool reported*,
+// never from the command's arguments. These tests pin the exact porcelain shapes,
+// the headline placement, and the fact-toned ink.
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 
 import { internals } from "../../extensions/pi-traceline/index.ts";
 import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
 
-const { recordCells, recordSuffix, toolFactSuffix, stripAnsi, setTracelineChat, setTracelineThemeGetter } = internals;
+const { recordCells, recordHeadline, toolFactSuffix, oneLine, stripAnsi, setTracelineChat, setTracelineThemeGetter } = internals;
 
 beforeEach(() => {
   setTracelineChat(undefined);
@@ -119,22 +120,45 @@ test("overflow drops whole facts oldest first, never mangles", () => {
     `[main a4f21c9] x\n${PUSH_OK}`,
   );
   // Plenty of room: both facts.
-  assert.equal(stripAnsi(recordSuffix(comp, 120)), "committed a4f21c9 · pushed main");
+  assert.equal(stripAnsi(recordHeadline(comp, 120)), "committed a4f21c9 · pushed main");
   // Tight row (~76 available at 80 cols → cap 25): the oldest fact drops whole.
-  assert.equal(stripAnsi(recordSuffix(comp, 76)), "pushed main");
+  assert.equal(stripAnsi(recordHeadline(comp, 76)), "pushed main");
   // Too tight for anything: no half-facts.
-  assert.equal(stripAnsi(recordSuffix(comp, 20)), "");
+  assert.equal(stripAnsi(recordHeadline(comp, 20)), "");
 });
 
-test("records join the fact suffix before the size cell", () => {
+test("records lead the row; the command trails behind its `$` (§9.10)", () => {
   const output = `[main a4f21c9] x\n${PUSH_OK}${"x".repeat(300)}`;
   const comp = bash("git commit -m x && git push", output);
-  assert.equal(stripAnsi(toolFactSuffix(comp, 200)), "committed a4f21c9 · pushed main · 0.4k ch");
+  // No record in the suffix, and a 0.4k confirmation earns no size cell (§9.7).
+  assert.equal(stripAnsi(toolFactSuffix(comp, 200)), "");
+  const line = stripAnsi(oneLine(comp, 120));
+  assert.ok(line.includes("committed a4f21c9 · pushed main $ git commit -m x && git push"), line);
+  assert.ok(!line.includes(" ch"), line);
+  // On a tighter row the cap (about a third, §9.10) drops the oldest fact whole,
+  // and the command keeps its width.
+  const tight = stripAnsi(oneLine(comp, 100));
+  assert.ok(tight.includes("pushed main $ git commit -m x && git push"), tight);
+  assert.ok(!tight.includes("committed"), tight);
+});
+
+test("a ballooning record output re-earns its size cell at warning severity (§9.10)", () => {
+  const comp = bash("git push", `${PUSH_OK}${"y".repeat(12_000)}`);
+  assert.match(stripAnsi(toolFactSuffix(comp, 200)), /^12\.[01]k ch$/);
+  const line = stripAnsi(oneLine(comp, 100));
+  assert.ok(line.includes("pushed main $ git push"), line);
+  assert.ok(/12\.[01]k ch$/.test(line.trimEnd()), line);
+});
+
+test("a record-less bash row keeps `$ command` at the left edge", () => {
+  const comp = bash("git status --short", " M index.ts\n");
+  const line = stripAnsi(oneLine(comp, 100));
+  assert.match(line, /› \$ git status --short/);
 });
 
 test("records wear the ink of what they state (§9.10)", () => {
   const comp = bash("git commit -m x && git push", `[main a4f21c9] x\n${PUSH_OK}`);
-  const raw = recordSuffix(comp, 200);
+  const raw = recordHeadline(comp, 200);
   // No theme in tests, so ink resolves to raw ANSI: success 32, warning 33, dim 90.
   // The committed verb is success-toned bold; the sha is opaque audit data — dim,
   // outside both the tone and the bold span.
@@ -147,7 +171,7 @@ test("records wear the ink of what they state (§9.10)", () => {
 
 test("a forced push tints warning; tones never merge across (§9.10)", () => {
   const forced = bash("git push --force", "To github.com:o/r.git\n + 1c75c2a...50cf33f main -> main (forced update)\n");
-  assert.match(recordSuffix(forced, 200), /\x1b\[33m\x1b\[1mpushed main\x1b\[22m\x1b\[0m/);
+  assert.match(recordHeadline(forced, 200), /\x1b\[33m\x1b\[1mpushed main\x1b\[22m\x1b\[0m/);
   // A forced ref and a routine tag in one push stay separate cells: a forced push
   // never hides inside a routine one.
   const mixed = bash(
@@ -160,7 +184,7 @@ test("a forced push tints warning; tones never merge across (§9.10)", () => {
 test("the tone is per-fact, not per-row: failed rows keep surviving facts green (§9.10)", () => {
   // Committed, demonstrably not landed: red discriminators, green fact.
   const failed = bash("git commit -m x && git push", "[main a4f21c9] x\n ! [rejected] main -> main\n", { error: true });
-  assert.match(recordSuffix(failed, 200), /\x1b\[32m\x1b\[1mcommitted\x1b\[22m/);
+  assert.match(recordHeadline(failed, 200), /\x1b\[32m\x1b\[1mcommitted\x1b\[22m/);
 });
 
 test("facts cache against result identity", () => {


### PR DESCRIPTION
Two related changes to how traceline rows carry their facts: magnitude and outcome move to where they qualify, instead of renting the right-suffix column.

## 1. Edit/write diff stats ride inline on the basename (`b57efe0`)

```
edit ~/projects/pine-of-glass/scripts/dev/screenshots/rig.mjs +4 -9
write ~/projects/pine-of-glass/worklog/2026-07-02-rig-fix.md +18
```

- `+N -M` renders inline after the path, the way a read carries its `:line-range`; zero sides drop (`+2 -0` → `+2`).
- Uses the existing add/remove tones (warning yellow stays reserved for scoped/partial reads).
- The near-noise size cell (a confirmation's length, not the file's) is dropped; mutation rows no longer light or widen the block's size column. Mixed read/edit blocks keep a deliberately ragged right edge.

## 2. Record facts lead the row as verb-led outcomes (`0baa943`)

```
committed c0ffee1 $ cd ~/projects/pine-of-glass && git commit -m "…"
pushed main $ ⋯ git push
merged PR #29 $ gh pr merge 29 --squash --delete-branch
published 0.5.20 $ npm publish
$ git status --short                                         0.0k ch
```

- Bash rows whose output proves they landed shared state graduate to record-first rows, joining the verb-first family (`read`, `edit`, `write`, `$`); the command trails as provenance behind its `$`, which keeps its promise that what follows ran in a shell.
- Output-only honesty unchanged: no porcelain, no headline — record-less and failed rows keep `$ command` at the left edge (partial success still headlines what landed: green `committed` on a red row).
- The headline survives truncation (middle cut lands in the command) and the 1/3 overflow cap still drops whole facts oldest-first.
- Record rows suppress their size cell as noise unless output reaches warning severity, where it re-earns its berth.

## Validation

- `npm run typecheck` clean; `npm test` 165/165 (records suite grown to 17: headline placement, warning-severity re-earn, tight-row cap, record-less left edge).
- Goldens regenerated and reviewed at 80/120 columns.
- Real-pi tmux startup smoke passed.
- Design language updated first (§9.5, §9.7, §9.10), then README and implementation.

Dogfooded locally via the symlinked extension. Version bump/changelog/release to follow as 0.5.20 once both changes have soaked.
