### PR TITLE
Cachemire: show the post-compaction cache split

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -174,6 +174,11 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
 - tense: in-flight statements are progressive with `~`
   (`cache breaking · re-writing ~138.2k`); resolved statements are past tense with
   exacts (`cache broke · re-wrote 138.2k`)
+- a resolved post-compaction notice shows both provider-exact sides:
+  `cache after compaction · preserved 34.9k of the prior 72.5k prefix · re-wrote
+  38.7k (52% of prompt)`. `preserved` means provider-reported cache reads from the
+  unchanged prompt prefix, not the number of conversation tokens the compactor retained.
+  If the model also changed, withhold the prior count rather than compare tokenizers
 - certainty ladder: contract-backed evidence gets definite words (`cache cold`);
   a documented band gets hedged words (`cache fading`); an unknown provider gets
   `likely`. Never write definite words on soft evidence

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -141,6 +141,14 @@ break (e.g. provider-side eviction) still gets a resolved-form line when usage
 arrives; a send that aborts before usage resolves the notice to an explicit "outcome
 unknown".
 
+Compaction is deliberately unsized in flight: Pi's compact event does not provide an
+exact provider-token split for the new prefix. The first billed call afterwards does,
+so the resolved notice shows both sides: `preserved 34.9k of the prior 72.5k prefix ·
+re-wrote 38.7k (52% of prompt)`. `Preserved` is the response's exact `cacheRead`
+from the unchanged prompt prefix. It is not a claim about how many semantic
+conversation tokens Pi kept. If the model also changed, the old-model prefix count is
+withheld rather than compared with usage from a different tokenizer.
+
 The `(99%)` in a resolved notice is the share of the request's prompt-side tokens
 (input + cacheRead + cacheWrite) that had to be re-written. `cache held` (green)
 appears when a predicted break didn't happen, usually shared-prefix warmth: another

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -36,18 +36,24 @@ cause from exact byte-level differences.
 
 The notice appears at send time, where Cachemire can tie it to the request. It
 updates in place when usage arrives. Progressive wording and `~` show an in-flight
-expectation. Past-tense
-wording shows exact actuals.
+expectation. Past-tense wording shows exact actuals.
 
 Healthy caches stay quiet. Notices appear only above a materiality threshold. The
 default threshold is $0.05 or 20k re-written tokens.
 
 ```
 ◍ cache breaking · re-writing ~138.2k (~$2.59) · cause: idle 9h50m > 5m TTL   (in flight)
+◍ cache after compaction · preserved 34.9k of the prior 72.5k prefix · re-wrote 38.7k (52% of prompt)
 ◍ cache broke · re-wrote 138.2k of 139.6k prompt (99%) · $0.52 · cause: idle 9h50m > 5m TTL
 ◍ cache partial · read 41.2k of 138.2k expected · re-wrote 138.2k (76% of prompt) · cause: system prompt changed
 ◍ cache held · read 76.0k of 77.7k expected · prefix stayed warm              (prediction wrong, good news)
 ```
