### PR TITLE
Gate pi-meantime behind an explicit opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ loop-economics voice as cachemire (`◍`) with wall-clock milliseconds as the
 currency. Design language grows a family row, latency/rate number grammar, and
 §10 (tempo facts: measurement honesty, segments, surfaces).
 
+- Meantime is feature-flagged off by default while its experimental UX settles.
+  Set `"enabled": true` in `pi-meantime.json` to opt in; otherwise its entrypoint
+  registers no hooks, timer, widget, notices, or `/pace` command.
 - A live tempo line above the editor names the current phase of the wait
   (`waiting`, `thinking`, `writing` with a `~tok/s` estimate from streamed
   chars, `tools` with wall-clock and a running count) and turns warning ink

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Small observability and context management tools for [Pi](https://github.com/ear
 1. [`contextimate`](./extensions/pi-contextimate) breaks down what is filling your context window: sysprompt, AGENTS.md, Skill frontmatter, Tool schemas, and session material. Toggle with ctrl+o on start and /reload.
 2. [`traceline`](./extensions/pi-traceline) collapses tool calls to one trace line each, so you can see the full arc of what Pi did (path taken, context read, bloated tool results). Toggle with ctrl+t (expands/collapses both thinking blocks and tools).
 3. [`cachemire`](./extensions/pi-cachemire) (**experimental**) explains cache behaviour and agent-loop economics: a cache TTL clock above the editor, predicted-then-resolved cache-break notices, a per-turn ledger, and `/cache` forensics. Included in the package as of `0.4.0`; wording, thresholds, and states may still evolve.
-4. [`meantime`](./extensions/pi-meantime) (**experimental**) explains where the wall-clock went: a live tempo line above the editor (waiting / thinking / writing / tools, with `~tok/s`), slow-start and slow-stream notices judged against the session's own medians, and a `/pace` ledger with an active-vs-idle share bar. New in `0.7.0`.
+4. [`meantime`](./extensions/pi-meantime) (**experimental, opt-in**) explains where the wall-clock went: a live tempo line above the editor (waiting / thinking / writing / tools, with `~tok/s`), slow-start and slow-stream notices judged against the session's own medians, and a `/pace` ledger with an active-vs-idle share bar. New in `0.7.0`, and feature-flagged off by default.
 
 See each extension's own `README.md` for details, `docs/` for deeper reference, and [`AGENTS.md`](./AGENTS.md) for development workflows and conventions.
 
 ## Installation
 - From GitHub: `pi install git:github.com/tmustier/pine-of-glass`
-- From npm (installs `contextimate`, `traceline`, and experimental `cachemire` and `meantime`): `pi install npm:pine-of-glass`
+- From npm (installs `contextimate`, `traceline`, and experimental `cachemire` and `meantime`): `pi install npm:pine-of-glass`. Meantime stays inert until its config sets `"enabled": true`.
 
 ## Screenshots
 ### [Traceline](./extensions/pi-traceline)
@@ -40,7 +40,7 @@ You now see cache-related warnings inline and a cache shotclock above the editor
 ![Cachemire /cache ledger table](./docs/img/pi-cachemire-ledger.png)
 
 ### [Meantime](./extensions/pi-meantime)
-A tempo line above the editor decomposes the current wait (waiting / thinking / writing / tools), slow calls earn a notice with a named cause, and `/pace` shows the per-call tempo ledger:
+Feature-flagged off by default. Once its config sets `"enabled": true`, a tempo line above the editor decomposes the current wait (waiting / thinking / writing / tools), slow calls earn a notice with a named cause, and `/pace` shows the per-call tempo ledger:
 
 ![Meantime live tool clock](./docs/img/pi-meantime-tempo.png)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -156,6 +156,8 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   live-rate calibration.
 - **Session totals and config parsing**: open idle time contributes to idle, active is
   the watched span minus idle, and malformed boundary values are ignored.
+- **Feature-flag registration**: the default config registers no hooks or command;
+  explicit `enabled: true` registers the full event surface and `/pace`.
 
 ## Layer 3: render goldens
 
@@ -200,8 +202,9 @@ model call required:
   cannot leave a hot orphan behind.
 - The full startup smoke checks that the `[Contextimate]` block renders, that
   `/contextimate compact` and `expanded` change the rendered mode line, and that `/reload`
-  keeps exactly one block. It also proves `/cache` and `/pace` render through the real TUI
-  and both survive the Ctrl+T chat rebuild.
+  keeps exactly one block. Its project config explicitly enables Meantime, proving the
+  public opt-in path; it then proves `/cache` and `/pace` render through the real TUI and
+  both survive the Ctrl+T chat rebuild.
 - Both exit non-zero on assertion failure so they can gate publishes. They do not run in
   CI because they need a TTY and an installed Pi. A "live turn" variant (real model, one
   bash call, assert a trace line appears and Ctrl+T restores native rows) stays a

--- a/extensions/pi-meantime/README.md
+++ b/extensions/pi-meantime/README.md
@@ -1,8 +1,8 @@
 # pi-meantime
 
-> **Status: experimental.** New in `pine-of-glass` `0.7.0`; wording, thresholds, and
-> states may change without notice. Track
-> [#26](https://github.com/tmustier/pine-of-glass/issues/26).
+> **Status: experimental and opt-in.** New in `pine-of-glass` `0.7.0`; wording,
+> thresholds, and states may change without notice. Meantime is feature-flagged off by
+> default. Track [#26](https://github.com/tmustier/pine-of-glass/issues/26).
 
 Explains where the wall-clock went. pi's footer *counts* elapsed time; meantime
 *decomposes* it: is the model thinking or stuck, why was that call slow, and where did
@@ -74,13 +74,12 @@ pi -e ./extensions/pi-meantime
 
 ## Use
 
-Nothing to press: the tempo line ticks above the editor during a run and notices
-arrive on their own. `/pace` prints the ledger.
-
-Config lives at `~/.pi/agent/pi-meantime.json` or `<project>/.pi/pi-meantime.json`:
+Meantime is inert by default. To opt in, create `~/.pi/agent/pi-meantime.json` for
+all projects or `<project>/.pi/pi-meantime.json` for one project, then run `/reload`:
 
 ```json
 {
+  "enabled": true,
   "widget": true,
   "notices": true,
   "slowStartFactor": 3,
@@ -91,6 +90,11 @@ Config lives at `~/.pi/agent/pi-meantime.json` or `<project>/.pi/pi-meantime.jso
   "prefillCauseTokens": 20000
 }
 ```
+
+`enabled` is the feature flag. Unless it is explicitly `true`, Meantime registers no
+hooks, timer, widget, notices, or `/pace` command. Once enabled, there is nothing to
+press: the tempo line ticks during a run, notices arrive on their own, and `/pace`
+prints the ledger.
 
 A slow start fires when a call's first token takes at least `slowStartFactor` times
 the rolling median *and* clears the absolute floor; a slow stream fires when a call

--- a/extensions/pi-meantime/config.ts
+++ b/extensions/pi-meantime/config.ts
@@ -1,0 +1,57 @@
+// pi-meantime feature gate and tuning config. The family convention is user-level
+// `~/.pi/agent/pi-meantime.json`, then project-level `<cwd>/.pi/pi-meantime.json`.
+
+import { booleanValue, isJsonObject, positiveNumberValue } from "../_lib/boundary.ts";
+
+export interface MeantimeConfig {
+  /** Feature flag: the extension registers no runtime surface unless explicitly enabled. */
+  enabled: boolean;
+  widget: boolean;
+  notices: boolean;
+  /** Slow start: ttft ≥ factor × rolling median, and ≥ the absolute floor. */
+  slowStartFactor: number;
+  slowStartFloorMs: number;
+  /** Slow stream: rate ≤ median ÷ factor, on calls with enough output to matter. */
+  slowStreamFactor: number;
+  slowStreamMinTokens: number;
+  /** Resolved samples required before any baseline claim (short sessions stay silent). */
+  baselineMinCalls: number;
+  /** Uncached prompt tokens needed to name prefill as a slow-start cause. */
+  prefillCauseTokens: number;
+}
+
+export const DEFAULT_CONFIG: MeantimeConfig = {
+  enabled: false,
+  widget: true,
+  notices: true,
+  slowStartFactor: 3,
+  slowStartFloorMs: 5_000,
+  slowStreamFactor: 3,
+  slowStreamMinTokens: 300,
+  baselineMinCalls: 3,
+  prefillCauseTokens: 20_000,
+};
+
+export function parseMeantimeConfig(value: unknown): Partial<MeantimeConfig> {
+  if (!isJsonObject(value)) return {};
+  const config: Partial<MeantimeConfig> = {};
+  const enabled = booleanValue(value.enabled);
+  const widget = booleanValue(value.widget);
+  const notices = booleanValue(value.notices);
+  const slowStartFactor = positiveNumberValue(value.slowStartFactor);
+  const slowStartFloorMs = positiveNumberValue(value.slowStartFloorMs);
+  const slowStreamFactor = positiveNumberValue(value.slowStreamFactor);
+  const slowStreamMinTokens = positiveNumberValue(value.slowStreamMinTokens);
+  const baselineMinCalls = positiveNumberValue(value.baselineMinCalls);
+  const prefillCauseTokens = positiveNumberValue(value.prefillCauseTokens);
+  if (enabled !== undefined) config.enabled = enabled;
+  if (widget !== undefined) config.widget = widget;
+  if (notices !== undefined) config.notices = notices;
+  if (slowStartFactor !== undefined) config.slowStartFactor = slowStartFactor;
+  if (slowStartFloorMs !== undefined) config.slowStartFloorMs = slowStartFloorMs;
+  if (slowStreamFactor !== undefined) config.slowStreamFactor = slowStreamFactor;
+  if (slowStreamMinTokens !== undefined) config.slowStreamMinTokens = Math.floor(slowStreamMinTokens);
+  if (baselineMinCalls !== undefined) config.baselineMinCalls = Math.floor(baselineMinCalls);
+  if (prefillCauseTokens !== undefined) config.prefillCauseTokens = Math.floor(prefillCauseTokens);
+  return config;
+}

--- a/extensions/pi-meantime/index.ts
+++ b/extensions/pi-meantime/index.ts
@@ -201,13 +201,17 @@ function updateWidget(now = Date.now()): void {
 
 // --- extension entry --------------------------------------------------------------------------
 
-export default function piMeantime(pi: ExtensionAPI): void {
+/** Register the runtime only after the explicit config opt-in. Keeping this boundary
+ * outside every hook makes the disabled state inert: no events, command, timer, or UI. */
+export function registerMeantime(pi: ExtensionAPI, config: MeantimeConfig): void {
+  if (!config.enabled) return;
   const s = state();
+  s.config = config;
 
   pi.on("session_start", async (event, ctx) => {
     const now = Date.now();
     if (event.reason === "new" || event.reason === "resume" || event.reason === "fork") resetState(now);
-    s.config = loadConfig(process.cwd());
+    s.config = config;
     if (ctx.model) s.currentModel = `${ctx.model.provider}/${ctx.model.id}`;
     if (!ctx.hasUI) return;
     s.ui = ctx.ui;
@@ -220,9 +224,11 @@ export default function piMeantime(pi: ExtensionAPI): void {
     updateWidget(now);
   });
 
-  pi.on("session_shutdown", async () => {
+  pi.on("session_shutdown", async (_event, ctx) => {
     if (g.__piMeantimeTimer) clearInterval(g.__piMeantimeTimer);
     g.__piMeantimeTimer = undefined;
+    if (ctx.hasUI) ctx.ui.setWidget("pi-meantime", undefined);
+    s.lastWidgetText = undefined;
   });
 
   pi.on("model_select", async (event) => {
@@ -327,4 +333,8 @@ export default function piMeantime(pi: ExtensionAPI): void {
       appendChatLine(lines.join("\n"));
     },
   });
+}
+
+export default function piMeantime(pi: ExtensionAPI): void {
+  registerMeantime(pi, loadConfig(process.cwd()));
 }

--- a/extensions/pi-meantime/timing.ts
+++ b/extensions/pi-meantime/timing.ts
@@ -3,7 +3,9 @@
 // process; nothing is provider-reported timing (none exists) and nothing is
 // reconstructed from session history.
 
-import { booleanValue, isJsonObject, positiveNumberValue } from "../_lib/boundary.ts";
+import type { MeantimeConfig } from "./config.ts";
+export { DEFAULT_CONFIG, parseMeantimeConfig } from "./config.ts";
+export type { MeantimeConfig } from "./config.ts";
 
 // --- segments (design language §10.2) ---------------------------------------------------
 
@@ -296,54 +298,4 @@ export function sessionTotals(
     spanMs,
     activeMs: Math.max(0, spanMs - idleMs),
   };
-}
-
-// --- config (family convention: ~/.pi/agent/pi-meantime.json, <cwd>/.pi/pi-meantime.json)
-
-export interface MeantimeConfig {
-  widget: boolean;
-  notices: boolean;
-  /** Slow start: ttft ≥ factor × rolling median, and ≥ the absolute floor. */
-  slowStartFactor: number;
-  slowStartFloorMs: number;
-  /** Slow stream: rate ≤ median ÷ factor, on calls with enough output to matter. */
-  slowStreamFactor: number;
-  slowStreamMinTokens: number;
-  /** Resolved samples required before any baseline claim (short sessions stay silent). */
-  baselineMinCalls: number;
-  /** Uncached prompt tokens needed to name prefill as a slow-start cause. */
-  prefillCauseTokens: number;
-}
-
-export const DEFAULT_CONFIG: MeantimeConfig = {
-  widget: true,
-  notices: true,
-  slowStartFactor: 3,
-  slowStartFloorMs: 5_000,
-  slowStreamFactor: 3,
-  slowStreamMinTokens: 300,
-  baselineMinCalls: 3,
-  prefillCauseTokens: 20_000,
-};
-
-export function parseMeantimeConfig(value: unknown): Partial<MeantimeConfig> {
-  if (!isJsonObject(value)) return {};
-  const config: Partial<MeantimeConfig> = {};
-  const widget = booleanValue(value.widget);
-  const notices = booleanValue(value.notices);
-  const slowStartFactor = positiveNumberValue(value.slowStartFactor);
-  const slowStartFloorMs = positiveNumberValue(value.slowStartFloorMs);
-  const slowStreamFactor = positiveNumberValue(value.slowStreamFactor);
-  const slowStreamMinTokens = positiveNumberValue(value.slowStreamMinTokens);
-  const baselineMinCalls = positiveNumberValue(value.baselineMinCalls);
-  const prefillCauseTokens = positiveNumberValue(value.prefillCauseTokens);
-  if (widget !== undefined) config.widget = widget;
-  if (notices !== undefined) config.notices = notices;
-  if (slowStartFactor !== undefined) config.slowStartFactor = slowStartFactor;
-  if (slowStartFloorMs !== undefined) config.slowStartFloorMs = slowStartFloorMs;
-  if (slowStreamFactor !== undefined) config.slowStreamFactor = slowStreamFactor;
-  if (slowStreamMinTokens !== undefined) config.slowStreamMinTokens = Math.floor(slowStreamMinTokens);
-  if (baselineMinCalls !== undefined) config.baselineMinCalls = Math.floor(baselineMinCalls);
-  if (prefillCauseTokens !== undefined) config.prefillCauseTokens = Math.floor(prefillCauseTokens);
-  return config;
 }

--- a/tests/meantime/feature-flag.test.ts
+++ b/tests/meantime/feature-flag.test.ts
@@ -1,0 +1,49 @@
+// Meantime is shipped in the package before its experimental UX is ready for every
+// user. This test pins the registration boundary: disabled means no runtime surface,
+// while the explicit opt-in wires the complete extension.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+import { registerMeantime } from "../../extensions/pi-meantime/index.ts";
+import { DEFAULT_CONFIG } from "../../extensions/pi-meantime/timing.ts";
+
+function registrationProbe(): { pi: ExtensionAPI; events: string[]; commands: string[] } {
+  const events: string[] = [];
+  const commands: string[] = [];
+  const pi = {
+    on(event: string, _handler: unknown): void {
+      events.push(event);
+    },
+    registerCommand(name: string, _options: unknown): void {
+      commands.push(name);
+    },
+  } as unknown as ExtensionAPI;
+  return { pi, events, commands };
+}
+
+test("feature flag: disabled registers no hooks, timer path, UI, or command", () => {
+  const probe = registrationProbe();
+  registerMeantime(probe.pi, DEFAULT_CONFIG);
+  assert.deepEqual(probe.events, []);
+  assert.deepEqual(probe.commands, []);
+});
+
+test("feature flag: explicit opt-in registers the runtime and /pace", () => {
+  const probe = registrationProbe();
+  registerMeantime(probe.pi, { ...DEFAULT_CONFIG, enabled: true });
+  assert.deepEqual(probe.events, [
+    "session_start",
+    "session_shutdown",
+    "model_select",
+    "agent_start",
+    "before_provider_request",
+    "message_update",
+    "message_end",
+    "tool_execution_start",
+    "tool_execution_end",
+    "agent_end",
+    "agent_settled",
+  ]);
+  assert.deepEqual(probe.commands, ["pace"]);
+});

--- a/tests/meantime/timing.test.ts
+++ b/tests/meantime/timing.test.ts
@@ -246,10 +246,12 @@ test("sessionTotals: bucket sums, open idle interval, active = span − idle", (
 // --- config -----------------------------------------------------------------------------------
 
 test("parseMeantimeConfig: permissive at the boundary, precise at the call site", () => {
+  assert.equal(DEFAULT_CONFIG.enabled, false, "experimental runtime must be opt-in");
   assert.deepEqual(parseMeantimeConfig(null), {});
   assert.deepEqual(parseMeantimeConfig("nope"), {});
   assert.deepEqual(
-    parseMeantimeConfig({ widget: false, slowStartFloorMs: 8_000, slowStreamMinTokens: 500.9, baselineMinCalls: -2, junk: 1 }),
-    { widget: false, slowStartFloorMs: 8_000, slowStreamMinTokens: 500 },
+    parseMeantimeConfig({ enabled: true, widget: false, slowStartFloorMs: 8_000, slowStreamMinTokens: 500.9, baselineMinCalls: -2, junk: 1 }),
+    { enabled: true, widget: false, slowStartFloorMs: 8_000, slowStreamMinTokens: 500 },
   );
+  assert.deepEqual(parseMeantimeConfig({ enabled: "yes" }), {});
 });

--- a/tests/smoke/startup-smoke.mjs
+++ b/tests/smoke/startup-smoke.mjs
@@ -5,7 +5,8 @@
 //   2. /contextimate compact and expanded actually switch the rendered mode line,
 //   3. /reload leaves exactly one estimator block,
 //   4. traceline announces itself (extension loaded without crashing the TUI),
-//   5. /pace and /cache render, and both survive the Ctrl+T chat rebuild.
+//   5. the explicit Meantime feature flag enables /pace through real Pi,
+//   6. /pace and /cache render, and both survive the Ctrl+T chat rebuild.
 // Local-only: needs tmux + an installed pi on PATH. Exits non-zero on any failure.
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, realpathSync } from "node:fs";
@@ -87,6 +88,9 @@ for (const path of [fixtureDir, repoRoot]) {
 writeFileSync(join(fixtureHome, ".pi", "agent", "trust.json"), JSON.stringify(trusted, null, 2));
 writeFileSync(join(fixtureDir, "AGENTS.md"), "# Smoke fixture\nMinimal project context for the startup smoke test.\n");
 mkdirSync(join(fixtureDir, ".pi"), { recursive: true });
+// Meantime ships disabled. This project-local opt-in proves the public feature-flag
+// path against real Pi instead of accidentally relying on a test-only registration.
+writeFileSync(join(fixtureDir, ".pi", "pi-meantime.json"), JSON.stringify({ enabled: true }, null, 2));
 
 // Fixture-controlled compact marker: a project skill whose *name* renders as a compact
 // scan row (`zz-smoke-probe  ~0.1k …`) but appears in no summary row — a deterministic


### PR DESCRIPTION
## Summary

- add `enabled` to `pi-meantime.json`, defaulting to `false`
- return before registering hooks, timers, UI, notices, or `/pace` unless explicitly enabled
- clear the widget during shutdown so enabled-to-disabled reloads do not leave stale UI
- extract Meantime config into its own module and document the opt-in

## Proof

- `npm run check`: 205 tests pass
- `npm run test:smoke`: both real-Pi smokes pass; the startup smoke explicitly opts in through project config
- `npm pack --dry-run --json`: `extensions/pi-meantime/config.ts` is included
