### PR TITLE
docs: simplify Traceline README

### DIFF
--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -1,24 +1,32 @@
 # pi-traceline
 
-`pi-traceline` collapses each tool call in a turn to a single, scannable **trace line**, so the turn reads as a timeline: which path Pi took, what context it pulled in, which outputs ballooned. It is built for the "I let Pi run for a couple of minutes and came back" moment; `Ctrl+T` flips back to full native detail whenever you want it.
+`pi-traceline` turns each tool call into one line. Use it to see what Pi did, which files it changed and which tool results used the most context.
 
-![One tool call per trace line, with a result-size suffix on the right](../../docs/img/pi-traceline-collapsed.png)
+Press `Ctrl+T` to switch between the trace and Pi's full tool output.
 
-Each row leads with its verb and target, file mutations carry a `+N -M` diff inline on the basename (the way a read carries its `:line-range`), commands that landed shared state lead with a record of what they did, and completed rows end in a result-size cell on a shared right edge:
+![Traceline showing one tool call per line](../../docs/img/pi-traceline-collapsed.png)
+
+A trace looks like this:
 
 ```
   ▏ › read resource .pi/agent/AGENTS.md:1-20                 1.4k ch
   ▏ › [skill] google-workspace-stack:1-20                    1.0k ch
   ▏ › subagent delegate                                      0.1k ch
-  ▏ › edit ~/projects/demo/index.ts +3 -1
+  ▏ › edit ./index.ts +3 -1
   ▏ › write /tmp/pi-extension-test-...-elephant.txt +5
-  ▏ › $ rm /tmp/pi-extension-test-...-elephant.txt ...       0.0k ch
   ▏ › pushed main $ git push
 ```
 
+Each line shows the action and its target. Traceline also shows useful facts such as:
+
+- line ranges for reads
+- added and removed lines for file changes
+- verified outcomes for commands such as `git push` and `gh pr merge`
+- result size in characters, aligned on the right
+
 ## Install
 
-Install from npm:
+Install the `pine-of-glass` package from npm:
 
 ```bash
 pi install npm:pine-of-glass
@@ -30,86 +38,96 @@ Try it for one run without installing:
 pi -e npm:pine-of-glass
 ```
 
-For local development from a clone:
+Run it from a local clone:
 
 ```bash
 pi -e ./extensions/pi-traceline
 ```
 
-## Use
+## Switch between trace and detail
 
-`pi-traceline` rides Pi's native reasoning-visibility toggle and adds no keybinding of its own:
+Traceline follows Pi's reasoning visibility setting. It does not add a keybinding.
 
-- `Ctrl+T` toggles Pi's reasoning visibility; tool rows follow the same state
-- reasoning shown → native tool rows, untouched (full detail)
-- reasoning hidden → each tool row collapses to one trace line
+- press `Ctrl+T` to show Pi's reasoning and full tool output
+- press `Ctrl+T` again to hide reasoning and show one line per tool call
 
-The collapse state is read from a live assistant row, so the tool view can never desync from the reasoning view. Pi's own `Thinking blocks: hidden/visible` status caption is suppressed (with every tool row visibly collapsing, the toggle is self-evident). Plain terminal scrolling is never touched: traceline requests no mouse reporting.
+The tool view reads its state from the live assistant row. It cannot get out of sync with the reasoning view. Traceline hides Pi's `Thinking blocks: hidden/visible` caption because the changing tool rows already show the state.
 
-Size thresholds are overridable via the family config convention (`~/.pi/agent/pi-traceline.json` or `<cwd>/.pi/pi-traceline.json`):
+Traceline does not enable mouse reporting or change terminal scrolling.
+
+## Find large tool results
+
+Completed rows show their result size on a shared right edge. This makes unusually large results easy to spot.
+
+Results use these colours by default:
+
+- dim below 10k characters
+- warning colour from 10k characters
+- error colour from 50k characters
+
+Results under 100 characters stay hidden unless another row in the same block has a visible size. File changes show diff counts instead of result size.
+
+Set different thresholds in `~/.pi/agent/pi-traceline.json` or `<project>/.pi/pi-traceline.json`:
 
 ```json
 { "sizeWarningChars": 10000, "sizeErrorChars": 50000 }
 ```
 
-## How to read a row
+## Read command rows
 