+
+A compaction prediction stays unsized because the new prefix is not provider-known
+until the next response. The resolved line uses exact provider usage. `Preserved`
+means cache reads from the unchanged prompt prefix, not semantic conversation tokens
+retained by the compactor. If the model also changed, Cachemire withholds the prior
+count rather than compare values from different tokenizers.
 
 ## See the cost of each turn
 

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -9,6 +9,7 @@ import { findChatContainer, type ContainerLike } from "../_lib/chat.ts";
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import { GLYPH, SCALE, SEP, ink, panelHeader, type Tone } from "../_lib/style.ts";
+import { promptTokens, renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
 
 /**
  * pi-cachemire — explains the cache and loop economics of a pi session.
@@ -84,6 +85,8 @@ export interface CallRecord {
   expectedRead: number;
   classification: CallClassification;
   rewroteTokens: number;
+  /** Context for the first billed provider call after session compaction. */
+  postCompaction?: { modelSwitched: boolean };
   costUsd?: number;
   uncachedUsd?: number; // counterfactual without caching, at this call's rates
   restored?: boolean;
@@ -662,62 +665,6 @@ function settleDanglingSend(state: {
 
 // --- ledger lines ----------------------------------------------------------------------
 
-function renderRunSummary(run: RunAggregate, endedAt: number): string {
-  const promptTokens = run.input + run.cacheRead;
-  const cachedPct = promptTokens > 0 ? (run.cacheRead / promptTokens) * 100 : 0;
-  const parts = [
-    `turn: ${run.calls} ${run.calls === 1 ? "call" : "calls"}`,
-    formatDuration(endedAt - run.startedAt),
-    `read ${compactCount(run.cacheRead)} (${cachedPct >= 99.95 ? "100" : cachedPct.toFixed(1)}% cached)`,
-    `wrote ${compactCount(run.cacheWrite)}`,
-    `out ${compactCount(run.output)}`,
-  ];
-  if (run.costUsd > 0) parts.push(formatUsd(run.costUsd));
-  return parts.join(SEP);
-}
-
-// Tense grammar: in-flight predictions are progressive with ~estimates ("breaking ·
-// re-writing ~77.7k"); resolved lines are past tense with exact usage ("broke · re-wrote
-// 77.7k of 80.1k prompt (97%)").
-function renderBreakingLine(prediction: BreakPrediction): string {
-  const size = prediction.expectedRewriteTokens
-    ? ` \u00b7 re-writing ~${compactCount(prediction.expectedRewriteTokens)}${prediction.expectedUsd !== undefined ? ` (~${formatUsd(prediction.expectedUsd)})` : ""}`
-    : prediction.cause.kind === "compaction"
-      ? " \u00b7 re-writing the new prefix"
-      : prediction.cause.kind === "thinking"
-        // Anthropic documents that system/tools survive *budget* changes; for adaptive
-        // effort changes a live test on claude-fable-5 broke 100% of the prompt
-        // (read 0, re-wrote 30.0k of 30.0k), so no survival claim is made there.
-        ? prediction.cause.detail.includes("thinking budget")
-          ? " \u00b7 re-writing history (system/tools stay cached)"
-          : " \u00b7 re-writing the prompt"
-        : " \u00b7 re-writing the full prompt"; // unsized model switch: old-tokenizer count withheld
-  return `cache breaking${size} \u00b7 cause: ${prediction.cause.detail}`;
-}
-
-function promptTokens(usage: UsageLike): number {
-  return usage.input + usage.cacheRead + usage.cacheWrite;
-}
-
-function renderMissLine(record: CallRecord): string {
-  const prompt = promptTokens(record.usage);
-  const pct = prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}% of prompt)` : "";
-  const what = record.classification.kind === "partial"
-    ? `cache partial \u00b7 read ${compactCount(record.usage.cacheRead)} of ${compactCount(record.expectedRead)} expected` +
-      ` \u00b7 re-wrote ${compactCount(record.rewroteTokens)}${pct}`
-    : `cache broke \u00b7 re-wrote ${compactCount(record.rewroteTokens)} of ${compactCount(prompt)} prompt` +
-      `${prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}%)` : ""}` +
-      `${record.costUsd !== undefined ? ` \u00b7 ${formatUsd(record.costUsd)}` : ""}`;
-  return `${what} \u00b7 cause: ${record.classification.cause?.detail ?? "unknown"}`;
-}
-
-// A predicted break that resolved into a hit — good news, and a small lesson about
-// shared-prefix warmth (another session with the same harness prefix kept it alive).
-function renderHeldLine(record: CallRecord): string {
-  return `cache held \u00b7 read ${compactCount(record.usage.cacheRead)} of ${compactCount(record.expectedRead)} expected` +
-    " \u00b7 prefix stayed warm";
-}
-
 // The family status scale (design language §1): ○ cold · ● hit · ◑ partial · ◌ miss.
 const EVENT_GLYPHS: Record<CallClassification["kind"], string> = {
   cold: SCALE.cold,
@@ -1295,6 +1242,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
       expectedRead: s.expectedRead,
       classification,
       rewroteTokens: usage.cacheWrite > 0 ? usage.cacheWrite : usage.input,
+      postCompaction: s.compacted ? { modelSwitched: s.modelSwitched } : undefined,
       costUsd: usage.cost.total,
       uncachedUsd: uncachedCostUsd(usage, s.rates),
     };

