### PR TITLE
traceline: group adjacent thinking previews

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -434,12 +434,21 @@ punctuate the wall; ambient green stays purged.
 
 ### 9.11 Collapsed thinking
 
-A collapsed thinking block stays compact without hiding its sequence. Each
+A collapsed thinking run stays compact without hiding its sequence. Each
 non-empty source line renders as `Thinking: <line>`. One or more consecutive
-empty source lines render as one blank line, preserving paragraph boundaries
-without reproducing arbitrary vertical whitespace. Distinct adjacent thinking
-blocks keep distinct previews. Only native `Thinking...` labels that have no
-matching reasoning payload fold as duplicates.
+empty source lines within a thinking block render as one blank line, preserving
+paragraph boundaries without reproducing arbitrary vertical whitespace.
+
+Adjacent thinking blocks form one logical multiline preview. The first native
+label expands to every preview line in the run; later labels and the native
+spacers between them disappear. Empty or whitespace-only thinking fragments do
+not render and do not break the run. Any non-thinking content entry, including
+text, a tool call or another semantic block, ends the run and keeps the native
+boundary before the next preview. A single thinking block renders exactly as it
+does outside a run. A non-empty payload that cannot yield a sanitized preview
+keeps one native label inside the run; consecutive such blocks fold. Native
+`Thinking...` labels with no matching content metadata retain the safe
+duplicate-label fallback.
 
 With traceline loaded, Ctrl+T's effect is self-evident: every tool row collapses
 to a trace line or expands back. So traceline suppresses pi's

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,6 +74,7 @@ moved.
 | `[Context]`/`[Skills]`/… resource headers still render in the startup transcript shape matched by `RESOURCE_HEADER_RE` | contextimate block insertion point |
 | `ToolExecutionComponent` (or successor) instances satisfy `isToolRow`: `render`, `setExpanded`, `toolName` in instance; prototype is patchable | traceline prototype patch |
 | Assistant message component satisfies `isAssistantRow`: `setHideThinkingBlock` fn + `hideThinkingBlock` boolean | traceline collapse-state source of truth |
+| A collapsed `AssistantMessageComponent` skips empty thinking blocks, emits one label per non-empty block, and keeps native spacers across tool and text boundaries | traceline grouped thinking previews |
 | `ExtensionAPI` exposes `getActiveTools()` ⊆ `getAllTools()` by name; `ToolInfo` has `name`, `description`, `parameters`, `sourceInfo{scope,source,origin,path}`, `promptGuidelines` | contextimate tools section |
 
 Where instantiating real components is impractical, the contract test asserts on the
@@ -100,6 +101,10 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   are user-facing grammar).
 - **`toolStatus`**: result+`isError` → error; result+complete → success; partial/none →
   running.
+- **Collapsed thinking previews**: three adjacent non-empty blocks form one tight
+  multiline run; empty thinking fragments do not consume labels or break adjacency;
+  text, tools and other semantic content do; single-block rendering, fallback labels,
+  OSC marks, paragraph breaks and width bounds remain unchanged.
 
 ### contextimate
 
@@ -150,8 +155,9 @@ and compares against checked-in golden files (`tests/fixtures/goldens/*.txt`).
   PR like any code change. The golden diff *is* the review surface for issues #9's relabel.
 - Traceline gets a narrow golden: `oneLine()` output (ANSI stripped) for a table of
   synthetic comps (read with range, bash with `cd …`, MCP tool, error status, missing
-  renderer fallback) at width 80; this pins the row grammar without touching Pi's
-  renderer. The stand-ins preserve causal runtime invariants: native renderer text derives
+  renderer fallback) and one three-block collapsed thinking run at width 80; this pins
+  the row grammar without touching Pi's renderer. The stand-ins preserve causal runtime
+  invariants: native renderer text derives
   from the same arguments, following tool rows have matching assistant `toolCall` blocks,
   and write results follow a pre-execution snapshot. The contract suite separately proves
   that the duck types match real Pi.
@@ -166,9 +172,10 @@ and compares against checked-in golden files (`tests/fixtures/goldens/*.txt`).
 `npm run test:smoke` launches real `pi` processes in isolated tmux sessions with no
 model call required:
 
-- `test:smoke:traceline` resumes a crafted session with collapsed empty,
-  whitespace-only and informative thinking blocks. It requires the informative preview
-  and prompt to render, then proves Pi still handles `/quit`. A 45-second hard watchdog
+- `test:smoke:traceline` resumes a crafted session with three adjacent collapsed
+  thinking blocks and empty or whitespace-only fragments interleaved. It requires all
+  three preview rows to render consecutively, then proves Pi still handles `/quit`. A
+  45-second hard watchdog
   kills only the uniquely launched fixture process if rendering blocks, so the regression
   cannot leave a hot orphan behind.
 - The full startup smoke checks that the `[Contextimate]` block renders, that

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -99,9 +99,9 @@ Traceline folds adjacent rows when repetition would hide the useful difference:
 
 - repeated `cd`, environment assignment and setup prefixes become `⋯`
 - paginated reads of one file become one row with all ranges, the call count and total size
-- collapsed thinking keeps each reasoning line and paragraph break visible
+- adjacent collapsed thinking blocks become one multiline preview, with each reasoning line and paragraph break kept visible
 