-- **Status lives in the bullet** (`›`): green success, blue running, red error. Healthy rows keep every discriminator neutral bold; a *failed* call also tints its verb, bash head command, and basename error-red, so a failure is more than one red glyph in a dim wall.
-- **A dim `▏` rail** opens every row, and the block indents one gutter under the prose margin, so consecutive calls fuse into one visible block: block identity from indentation and one character of layout, not painted backgrounds.
-- **The result-size cell** (`1.4k ch`, in the family number grammar) is severity-tinted: dim while healthy, warning-coloured at ≥10k ch, error-coloured at ≥50k ch, so an over-large output jumps out of the column. Results under 100 ch show no cell, but the floor is block-scoped: if any row in a contiguous block clears it, every completed row in the block shows its cell, keeping the right edge aligned.
-- **Diff stats** on `edit` and `write` rows show `+N -M` with zero sides dropped (`+5`, not `+5 -0`), inline on the basename (§9.5) the way a read shows its `:line-range` (add-green / remove-red). The magnitude rides the file it changed rather than a right column, so no gap opens between path and change, and the near-noise size cell is dropped (a mutation opts out of the block's fact columns). `write` stats come from a pre-execution snapshot; restored rows not seen live may show no diff.
-- **Record facts** lead bash rows that changed shared state beyond the working tree (`git commit`/`push`, `gh pr merge`/`close`/`create`, `gh issue close`, `gh release create`, `npm publish`): the row graduates to a verb-led outcome (`pushed main $ git push`, `merged PR #87 $ gh pr merge 87 --squash`), with the command trailing as provenance behind its `$`. Facts are parsed from success evidence the tool actually *reported*, so a row leads with an outcome exactly when there demonstrably was one. When output is a targetless verified state such as `MERGED` from `gh pr view 826 --json state`, the explicit checked target can supply the PR number; the outcome still never comes from arguments alone. Each fact wears the ink of what it states (success-toned bold; a sha stays dim as audit data; a forced push tints warning), per fact rather than per row: a failed push after a good commit shows a green `committed` on a red row. On narrow rows whole facts drop oldest-first, and the headline survives truncation: the middle cut lands in the command. A record row's size cell is suppressed as noise unless the output reaches warning severity.
-
-Rendering reuses Pi's own tool-call renderer for most tools, so accented paths, warning line ranges, and custom-tool renderers track Pi's defaults; traceline's own ink is theme-derived and its unstyled spans demote to one dim supporting grey. The full visual grammar is the family design language: see [`docs/design-language.md`](../../docs/design-language.md) §9.
-
-## Bash rows
-
-A bash row anchors on a bold `$`, then bolds the head word of every command that informs, and dims everything else (arguments, connectors, redirects, heredoc markers) to the one supporting grey:
+A command starts with `$`. Traceline highlights the commands that carry meaning and dims arguments, redirects and plumbing.
 
 ```
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5  1.4k ch
 ```
 
-The bold is rationed to commands that carry signal (measured over a 51k-invocation corpus; see [`scripts/dev/bash-corpus/`](../../scripts/dev/bash-corpus/)):
+Multiline commands fit on one line. A dim `↵` marks each original line break. Traceline removes common boilerplate such as a leading `set -euo pipefail` and the bash tool's `(timeout Ns)` suffix. Use `Ctrl+T` to see the complete command.
 
-- `cd … &&` preambles and `echo`/`true`/`false`/`printf`/`exit` plumbing (`|| true`, `&& echo done`) stay dim whenever a real command is present (a leading `set -…` hygiene run drops outright, reclaiming its width; see below); a row that is *nothing but* preamble or plumbing keeps its first head, so `$ cd /tmp` never goes dark
-- `&&`, `||`, `;` and flattened line breaks start new commands whose heads bold; pipes and redirects continue one (`| head -240` is a filter and stays dim)
-- sequencers inside quoted scripts are data (`python3 -c '…'` bolds `python3` once and nothing inside the string), and heredoc bodies stay inert
-
-Multiline commands (heredocs, inline scripts, chained pipelines) flatten into the one trace line with a dim `↵` marking each original break. Two kinds of near-constant boilerplate are dropped so the real command keeps the width: the `(timeout Ns)` suffix, and a leading `set -…` hygiene run (`set -euo pipefail`, `set -e`) that never discriminates one row from another. The full invocation is one `Ctrl+T` away.
-
-## Repetition folds instead of re-printing
-
-The informative diff between adjacent rows is often small while a shared prefix dominates, so three folds keep the trace skimmable:
+Successful commands can lead with a verified outcome:
 
 ```
-  ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5  1.4k ch
-  ▏ › $ ⋯ npm run typecheck                                           14.2k ch
-  ▏ › read ~/projects/pine-of…dex.ts:1-200,201-400,401-600  3 calls · 51.1k ch
+  ▏ › committed a1b2c3d $ git commit -m "Fix parser"
+  ▏ › pushed main $ git push
+  ▏ › merged PR #87 $ gh pr merge 87 --squash
 ```
 
-- **Repeated situating preambles** collapse to a dim `⋯`. A bash row's *leading preamble run* is the situating throat-clearing at its head: `cd <dir>`, bare `VAR=…`/`export` assignments, and `set -…` hygiene, across `&&`, `;` or `↵` breaks (pi's bash tool is stateless per call, so agents re-`cd` on every call). The `set -…` part drops outright, and the remaining `cd`/assignment context folds to a `⋯` when it repeats the previous bash row's, whatever separator either row was written with. The `⋯` absorbs the whole run and its separator (`⋯ npm test`, not `⋯ && npm test`), a distinct context prints once, and a `⋯` never points across visible prose.
-- **Paginated reads** of one file fold into a single row with the combined ranges, call count, and total size. Anything visible between the reads breaks the fold; `Ctrl+T`'s native view restores the individual rows.
-- **Collapsed thinking previews** render as `Thinking: <first reasoning line> ... (N lines)`, with adjacent label runs coalesced, and each tool row sits tight under the preview that motivated it, so each thought→action couplet reads as one unit.
+Traceline only shows an outcome when the tool output proves it happened. It does not treat the command arguments as proof.
 