--- a/extensions/pi-cachemire/render.ts
+++ b/extensions/pi-cachemire/render.ts
@@ -1,0 +1,75 @@
+import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
+import { SEP } from "../_lib/style.ts";
+import type { BreakPrediction, CallRecord, RunAggregate, UsageLike } from "./index.ts";
+
+export function promptTokens(usage: UsageLike): number {
+  return usage.input + usage.cacheRead + usage.cacheWrite;
+}
+
+export function renderRunSummary(run: RunAggregate, endedAt: number): string {
+  const promptTokens = run.input + run.cacheRead;
+  const cachedPct = promptTokens > 0 ? (run.cacheRead / promptTokens) * 100 : 0;
+  const parts = [
+    `turn: ${run.calls} ${run.calls === 1 ? "call" : "calls"}`,
+    formatDuration(endedAt - run.startedAt),
+    `read ${compactCount(run.cacheRead)} (${cachedPct >= 99.95 ? "100" : cachedPct.toFixed(1)}% cached)`,
+    `wrote ${compactCount(run.cacheWrite)}`,
+    `out ${compactCount(run.output)}`,
+  ];
+  if (run.costUsd > 0) parts.push(formatUsd(run.costUsd));
+  return parts.join(SEP);
+}
+
+// Tense grammar: in-flight predictions are progressive with ~estimates ("breaking ·
+// re-writing ~77.7k"); resolved lines are past tense with exact usage ("broke · re-wrote
+// 77.7k of 80.1k prompt (97%)").
+export function renderBreakingLine(prediction: BreakPrediction): string {
+  const size = prediction.expectedRewriteTokens
+    ? ` \u00b7 re-writing ~${compactCount(prediction.expectedRewriteTokens)}${prediction.expectedUsd !== undefined ? ` (~${formatUsd(prediction.expectedUsd)})` : ""}`
+    : prediction.cause.kind === "compaction"
+      ? " \u00b7 re-writing the new prefix"
+      : prediction.cause.kind === "thinking"
+        // Anthropic documents that system/tools survive *budget* changes; for adaptive
+        // effort changes a live test on claude-fable-5 broke 100% of the prompt
+        // (read 0, re-wrote 30.0k of 30.0k), so no survival claim is made there.
+        ? prediction.cause.detail.includes("thinking budget")
+          ? " \u00b7 re-writing history (system/tools stay cached)"
+          : " \u00b7 re-writing the prompt"
+        : " \u00b7 re-writing the full prompt"; // unsized model switch: old-tokenizer count withheld
+  return `cache breaking${size} \u00b7 cause: ${prediction.cause.detail}`;
+}
+
+function isPostCompaction(record: CallRecord): boolean {
+  return record.postCompaction !== undefined || record.classification.cause?.kind === "compaction";
+}
+
+function renderCompactionLine(record: CallRecord): string {
+  const prior = record.expectedRead > 0 && record.postCompaction?.modelSwitched !== true
+    ? ` of the prior ${compactCount(record.expectedRead)} prefix`
+    : " from the prior prefix";
+  const prompt = promptTokens(record.usage);
+  const rewriteShare = prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}% of prompt)` : "";
+  return `cache after compaction \u00b7 preserved ${compactCount(record.usage.cacheRead)}${prior}` +
+    ` \u00b7 re-wrote ${compactCount(record.rewroteTokens)}${rewriteShare}`;
+}
+
+export function renderMissLine(record: CallRecord): string {
+  if (isPostCompaction(record)) return renderCompactionLine(record);
+  const prompt = promptTokens(record.usage);
+  const pct = prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}% of prompt)` : "";
+  const what = record.classification.kind === "partial"
+    ? `cache partial \u00b7 read ${compactCount(record.usage.cacheRead)} of ${compactCount(record.expectedRead)} expected` +
+      ` \u00b7 re-wrote ${compactCount(record.rewroteTokens)}${pct}`
+    : `cache broke \u00b7 re-wrote ${compactCount(record.rewroteTokens)} of ${compactCount(prompt)} prompt` +
+      `${prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}%)` : ""}` +
+      `${record.costUsd !== undefined ? ` \u00b7 ${formatUsd(record.costUsd)}` : ""}`;
+  return `${what} \u00b7 cause: ${record.classification.cause?.detail ?? "unknown"}`;
+}
+
+// A predicted break that resolved into a hit: good news, and a small lesson about
+// shared-prefix warmth (another session with the same harness prefix kept it alive).
+export function renderHeldLine(record: CallRecord): string {
+  if (isPostCompaction(record)) return renderCompactionLine(record);
+  return `cache held \u00b7 read ${compactCount(record.usage.cacheRead)} of ${compactCount(record.expectedRead)} expected` +
+    " \u00b7 prefix stayed warm";
+}

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -5,7 +5,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 1419,
+      "extensions/pi-cachemire/index.ts": 1367,
       "extensions/pi-contextimate/index.ts": 1959,
       "extensions/pi-traceline/index.ts": 1817,
       "tests/cachemire/economics-and-render.test.ts": 352,

--- a/tests/cachemire/compaction-render.test.ts
+++ b/tests/cachemire/compaction-render.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { internals, type CallRecord } from "../../extensions/pi-cachemire/index.ts";
+
+const { renderHeldLine, renderMissLine } = internals;
+
+const COMPACTED: CallRecord = {
+  index: 5,
+  at: 600_000,
+  gapMs: 60_000,
+  usage: { input: 400, output: 1_000, cacheRead: 34_900, cacheWrite: 38_700 },
+  expectedRead: 72_500,
+  classification: { kind: "partial", cause: { kind: "compaction", detail: "compaction rewrote history" } },
+  rewroteTokens: 38_700,
+  postCompaction: { modelSwitched: false },
+};
+
+test("resolved compaction notice reports the exact preserved and re-written split", () => {
+  assert.equal(
+    renderMissLine(COMPACTED),
+    "cache after compaction \u00b7 preserved 34.9k of the prior 72.5k prefix \u00b7 re-wrote 38.7k (52% of prompt)",
+  );
+});
+
+test("a post-compaction hit keeps the split instead of falling back to generic held wording", () => {
+  const held: CallRecord = {
+    ...COMPACTED,
+    usage: { ...COMPACTED.usage, cacheRead: 68_000, cacheWrite: 4_100 },
+    classification: { kind: "hit" },
+    rewroteTokens: 4_100,
+  };
+  assert.equal(
+    renderHeldLine(held),
+    "cache after compaction \u00b7 preserved 68.0k of the prior 72.5k prefix \u00b7 re-wrote 4.1k (6% of prompt)",
+  );
+});
+
+test("a model switch withholds the prior count because its tokenizer differs", () => {
+  assert.equal(
+    renderMissLine({ ...COMPACTED, postCompaction: { modelSwitched: true } }),
+    "cache after compaction \u00b7 preserved 34.9k from the prior prefix \u00b7 re-wrote 38.7k (52% of prompt)",
+  );
+});

--- a/tests/cachemire/goldens.test.ts
+++ b/tests/cachemire/goldens.test.ts
@@ -44,6 +44,18 @@ const RECORDS: CallRecord[] = [
   },
 ];
 
+const COMPACTION_RECORD: CallRecord = {
+  index: 5,
+  at: 10 * MIN,
+  gapMs: MIN,
+  usage: { input: 400, output: 1_000, cacheRead: 34_900, cacheWrite: 38_700 },
+  expectedRead: 72_500,
+  classification: { kind: "partial", cause: { kind: "compaction", detail: "compaction rewrote history" } },
+  rewroteTokens: 38_700,
+  postCompaction: { modelSwitched: false },
+  costUsd: 0.79,
+};
+
 test("cachemire ledger and one-line surfaces golden", () => {
   const clock = (input: Parameters<typeof cacheClock>[0]) => {
     const state = cacheClock(input);
@@ -67,6 +79,7 @@ test("cachemire ledger and one-line surfaces golden", () => {
     "=== notices (chat lines) ===",
     `\u25cd ${renderBreakingLine({ cause: { kind: "ttl", detail: "idle 7m00s > 5m TTL" }, expectedRewriteTokens: 150_300, expectedUsd: 2.82 })}`,
     `\u25cd ${renderBreakingLine({ cause: { kind: "compaction", detail: "history compacted" } })}`,
+    `\u25cd ${renderMissLine(COMPACTION_RECORD)}`,
     `\u25cd ${renderMissLine(RECORDS[3]!)}`,
     `\u25cd ${renderMissLine(RECORDS[2]!)}`,
     `\u25cd ${renderHeldLine(RECORDS[1]!)}`,

--- a/tests/fixtures/goldens/cachemire-lines.txt
+++ b/tests/fixtures/goldens/cachemire-lines.txt
@@ -21,6 +21,7 @@
 === notices (chat lines) ===
 ◍ cache breaking · re-writing ~150.3k (~$2.82) · cause: idle 7m00s > 5m TTL
 ◍ cache breaking · re-writing the new prefix · cause: history compacted
+◍ cache after compaction · preserved 34.9k of the prior 72.5k prefix · re-wrote 38.7k (52% of prompt)
 ◍ cache broke · re-wrote 153.0k of 153.2k prompt (100%) · $2.97 · cause: idle 7m00s > 5m TTL
 ◍ cache partial · read 90.0k of 152.1k expected · re-wrote 62.1k (41% of prompt) · cause: unknown (provider-side eviction?)
 ◍ cache held · read 150.3k of 150.3k expected · prefix stayed warm


### PR DESCRIPTION
## Summary
- resolve compaction notices with provider-reported preserved and rewritten tokens
- avoid comparing the prior prefix after a model switch changes tokenizer currency
- add focused rendering tests, golden coverage, and documentation

## Verification
- `npm run check` (182 tests)
- `npm run test:smoke`