-Visible prose between calls stops a fold. Pi's full view always keeps the original rows.
+Text, tool calls and other content separate thinking previews. Visible prose between tool calls stops a row fold. Pi's full view always keeps the original rows.
 
 ## Keep the useful part visible
 

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -104,10 +104,10 @@ import { dedupeThinkingLabels } from "./thinking-preview.ts";
  * Repetition the model emits is folded rather than re-printed (issue #14): a bash row
  * whose `cd <dir> && ` preamble repeats the previous bash row's renders it as a dim `⋯`,
  * giving the width back to the part of the command that differs; consecutive reads paging
- * through one file collapse into a single `read path:1-200,201-400 · 2 calls` row; and an
- * collapsed thinking blocks become informative `Thinking: <reasoning line>` previews.
- * Multiline reasoning keeps each non-empty source line, and a source blank line remains
- * one blank display line, so distinct thought steps do not disappear into a line count.
+ * through one file collapse into a single `read path:1-200,201-400 · 2 calls` row; and
+ * adjacent collapsed thinking blocks become one informative multiline preview.
+ * Multiline reasoning keeps each non-empty source line and source blank lines, while
+ * text, tool calls and other semantic content keep separate thinking runs separate.
  *
  * Spacing: one blank line before a tool group (restoring the spacer pi drops), none
  * between consecutive tools.
@@ -147,7 +147,7 @@ const ONE_LINE_CAPTURE_WIDTH = 10_000;
 const LINE_BREAK_MARK = "\u21b5"; // ↵ — marks a real newline in a flattened invocation
 const PREAMBLE_MARK = "\u22ef"; // ⋯ — stands in for a preamble identical to the row above
 const TRACELINE_PATCH_VERSION = 27;
-const TRACELINE_ASSISTANT_PATCH_VERSION = 3;
+const TRACELINE_ASSISTANT_PATCH_VERSION = 4;
 
 // --- theme-derived ink (design language §3) --------------------------------------------
 // The live Theme handle is captured at session_start; before that (and in unit tests

--- a/extensions/pi-traceline/thinking-preview.ts
+++ b/extensions/pi-traceline/thinking-preview.ts
@@ -6,15 +6,25 @@ import { ELLIPSIS } from "../_lib/style.ts";
 
 const PREVIEW_RENDER_WIDTH = 10_000;
 
-// pi renders one collapsed label per thinking *block*. Traceline replaces each label
-// with the block's reasoning lines: every non-empty source line gets an informative
-// `Thinking: …` preview, while one or more consecutive empty source lines become one
-// blank display line. This preserves thought steps and paragraph boundaries without
-// reproducing arbitrary vertical whitespace. If Pi emits labels without corresponding
-// reasoning payloads, the old duplicate-label fold remains as a safe fallback. OSC 133
-// zone marks on dropped fallback labels are transplanted onto the last kept line.
+// pi renders one collapsed label per non-empty thinking block. Traceline replaces a
+// contiguous run of those labels with one logical multiline preview: every non-empty
+// source line gets an informative `Thinking: …` row, source paragraph breaks survive,
+// and Pi's spacers between provider-split adjacent blocks disappear. Any non-thinking
+// content entry ends the run, even when Pi does not render that entry here (a tool call,
+// for example). Empty thinking fragments neither render nor break adjacency. Payloads
+// that cannot yield a safe preview keep one native label; labels without corresponding
+// payloads retain the duplicate-label fallback. OSC marks move to the last kept run line.
 function oscSequences(line: string): string {
   return (line.match(OSC_SEQUENCE) ?? []).join("");
+}
+
+function insertAfterLeadingOsc(line: string, marks: string): string {
+  let end = 0;
+  OSC_SEQUENCE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = OSC_SEQUENCE.exec(line)) && match.index === end) end = OSC_SEQUENCE.lastIndex;
+  OSC_SEQUENCE.lastIndex = 0;
+  return `${line.slice(0, end)}${marks}${line.slice(end)}`;
 }
 
 function nativeHiddenThinkingLabel(comp: AssistantRowDataLike): string {
@@ -80,18 +90,53 @@ function thinkingPreviewForTrace(text: string): ThinkingPreview[] {
   return previews;
 }
 
-function thinkingPreviewBlocks(comp: AssistantRowDataLike): ThinkingPreview[][] {
+const FALLBACK_LABEL = Symbol("fallback-label");
+type ThinkingPreviewRow = ThinkingPreview | typeof FALLBACK_LABEL;
+
+type ThinkingLabelPlan = {
+  rows: ThinkingPreviewRow[];
+  emitsGroup: boolean;
+};
+
+function thinkingLabelPlans(comp: AssistantRowDataLike): ThinkingLabelPlan[] {
   const content = comp.lastMessage?.content;
   if (!Array.isArray(content)) return [];
-  const previews: ThinkingPreview[][] = [];
+
+  const plans: ThinkingLabelPlan[] = [];
+  let blocks: ThinkingPreview[][] = [];
+  const flush = () => {
+    if (blocks.length === 0) return;
+    const rows: ThinkingPreviewRow[] = [];
+    for (const previews of blocks) {
+      if (previews.some((preview) => preview !== undefined)) {
+        rows.push(...previews);
+      } else if (rows.at(-1) !== FALLBACK_LABEL) {
+        // A non-empty payload that sanitizes to nothing still needs one native label.
+        // Consecutive such blocks keep the old duplicate-label fold inside the run.
+        rows.push(FALLBACK_LABEL);
+      }
+    }
+    for (let i = 0; i < blocks.length; i++) {
+      plans.push({ rows, emitsGroup: i === 0 });
+    }
+    blocks = [];
+  };
+
   for (const block of content) {
-    if (block?.type !== "thinking" || typeof block.thinking !== "string") continue;
-    // Pi does not render a collapsed label for empty or whitespace-only thinking. Skip
-    // those blocks here too, so the next native label stays paired with its real trace.
-    if (block.thinking.trim().length === 0) continue;
-    previews.push(thinkingPreviewForTrace(block.thinking));
+    if (block?.type === "thinking") {
+      if (typeof block.thinking === "string" && block.thinking.trim().length > 0) {
+        // Pi skips empty thinking blocks, so only rendered blocks receive a label plan.
+        // Empty fragments still leave `blocks` open and therefore preserve adjacency.
+        blocks.push(thinkingPreviewForTrace(block.thinking));
+      }
+      continue;
+    }
+    // Content order is the semantic authority. In particular, an invisible toolCall
+    // separates runs even though native assistant rendering may show only a blank spacer.
+    flush();
   }
-  return previews;
+  flush();
+  return plans;
 }
 
 function replaceVisibleThinkingLabel(line: string, displayLabel: string, width?: number): string {
@@ -109,43 +154,87 @@ function replaceVisibleThinkingLabel(line: string, displayLabel: string, width?:
 
 export function dedupeThinkingLabels(comp: AssistantRowDataLike, lines: string[], width?: number): string[] {
   const label = nativeHiddenThinkingLabel(comp);
-  const previewBlocks = thinkingPreviewBlocks(comp);
+  const labelPlans = thinkingLabelPlans(comp);
   const out: string[] = [];
-  let previewIndex = 0;
+  let planIndex = 0;
   let lastFallbackLabelAt = -1; // index in `out`, with only blanks after it
-  let salvaged = "";
+  let activePreviewLineAt = -1;
+  let pendingMarksAt = -1;
+  let pendingMarks = "";
+  const flushPendingMarks = () => {
+    if (pendingMarks && pendingMarksAt >= 0 && pendingMarksAt < out.length) {
+      // Keep marks already carried by the retained native row first, then transplant
+      // later dropped marks before its styling/text. Reversing OSC 133 A/B order can
+      // produce malformed terminal zones.
+      out[pendingMarksAt] = insertAfterLeadingOsc(out[pendingMarksAt]!, pendingMarks);
+    }
+    pendingMarksAt = -1;
+    pendingMarks = "";
+  };
+  const queueMarks = (target: number, marks: string) => {
+    if (!marks || target < 0) return;
+    if (pendingMarksAt !== target) flushPendingMarks();
+    pendingMarksAt = target;
+    pendingMarks += marks;
+  };
+
   for (const line of lines) {
     const visible = stripAnsi(line).trim();
     if (visible === label) {
-      const previews = previewBlocks[previewIndex++];
-      if (previews?.some((preview) => preview !== undefined)) {
+      const plan = labelPlans[planIndex++];
+      if (plan) {
         lastFallbackLabelAt = -1;
-        let firstPreview = true;
-        for (const preview of previews) {
-          if (preview === undefined) {
+        if (!plan.emitsGroup) {
+          // Pi inserts a spacer between visible thinking blocks. The first label already
+          // emitted this whole adjacent group, so remove only the blanks immediately
+          // before its now-redundant continuation label. Transplant dropped OSC marks to
+          // the group's last preview now, never across a later semantic boundary.
+          let spacerMarks = "";
+          while (out.length > 0 && stripAnsi(out.at(-1)!).trim().length === 0) {
+            spacerMarks = `${oscSequences(out.pop()!)}${spacerMarks}`;
+          }
+          queueMarks(activePreviewLineAt, spacerMarks + oscSequences(line));
+          continue;
+        }
+
+        flushPendingMarks();
+        let firstRow = true;
+        for (const row of plan.rows) {
+          if (row === undefined) {
             out.push("");
             continue;
           }
           // Only the first replacement inherits the native row's OSC zone marks.
           // Synthetic continuation rows keep its SGR styling but must not duplicate OSC.
-          const template = firstPreview ? line : line.replace(OSC_SEQUENCE, "");
-          out.push(replaceVisibleThinkingLabel(template, `Thinking: ${preview}`, width));
-          firstPreview = false;
+          const template = firstRow ? line : line.replace(OSC_SEQUENCE, "");
+          out.push(row === FALLBACK_LABEL ? template : replaceVisibleThinkingLabel(template, `Thinking: ${row}`, width));
+          firstRow = false;
         }
+        activePreviewLineAt = out.length - 1;
         continue;
       }
+
       if (lastFallbackLabelAt >= 0) {
-        while (out.length > lastFallbackLabelAt + 1) salvaged += oscSequences(out.pop()!);
-        salvaged += oscSequences(line);
+        let spacerMarks = "";
+        while (out.length > lastFallbackLabelAt + 1) {
+          spacerMarks = `${oscSequences(out.pop()!)}${spacerMarks}`;
+        }
+        queueMarks(lastFallbackLabelAt, spacerMarks + oscSequences(line));
         continue;
       }
+      flushPendingMarks();
+      activePreviewLineAt = -1;
       lastFallbackLabelAt = out.length;
       out.push(line);
       continue;
     }
-    if (visible.length > 0) lastFallbackLabelAt = -1;
+    if (visible.length > 0) {
+      flushPendingMarks();
+      activePreviewLineAt = -1;
+      lastFallbackLabelAt = -1;
+    }
     out.push(line);
   }
-  if (salvaged && out.length > 0) out[out.length - 1] = `${salvaged}${out[out.length - 1]}`;
+  flushPendingMarks();
   return out;
 }

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -194,7 +194,7 @@ test("real AssistantMessageComponent satisfies traceline's assistant duck type",
   assert.equal(peek.hideThinkingBlock, true, "hideThinkingBlock no longer mirrors setHideThinkingBlock — collapse state desyncs");
 });
 
-test("adjacent thinking blocks double the collapsed label natively; traceline gives each a preview", () => {
+test("adjacent thinking blocks get native labels; traceline groups their previews", () => {
   pi.initTheme(undefined, false);
   const component = new pi.AssistantMessageComponent(assistantMessage([
     { type: "thinking", thinking: "first reasoning segment" },
@@ -205,16 +205,16 @@ test("adjacent thinking blocks double the collapsed label natively; traceline gi
   const native = component.render(80);
   const labelCount = (lines: string[]) =>
     lines.filter((line) => traceline.stripAnsi(line).trim() === "Thinking...").length;
-  // The seam itself (issue #14 №3): pi renders one collapsed label per thinking *block*.
-  // If this drops to 1, pi fixed it upstream — retire dedupeThinkingLabels.
-  assert.equal(labelCount(native), 2, "adjacent thinking blocks no longer double the label — dedupe may be retirable");
+  // The seam itself (issue #14 №3): pi renders one collapsed label per non-empty
+  // thinking block. A change here requires re-checking preview-to-label alignment.
+  assert.equal(labelCount(native), 2, "Pi's collapsed-label cardinality changed");
 
   const deduped = traceline.dedupeThinkingLabels(component as never, native, 80);
-  assert.equal(labelCount(deduped), 0, "dedupe should replace native placeholders with trace previews");
+  assert.equal(labelCount(deduped), 0, "native placeholders should become trace previews");
   assert.deepEqual(
-    deduped.map((line) => traceline.stripAnsi(line).trim()).filter(Boolean),
-    ["Thinking: first reasoning segment", "Thinking: second reasoning segment"],
-    "each source thinking block must remain visible",
+    deduped.map((line) => traceline.stripAnsi(line).trim()),
+    ["", "Thinking: first reasoning segment", "Thinking: second reasoning segment"],
+    "adjacent source blocks remain visible without Pi's inter-label spacer",
   );
 
   // pi marks the message's first and last lines with OSC 133 zone marks; the dedupe must

--- a/tests/contract/pi-thinking-preview.test.ts
+++ b/tests/contract/pi-thinking-preview.test.ts
@@ -1,5 +1,5 @@
-// Contract test against Pi's installed AssistantMessageComponent. Empty thinking blocks
-// are intentionally real payloads here, not a mock of how Pi might render them.
+// Contract tests against Pi's installed AssistantMessageComponent. These use real
+// payloads and native spacing, not a mock of how Pi might render thinking blocks.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -7,6 +7,16 @@ import * as pi from "@earendil-works/pi-coding-agent";
 
 import { internals as traceline } from "../../extensions/pi-traceline/index.ts";
 import { assistantMessage } from "../helpers.ts";
+
+function collapsedLines(content: Parameters<typeof assistantMessage>[0]): { native: string[]; preview: string[] } {
+  pi.initTheme(undefined, false);
+  const component = new pi.AssistantMessageComponent(assistantMessage(content));
+  component.setHideThinkingBlock(true);
+  const native = component.render(80);
+  const preview = traceline.dedupeThinkingLabels(component as never, native, 80);
+  const normalize = (lines: string[]) => lines.map((line) => traceline.stripAnsi(line).trim());
+  return { native: normalize(native), preview: normalize(preview) };
+}
 
 test("empty thinking blocks are skipped natively and do not shift Traceline previews", () => {
   pi.initTheme(undefined, false);
@@ -32,4 +42,58 @@ test("empty thinking blocks are skipped natively and do not shift Traceline prev
     visibleDeduped.includes("Thinking: informative reasoning survives"),
     `empty blocks consumed the informative preview: ${JSON.stringify(visibleDeduped)}`,
   );
+});
+
+test("three adjacent native blocks become one multiline preview across empty fragments", () => {
+  const { native, preview } = collapsedLines([
+    { type: "thinking", thinking: "first adjacent step" },
+    { type: "thinking", thinking: "" },
+    { type: "thinking", thinking: " \n\t " },
+    { type: "thinking", thinking: "second adjacent step" },
+    { type: "thinking", thinking: "third adjacent step" },
+  ]);
+
+  assert.equal(
+    native.filter((line) => line === "Thinking...").length,
+    3,
+    "Pi's label-per-non-empty-block contract changed: re-check grouping",
+  );
+  assert.deepEqual(preview, [
+    "",
+    "Thinking: first adjacent step",
+    "Thinking: second adjacent step",
+    "Thinking: third adjacent step",
+  ]);
+});
+
+test("tool calls and text keep native boundaries between thinking runs", () => {
+  const { preview } = collapsedLines([
+    { type: "thinking", thinking: "before tool" },
+    { type: "toolCall", id: "contract-call", name: "read", arguments: {} },
+    { type: "thinking", thinking: "after tool" },
+    { type: "text", text: "visible bridge" },
+    { type: "thinking", thinking: "after text" },
+  ]);
+
+  assert.deepEqual(preview, [
+    "",
+    "Thinking: before tool",
+    "",
+    "Thinking: after tool",
+    "",
+    "visible bridge",
+    "Thinking: after text",
+  ]);
+});
+
+test("a single collapsed block keeps multiline and paragraph rendering", () => {
+  const { preview } = collapsedLines([
+    { type: "thinking", thinking: "single first line\n\nsingle second line" },
+  ]);
+  assert.deepEqual(preview, [
+    "",
+    "Thinking: single first line",
+    "",
+    "Thinking: single second line",
+  ]);
 });

--- a/tests/fixtures/goldens/traceline-rows-120.txt
+++ b/tests/fixtures/goldens/traceline-rows-120.txt
@@ -4,8 +4,8 @@ Let me look at the failing suite.
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5                                          1.4k ch
 
 Thinking: Checking the typecheck before the next command.
-
 Thinking: The previous test output was noisy.
+Thinking: Reading the paginated file next.
   ▏ › $ ⋯ npm run typecheck                                                                                   14.2k ch
   ▏ › read ~/projects/pine-of-glass/extensions/pi-cachemire/index.ts:1-200,201-400,401-600          3 calls · 51.1k ch
   ▏ › $ ⋯ rm -f /tmp/pog-scratch.txt                                                                           0.0k ch

--- a/tests/fixtures/goldens/traceline-rows-80.txt
+++ b/tests/fixtures/goldens/traceline-rows-80.txt
@@ -4,8 +4,8 @@ Let me look at the failing suite.
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5  1.4k ch
 
 Thinking: Checking the typecheck before the next command.
-
 Thinking: The previous test output was noisy.
+Thinking: Reading the paginated file next.
   ▏ › $ ⋯ npm run typecheck                                           14.2k ch
   ▏ › read ~/projects/pine-of…dex.ts:1-200,201-400,401-600  3 calls · 51.1k ch
   ▏ › $ ⋯ rm -f /tmp/pog-scratch.txt                                   0.0k ch

--- a/tests/smoke/traceline-empty-thinking-smoke.mjs
+++ b/tests/smoke/traceline-empty-thinking-smoke.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// Resume a real Pi session whose assistant message contains empty and whitespace-only
-// thinking blocks before a real collapsed trace. A past Traceline implementation entered
-// a synchronous loop while preparing previews for the empty block. Every subprocess call
-// is bounded, and the uniquely launched Pi is killed on timeout so the smoke cannot leave
-// a hot orphan behind.
+// Resume a real Pi session whose assistant message contains three adjacent thinking
+// blocks with empty and whitespace-only fragments interleaved. The collapsed preview must
+// stay tight and aligned. A past Traceline implementation entered a synchronous loop on
+// an empty block, so every subprocess call is bounded and the uniquely launched Pi is
+// killed on timeout.
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,8 +13,12 @@ import { fileURLToPath } from "node:url";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const extensionPath = join(repoRoot, "extensions", "pi-traceline", "index.ts");
 const tmuxSession = `pog-empty-thinking-${process.pid}`;
-const sentinel = "EMPTY_THINKING_RESUME_SENTINEL";
-const preview = "Thinking: informative reasoning survives";
+const sentinel = "GROUPED_THINKING_RESUME_SENTINEL";
+const previews = [
+  "Thinking: first adjacent reasoning step",
+  "Thinking: second adjacent reasoning step",
+  "Thinking: third adjacent reasoning step",
+];
 const hardDeadline = Date.now() + 45_000;
 let launchedPid;
 let fixtureHome;
@@ -80,9 +84,11 @@ function sessionEntries(cwd) {
       message: {
         role: "assistant",
         content: [
+          { type: "thinking", thinking: "first adjacent reasoning step" },
           { type: "thinking", thinking: "" },
           { type: "thinking", thinking: " \n\t\n " },
-          { type: "thinking", thinking: "informative reasoning survives" },
+          { type: "thinking", thinking: "second adjacent reasoning step" },
+          { type: "thinking", thinking: "third adjacent reasoning step" },
           { type: "text", text: sentinel },
         ],
         api: "anthropic-messages",
@@ -172,14 +178,19 @@ try {
 
   while (Date.now() < hardDeadline && hasTmuxSession()) {
     lastPane = capturePane();
-    if (lastPane.includes(sentinel) && lastPane.includes(preview)) break;
+    if (lastPane.includes(sentinel) && previews.every((preview) => lastPane.includes(preview))) break;
     sleep(250);
   }
   if (!lastPane.includes(sentinel)) {
     throw new Error(`resumed session did not render before the hard watchdog\n${lastPane}`);
   }
-  if (!lastPane.includes(preview)) {
-    throw new Error(`collapsed preview lost alignment after empty thinking blocks\n${lastPane}`);
+  if (!previews.every((preview) => lastPane.includes(preview))) {
+    throw new Error(`collapsed preview lost adjacent thinking content\n${lastPane}`);
+  }
+  const paneLines = lastPane.split("\n").map((line) => line.trim());
+  const previewRows = previews.map((preview) => paneLines.indexOf(preview));
+  if (!previewRows.every((row, index) => index === 0 || row === previewRows[index - 1] + 1)) {
+    throw new Error(`adjacent thinking previews were separated by native spacers\n${lastPane}`);
   }
 
   run(["tmux", "send-keys", "-t", tmuxSession, "/quit", "Enter"], { timeoutMs: 2_000 });
@@ -187,7 +198,7 @@ try {
   while (Date.now() < exitDeadline && hasTmuxSession()) sleep(100);
   if (hasTmuxSession()) throw new Error("resumed Pi rendered but did not respond to /quit");
 
-  console.log("real-Pi empty-thinking resume smoke passed");
+  console.log("real-Pi grouped-thinking resume smoke passed");
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;

--- a/tests/traceline/goldens.test.ts
+++ b/tests/traceline/goldens.test.ts
@@ -1,7 +1,8 @@
 // Visual regression net for the one-line trace grammar (design language §10):
 // a realistic scripted sequence — repeated cd preambles, a dropped set-hygiene run, a
-// newline-preamble context fold, a paginated read run, healthy and ballooned outputs, a
-// flattened multiline command — rendered at 80 and 120 columns.
+// newline-preamble context fold, a grouped multiline thinking preview, a paginated read
+// run, healthy and ballooned outputs, and a flattened multiline command, rendered at 80
+// and 120 columns.
 // Colour is not under test (see docs/testing.md); structure, alignment, folding, and
 // wording are. Regenerate with UPDATE_GOLDENS=1 npm test and review the diff like code.
 import { test, beforeEach } from "node:test";
@@ -70,8 +71,11 @@ function prose(text: string, rows: ToolRowLike[]) {
   return { ...assistantBefore(rows, [{ type: "text", text }]), __prose: text };
 }
 
-function thinking(text: string, rows: ToolRowLike[]) {
-  return { ...assistantBefore(rows, [{ type: "thinking", thinking: text }], true), __thinking: true };
+function thinking(blocks: string[], rows: ToolRowLike[]) {
+  return {
+    ...assistantBefore(rows, blocks.map((text) => ({ type: "thinking", thinking: text })), true),
+    __thinkingBlocks: blocks.length,
+  };
 }
 
 beforeEach(() => {
@@ -113,7 +117,11 @@ test("one-line trace goldens at 80 and 120 columns", () => {
     const children = [
       prose("Let me look at the failing suite.", [testRun]),
       testRun,
-      thinking("Checking the typecheck before the next command.\n\nThe previous test output was noisy.", [typecheck, read1, read2, read3, cleanup]),
+      thinking([
+        "Checking the typecheck before the next command.",
+        "The previous test output was noisy.",
+        "Reading the paginated file next.",
+      ], [typecheck, read1, read2, read3, cleanup]),
       typecheck,
       read1,
       read2,
@@ -142,12 +150,15 @@ test("one-line trace goldens at 80 and 120 columns", () => {
           for (const line of renderTraceRow(child, width)) lines.push(stripAnsi(line));
           continue;
         }
-        const meta = child as { __prose?: string; __thinking?: boolean };
+        const meta = child as { __prose?: string; __thinkingBlocks?: number };
         if (meta.__prose !== undefined) {
           lines.push("", meta.__prose);
           continue;
         }
-        const previews = dedupeThinkingLabels(child, ["Thinking..."], width).map(stripAnsi);
+        const nativeLabels = Array.from({ length: meta.__thinkingBlocks ?? 1 }, (_, index) =>
+          index === 0 ? ["Thinking..."] : ["", "Thinking..."]
+        ).flat();
+        const previews = dedupeThinkingLabels(child, nativeLabels, width).map(stripAnsi);
         lines.push("", ...(previews.length > 0 ? previews : ["Thinking..."]));
       }
       return `${lines.join("\n")}\n`;

--- a/tests/traceline/repetition.test.ts
+++ b/tests/traceline/repetition.test.ts
@@ -1,8 +1,8 @@
 // Repetition folding + preamble reclaim (issue #14, design language §9.4): a leading
 // `set -…` hygiene run drops, the surviving `cd`/assignment context folds to a dim ⋯
-// when it repeats the previous bash row's, consecutive same-file reads fold into one
-// row, and collapsed Thinking... labels preserve reasoning lines. Comps are synthetic duck-type
-// stand-ins; the contract suite proves the duck types against the real installed pi.
+// when it repeats the previous bash row's, and consecutive same-file reads fold into one
+// row. Comps are synthetic duck-type stand-ins; the contract suite proves the duck types
+// against the real installed pi.
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { homedir } from "node:os";
@@ -18,7 +18,6 @@ const {
   bashPreambleRun,
   foldBashPreamble,
   readRun,
-  dedupeThinkingLabels,
   setTracelineChat,
   setTracelineThemeGetter,
 } = internals;
@@ -259,73 +258,4 @@ test("runs break on anything visible between the reads — and on a different fi
   const visible = stripAnsi(renderTraceRow(single, 120).at(-1)!);
   assert.ok(visible.includes("read ~/projects/demo/big-file.ts:1-200"), visible);
   assert.ok(!visible.includes("calls"), visible);
-});
-
-test("collapsed Thinking labels preserve reasoning lines and paragraph breaks", () => {
-  const comp = {
-    hiddenThinkingLabel: "Thinking...",
-    lastMessage: { content: [{ type: "thinking", thinking: "\n  **first reasoning line**\nsecond reasoning line" }] },
-  };
-  const paragraphComp = {
-    hiddenThinkingLabel: "Thinking...",
-    lastMessage: { content: [{ type: "thinking", thinking: "first paragraph\n\nsecond paragraph" }] },
-  };
-  const adjacentBlocks = {
-    hiddenThinkingLabel: "Thinking...",
-    lastMessage: { content: [
-      { type: "thinking", thinking: "first reasoning block" },
-      { type: "thinking", thinking: "second reasoning block" },
-    ] },
-  };
-  const noPreview = { hiddenThinkingLabel: "Thinking..." };
-  const L = "\x1b[3mThinking...\x1b[23m";
-  const P1 = "\x1b[3mThinking: first reasoning line\x1b[23m";
-  const P2 = "\x1b[3mThinking: second reasoning line\x1b[23m";
-
-  assert.deepEqual(dedupeThinkingLabels(comp, ["", L]), ["", P1, P2]);
-  assert.deepEqual(
-    dedupeThinkingLabels(paragraphComp, ["", L]),
-    ["", "\x1b[3mThinking: first paragraph\x1b[23m", "", "\x1b[3mThinking: second paragraph\x1b[23m"],
-    "two source newlines preserve one blank display line",
-  );
-  assert.deepEqual(
-    dedupeThinkingLabels(
-      { hiddenThinkingLabel: "Thinking...", lastMessage: { content: [{ type: "thinking", thinking: "first\n\n\nsecond" }] } },
-      [L],
-    ),
-    ["\x1b[3mThinking: first\x1b[23m", "", "\x1b[3mThinking: second\x1b[23m"],
-    "long blank runs collapse to one display line",
-  );
-  assert.deepEqual(
-    dedupeThinkingLabels(adjacentBlocks, ["", L, "", L]),
-    ["", "\x1b[3mThinking: first reasoning block\x1b[23m", "", "\x1b[3mThinking: second reasoning block\x1b[23m"],
-    "distinct adjacent thinking blocks keep both previews",
-  );
-  assert.deepEqual(dedupeThinkingLabels(noPreview, ["", L, "", L]), ["", L], "missing traces still fold Pi's duplicate labels");
-  assert.deepEqual(dedupeThinkingLabels(comp, ["just prose"]), ["just prose"]);
-
-  // Synthetic continuation lines inherit style but not OSC zone marks.
-  const marked = `\x1b]133;C\x07${L}`;
-  const out = dedupeThinkingLabels(comp, [marked]);
-  assert.equal(out.length, 2);
-  assert.ok(out[0]!.startsWith("\x1b]133;C\x07"), `native zone mark must survive: ${JSON.stringify(out)}`);
-  assert.equal((out.join("").match(/\x1b\]133;C\x07/g) ?? []).length, 1, "synthetic rows must not duplicate OSC marks");
-
-  // A custom hiddenThinkingLabel is respected.
-  const custom = { hiddenThinkingLabel: "Pondering…" };
-  assert.deepEqual(dedupeThinkingLabels(custom, ["Pondering…", "", "Pondering…"]), ["Pondering…"]);
-
-  const literalStar = dedupeThinkingLabels(
-    { hiddenThinkingLabel: "Thinking...", lastMessage: { content: [{ type: "thinking", thinking: "2 * 3 = 6" }] } },
-    [L],
-  )[0]!;
-  assert.equal(stripAnsi(literalStar).trim(), "Thinking: 2 * 3 = 6", "markdown rendering must preserve genuine stars");
-
-  const long = dedupeThinkingLabels(
-    { hiddenThinkingLabel: "Thinking...", lastMessage: { content: [{ type: "thinking", thinking: "a very long reasoning preview" }] } },
-    [L],
-    18,
-  )[0]!;
-  assert.ok(stripAnsi(long).length <= 18, `preview must respect row width: ${stripAnsi(long)}`);
-  assert.ok(stripAnsi(long).startsWith("Thinking:"), stripAnsi(long));
 });

--- a/tests/traceline/thinking-preview.test.ts
+++ b/tests/traceline/thinking-preview.test.ts
@@ -1,0 +1,193 @@
+// Collapsed-thinking preview grammar (design language §9.11): adjacent provider
+// fragments form one multiline run, while every non-thinking content entry is a
+// semantic boundary. The installed-Pi suite separately pins native label spacing.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { stripAnsi } from "../../extensions/_lib/ansi.ts";
+import { dedupeThinkingLabels } from "../../extensions/pi-traceline/thinking-preview.ts";
+
+const LABEL = "\x1b[3mThinking...\x1b[23m";
+const preview = (text: string) => `\x1b[3mThinking: ${text}\x1b[23m`;
+
+function thinkingComp(content: Array<Record<string, unknown>>) {
+  return { hiddenThinkingLabel: "Thinking...", lastMessage: { content } };
+}
+
+test("a single block preserves reasoning lines, paragraph breaks, and width", () => {
+  const multiline = thinkingComp([
+    { type: "thinking", thinking: "\n  **first reasoning line**\nsecond reasoning line" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(multiline, ["", LABEL]),
+    ["", preview("first reasoning line"), preview("second reasoning line")],
+  );
+
+  const paragraphs = thinkingComp([
+    { type: "thinking", thinking: "first paragraph\n\n\nsecond paragraph" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(paragraphs, [LABEL]),
+    [preview("first paragraph"), "", preview("second paragraph")],
+    "long source blank runs collapse to one display line",
+  );
+
+  const literalStar = dedupeThinkingLabels(
+    thinkingComp([{ type: "thinking", thinking: "2 * 3 = 6" }]),
+    [LABEL],
+  )[0]!;
+  assert.equal(stripAnsi(literalStar).trim(), "Thinking: 2 * 3 = 6", "markdown rendering preserves genuine stars");
+
+  const long = dedupeThinkingLabels(
+    thinkingComp([{ type: "thinking", thinking: "a very long reasoning preview" }]),
+    [LABEL],
+    18,
+  )[0]!;
+  assert.ok(stripAnsi(long).length <= 18, `preview must respect row width: ${stripAnsi(long)}`);
+  assert.ok(stripAnsi(long).startsWith("Thinking:"), stripAnsi(long));
+});
+
+test("three adjacent blocks form one tight multiline preview", () => {
+  const adjacent = thinkingComp([
+    { type: "thinking", thinking: "first reasoning block" },
+    { type: "thinking", thinking: "second reasoning block" },
+    { type: "thinking", thinking: "third reasoning block" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(adjacent, ["", LABEL, "", LABEL, "", LABEL]),
+    [
+      "",
+      preview("first reasoning block"),
+      preview("second reasoning block"),
+      preview("third reasoning block"),
+    ],
+  );
+});
+
+test("empty thinking fragments neither consume labels nor break adjacency", () => {
+  const interleaved = thinkingComp([
+    { type: "thinking", thinking: "first reasoning block" },
+    { type: "thinking", thinking: "" },
+    { type: "thinking", thinking: " \n\t " },
+    { type: "thinking", thinking: "second reasoning block" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(interleaved, ["", LABEL, "", LABEL]),
+    ["", preview("first reasoning block"), preview("second reasoning block")],
+  );
+});
+
+test("text, tools, and other semantic content end a thinking run", () => {
+  const toolBoundary = thinkingComp([
+    { type: "thinking", thinking: "before tool" },
+    { type: "toolCall", id: "call-1", name: "read", arguments: {} },
+    { type: "thinking", thinking: "after tool" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(toolBoundary, [LABEL, "", LABEL]),
+    [preview("before tool"), "", preview("after tool")],
+    "an invisible tool call keeps the native boundary",
+  );
+
+  const otherBoundaries = thinkingComp([
+    { type: "thinking", thinking: "before text" },
+    { type: "text", text: "visible bridge" },
+    { type: "thinking", thinking: "after text" },
+    { type: "metadata", value: "semantic boundary" },
+    { type: "thinking", thinking: "after other content" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(otherBoundaries, [LABEL, "", "visible bridge", "", LABEL, "", LABEL]),
+    [
+      preview("before text"),
+      "",
+      "visible bridge",
+      "",
+      preview("after text"),
+      "",
+      preview("after other content"),
+    ],
+  );
+});
+
+test("OSC marks from grouped labels stay before later semantic content", () => {
+  const markedEnd = "\x1b]133;B\x07";
+  const separated = thinkingComp([
+    { type: "thinking", thinking: "first grouped step" },
+    { type: "thinking", thinking: "second grouped step" },
+    { type: "text", text: "visible boundary" },
+    { type: "thinking", thinking: "later separate step" },
+  ]);
+  const out = dedupeThinkingLabels(
+    separated,
+    [LABEL, "", `${markedEnd}${LABEL}`, "", "visible boundary", LABEL],
+  );
+  assert.deepEqual(out, [
+    preview("first grouped step"),
+    `${markedEnd}${preview("second grouped step")}`,
+    "",
+    "visible boundary",
+    preview("later separate step"),
+  ]);
+  assert.ok(!out.at(-1)!.includes(markedEnd), "a dropped mark must not cross the semantic boundary");
+});
+
+test("fallback labels fold only within a known run and preserve OSC marks", () => {
+  const controlOnlyAdjacent = thinkingComp([
+    { type: "thinking", thinking: "\x01" },
+    { type: "thinking", thinking: "\x02" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(controlOnlyAdjacent, [LABEL, "", LABEL]),
+    [LABEL],
+    "unpreviewable adjacent payloads keep the duplicate-label fallback",
+  );
+
+  const markedStart = "\x1b]133;A\x07";
+  const markedEnd = "\x1b]133;B\x07";
+  assert.deepEqual(
+    dedupeThinkingLabels(controlOnlyAdjacent, [`${markedStart}${LABEL}`, "", `${markedEnd}${LABEL}`]),
+    [`${markedStart}${markedEnd}${LABEL}`],
+    "later fallback marks retain their order after marks on the kept native row",
+  );
+
+  const mixedAdjacent = thinkingComp([
+    { type: "thinking", thinking: "visible step" },
+    { type: "thinking", thinking: "\x01" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(mixedAdjacent, [LABEL, "", `${markedEnd}${LABEL}`]),
+    [preview("visible step"), `${markedEnd}${LABEL}`],
+    "an unpreviewable block keeps one fallback row and receives its native OSC mark",
+  );
+
+  const controlOnlySeparated = thinkingComp([
+    { type: "thinking", thinking: "\x01" },
+    { type: "toolCall", id: "call-2", name: "read", arguments: {} },
+    { type: "thinking", thinking: "\x02" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(controlOnlySeparated, [LABEL, "", LABEL]),
+    [LABEL, "", LABEL],
+    "semantic boundaries also separate fallback labels when content metadata exists",
+  );
+
+  assert.deepEqual(
+    dedupeThinkingLabels({ hiddenThinkingLabel: "Thinking..." }, ["", LABEL, "", LABEL]),
+    ["", LABEL],
+    "missing content metadata retains the safe duplicate-label fallback",
+  );
+
+  const multiline = thinkingComp([{ type: "thinking", thinking: "first\nsecond" }]);
+  const marked = `\x1b]133;C\x07${LABEL}`;
+  const out = dedupeThinkingLabels(multiline, [marked]);
+  assert.equal(out.length, 2);
+  assert.ok(out[0]!.startsWith("\x1b]133;C\x07"), `native zone mark must survive: ${JSON.stringify(out)}`);
+  assert.equal((out.join("").match(/\x1b\]133;C\x07/g) ?? []).length, 1, "synthetic rows do not duplicate OSC marks");
+
+  assert.deepEqual(
+    dedupeThinkingLabels({ hiddenThinkingLabel: "Pondering…" }, ["Pondering…", "", "Pondering…"]),
+    ["Pondering…"],
+    "a custom hidden-thinking label is respected",
+  );
+});


### PR DESCRIPTION
## Summary

- Group truly adjacent collapsed thinking blocks into one tight multiline preview.
- Keep text, tool calls, and every other semantic content entry as a hard group boundary.
- Preserve empty-fragment alignment, single-block rendering, width limits, fallback labels, OSC ordering, and bounded render work.
- Document the visual contract and extend unit, installed-Pi contract, golden, and real-Pi smoke coverage.

## Validation

- `npm run check` (179 tests)
- `npm run test:smoke` (grouped-thinking resume smoke and full startup smoke)
- Independent local code review: no material findings after resolving OSC/fallback edge cases
- Real Pi TUI captured at 108 columns and visually reviewed against the supplied reference: adjacent previews are consecutive, italic, aligned, and unwrapped