-## Reading the end of the line
+## Keep repeated work compact
 
-The discriminating part of a row usually lives at the tail (the basename plus `:range`, the operative end of a pipeline) while the head is boilerplate. So instead of a trailing ellipsis that deletes the signal, traceline:
+Traceline folds adjacent rows when repetition would hide the useful difference:
 
-- **tildifies** home directories to reclaim width before truncating (OSC 8 hyperlink URLs stay intact, so click targets keep working)
-- **middle-truncates** with a dimmed `…` at deterministic, block-scoped columns: every row in a block shares one body budget, so ellipses and tail edges line up down the block and the tail always survives
-- **collapses cwd to a dim `./`** on plain file reads, edits, and writes (`~/projects/site/src/pages/product.astro` renders as `./src/pages/product.astro` when the row ran in `~/projects/site`); paths outside cwd keep their tildified absolute form, so the asymmetry itself says in-repo vs out-of-repo
-- **dims the boring prefix**: the block's common directory prefix or the cwd prefix dims, and the divergent tails render bold
+- repeated `cd`, environment assignment and setup prefixes become `⋯`
+- paginated reads of one file become one row with all ranges, the call count and total size
+- adjacent collapsed thinking labels become one preview
+
+Visible prose between calls stops a fold. Pi's full view always keeps the original rows.
+
+## Keep the useful part visible
+
+Traceline shortens rows before they reach the terminal edge. It:
+
+- changes the home directory to `~`
+- changes the current working directory to `./` for file reads and changes
+- dims common path prefixes
+- removes the middle of long rows so the basename, line range or final command stays visible
+- uses one width for a block so columns and ellipses line up
 
 ```
-  ▏ › read ~/projects/pine-of-glass/…/pi-traceline/README.md:1-300        3.8k ch
-  ▏ › read ~/projects/pine-of-glass/…/pi-traceline/index.ts:1-200        18.5k ch
-  ▏ › $ cd ~/projects/pine-of-glass && rm -f docs/img/…-native.png        0.0k ch
+  ▏ › read ~/projects/pine-of-glass/…/pi-traceline/README.md:1-300   3.8k ch
+  ▏ › read ~/projects/pine-of-glass/…/pi-traceline/index.ts:1-200  18.5k ch
 ```
 
-## How it works
+## Understand colours and status
 
-- On `session_start` it captures the real TUI and wraps `requestRender`, then patches the shared tool-row component prototype's `render` the moment a tool row exists (and the assistant-row prototype, for collapsed-thinking previews). The patches are versioned and idempotent across reloads and session resumes.
-- While reasoning is shown, `render` defers to Pi's original implementation unchanged. While reasoning is hidden, it emits the single trace line.
-- Any failure inside the one-line path falls back to Pi's original `render`, so the extension can never break a frame.
-- Nothing in Pi's `node_modules` is modified, so it survives `pi update`.
+The `›` bullet shows status: blue while running, green after success and red after failure. Failed rows also colour the action and main target red, so the failure does not depend on one small glyph.
+
+The dim `▏` rail joins consecutive tool calls into a visible block. Traceline uses theme-derived colours rather than fixed terminal colours.
+
+Read the [family design language](../../docs/design-language.md#9-trace-rows) for the full rendering rules.
+
+## How Traceline works
+
+Traceline wraps Pi's tool-row renderer after the session starts. When reasoning is visible, it uses Pi's native renderer unchanged. When reasoning is hidden, it renders the compact trace.
+
+If compact rendering fails, Traceline falls back to Pi's native row. It does not modify Pi's `node_modules`, so it survives `pi update`.


### PR DESCRIPTION
## Summary

- cut the Traceline README from 1,579 to 769 words
- lead with the user need, control and core trace format
- split dense implementation detail into short, task-focused sections
- apply GOV.UK plain-English and formatting guidance
- link detailed rendering rules to the existing design language

## Checks

- `npm run check` (167 tests passed)