### PR TITLE
fix(traceline): compact summary paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ currency. Design language grows a family row, latency/rate number grammar, and
   warning size threshold keeps its own row (still folding its own pages) and
   splits the run, as an error row already did, so ballooned reads stay visible
   in the size column. Ctrl+T's expanded view still shows every individual call.
+- Collapsed thinking previews keep consecutive standalone bold summaries tight.
+  OpenAI serializes these terse summaries as separate Markdown paragraphs; once
+  their emphasis is stripped, preserving every source blank line created an
+  artificial ladder of gaps. Ordinary prose paragraph breaks remain visible.
+  The installed-Pi contracts now track Pi 0.80.8's one native label per adjacent
+  thinking run.
 - Internal: the write pre-image snapshot and diff-stat parsing moved from
   `pi-traceline`'s `index.ts` into `write-diff.ts`; no behaviour change.
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -472,19 +472,23 @@ punctuate the wall; ambient green stays purged.
 
 A collapsed thinking run stays compact without hiding its sequence. Each
 non-empty source line renders as `Thinking: <line>`. One or more consecutive
-empty source lines within a thinking block render as one blank line, preserving
-paragraph boundaries without reproducing arbitrary vertical whitespace.
+empty source lines within ordinary prose render as one blank line, preserving
+real paragraph boundaries without reproducing arbitrary vertical whitespace.
+A blank run between consecutive standalone strong-emphasis summaries such as
+`**Planning the change**` disappears. Providers serialize adjacent terse
+summaries as separate Markdown paragraphs; the collapsed preview strips their
+emphasis, so retaining that paragraph spacing would turn a compact sequence into
+a ladder of artificial gaps.
 
-Adjacent thinking blocks form one logical multiline preview. The first native
-label expands to every preview line in the run; later labels and the native
-spacers between them disappear. Empty or whitespace-only thinking fragments do
-not render and do not break the run. Any non-thinking content entry, including
-text, a tool call or another semantic block, ends the run and keeps the native
-boundary before the next preview. A single thinking block renders exactly as it
-does outside a run. A non-empty payload that cannot yield a sanitized preview
-keeps one native label inside the run; consecutive such blocks fold. Native
-`Thinking...` labels with no matching content metadata retain the safe
-duplicate-label fallback.
+Adjacent thinking blocks form one logical multiline preview. Pi's one native
+label for the run expands to every preview line; extra labels and spacers from
+older label-per-block Pi versions also disappear. Empty or whitespace-only
+thinking fragments do not render and do not break the run. Any non-thinking
+content entry, including text, a tool call or another semantic block, ends the
+run and keeps the native boundary before the next preview. A non-empty payload
+that cannot yield a sanitized preview keeps one native label inside the run;
+consecutive such blocks fold. Native `Thinking...` labels with no matching
+content metadata retain the safe duplicate-label fallback.
 
 With traceline loaded, Ctrl+T's effect is self-evident: every tool row collapses
 to a trace line or expands back. So traceline suppresses pi's

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,7 +76,7 @@ moved.
 | `[Context]`/`[Skills]`/… resource headers still render in the startup transcript shape matched by `RESOURCE_HEADER_RE` | contextimate block insertion point |
 | `ToolExecutionComponent` (or successor) instances satisfy `isToolRow`: `render`, `setExpanded`, `toolName` in instance; prototype is patchable | traceline prototype patch |
 | Assistant message component satisfies `isAssistantRow`: `setHideThinkingBlock` fn + `hideThinkingBlock` boolean | traceline collapse-state source of truth |
-| A collapsed `AssistantMessageComponent` skips empty thinking blocks, emits one label per non-empty block, and keeps native spacers across tool and text boundaries | traceline grouped thinking previews |
+| A collapsed `AssistantMessageComponent` skips empty thinking blocks, emits one label per adjacent thinking run, and keeps native spacers across tool and text boundaries | traceline grouped thinking previews |
 | `ExtensionAPI` exposes `getActiveTools()` ⊆ `getAllTools()` by name; `ToolInfo` has `name`, `description`, `parameters`, `sourceInfo{scope,source,origin,path}`, `promptGuidelines` | contextimate tools section |
 
 Where instantiating real components is impractical, the contract test asserts on the
@@ -105,8 +105,9 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   running.
 - **Collapsed thinking previews**: three adjacent non-empty blocks form one tight
   multiline run; empty thinking fragments do not consume labels or break adjacency;
-  text, tools and other semantic content do; single-block rendering, fallback labels,
-  OSC marks, paragraph breaks and width bounds remain unchanged.
+  text, tools and other semantic content do; standalone strong-emphasis summary
+  paragraphs stay tight while ordinary prose paragraph breaks survive; fallback labels,
+  OSC marks and width bounds remain unchanged.
 
 ### contextimate
 
@@ -194,10 +195,10 @@ and compares against checked-in golden files (`tests/fixtures/goldens/*.txt`).
 `npm run test:smoke` launches real `pi` processes in isolated tmux sessions with no
 model call required:
 
-- `test:smoke:traceline` resumes a crafted session with three adjacent collapsed
-  thinking blocks and empty or whitespace-only fragments interleaved. It requires all
-  three preview rows to render consecutively, then proves Pi still handles `/quit`. A
-  45-second hard watchdog
+- `test:smoke:traceline` resumes a crafted session with adjacent collapsed thinking
+  blocks, standalone strong-emphasis summary paragraphs, and empty or whitespace-only
+  fragments interleaved. It requires every preview row to render consecutively, then
+  proves Pi still handles `/quit`. A 45-second hard watchdog
   kills only the uniquely launched fixture process if rendering blocks, so the regression
   cannot leave a hot orphan behind.
 - The full startup smoke checks that the `[Contextimate]` block renders, that

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -103,7 +103,7 @@ Traceline folds adjacent rows when repetition would hide the useful difference:
   then the basenames follow with their ranges. A long list wraps at file boundaries
   instead of truncating, and a file whose combined result grows past the warning
   threshold keeps its own row so the size column stays honest
-- adjacent collapsed thinking blocks become one multiline preview, with each reasoning line and paragraph break kept visible
+- adjacent collapsed thinking blocks become one multiline preview. Each reasoning line stays visible; real prose paragraphs keep their break, while consecutive bold summary paragraphs stay tight
 
 Text, tool calls and other content separate thinking previews. Visible prose between tool calls stops a row fold. Pi's full view always keeps the original rows.
 

--- a/extensions/pi-traceline/thinking-preview.ts
+++ b/extensions/pi-traceline/thinking-preview.ts
@@ -6,10 +6,11 @@ import { ELLIPSIS } from "../_lib/style.ts";
 
 const PREVIEW_RENDER_WIDTH = 10_000;
 
-// pi renders one collapsed label per non-empty thinking block. Traceline replaces a
-// contiguous run of those labels with one logical multiline preview: every non-empty
-// source line gets an informative `Thinking: …` row, source paragraph breaks survive,
-// and Pi's spacers between provider-split adjacent blocks disappear. Any non-thinking
+// Pi renders one collapsed label per adjacent thinking run; older versions rendered one
+// per non-empty block. Traceline accepts both shapes and expands the run into one logical
+// multiline preview: every non-empty source line gets an informative `Thinking: …` row,
+// genuine prose paragraph breaks survive, provider summary paragraphs stay tight, and
+// native spacers between provider-split adjacent blocks disappear. Any non-thinking
 // content entry ends the run, even when Pi does not render that entry here (a tool call,
 // for example). Empty thinking fragments neither render nor break adjacency. Payloads
 // that cannot yield a safe preview keep one native label; labels without corresponding
@@ -70,20 +71,52 @@ function markdownToPlainInline(markdown: string): string {
   return sanitizeThinkingLine(markdown);
 }
 
+type ThinkingSourceLine = {
+  sanitized: string;
+  standaloneSummary: boolean;
+};
+
+function isStandaloneStrongSummary(line: string): boolean {
+  for (const marker of ["**", "__"]) {
+    if (!line.startsWith(marker) || !line.endsWith(marker)) continue;
+    const body = line.slice(marker.length, -marker.length);
+    if (body.length > 0 && body === body.trim() && !body.includes(marker)) return true;
+  }
+  return false;
+}
+
+function nextNonEmptySourceLine(lines: ThinkingSourceLine[], start: number): ThinkingSourceLine | undefined {
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i]!.sanitized) return lines[i];
+  }
+  return undefined;
+}
+
 function thinkingPreviewForTrace(text: string): ThinkingPreview[] {
+  const lines = text.split(/\r\n|\r|\n/).map((rawLine) => {
+    const sanitized = sanitizeThinkingLine(rawLine);
+    return { sanitized, standaloneSummary: isStandaloneStrongSummary(sanitized) };
+  });
   const previews: ThinkingPreview[] = [];
   let previousWasBlank = false;
-  for (const rawLine of text.split(/\r\n|\r|\n/)) {
-    const sanitized = sanitizeThinkingLine(rawLine);
-    if (!sanitized) {
-      if (previews.length > 0 && !previousWasBlank) previews.push(undefined);
-      previousWasBlank = true;
+  let previousWasStandaloneSummary = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.sanitized) {
+      // OpenAI reasoning summaries commonly arrive as standalone bold paragraphs.
+      // Once markdown styling is stripped they read as a list, not prose paragraphs,
+      // so keep consecutive summary rows tight while preserving every real prose break.
+      const next = nextNonEmptySourceLine(lines, i + 1);
+      const separatesSummaries = previousWasStandaloneSummary && next?.standaloneSummary === true;
+      if (!separatesSummaries && previews.length > 0 && !previousWasBlank) previews.push(undefined);
+      previousWasBlank = !separatesSummaries;
       continue;
     }
-    const plain = markdownToPlainInline(sanitized);
+    const plain = markdownToPlainInline(line.sanitized);
     if (plain) {
       previews.push(plain);
       previousWasBlank = false;
+      previousWasStandaloneSummary = line.standaloneSummary;
     }
   }
   while (previews.length > 0 && previews.at(-1) === undefined) previews.pop();

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -194,7 +194,7 @@ test("real AssistantMessageComponent satisfies traceline's assistant duck type",
   assert.equal(peek.hideThinkingBlock, true, "hideThinkingBlock no longer mirrors setHideThinkingBlock — collapse state desyncs");
 });
 
-test("adjacent thinking blocks get native labels; traceline groups their previews", () => {
+test("adjacent thinking blocks get one native run label; traceline expands their previews", () => {
   pi.initTheme(undefined, false);
   const component = new pi.AssistantMessageComponent(assistantMessage([
     { type: "thinking", thinking: "first reasoning segment" },
@@ -205,9 +205,9 @@ test("adjacent thinking blocks get native labels; traceline groups their preview
   const native = component.render(80);
   const labelCount = (lines: string[]) =>
     lines.filter((line) => traceline.stripAnsi(line).trim() === "Thinking...").length;
-  // The seam itself (issue #14 №3): pi renders one collapsed label per non-empty
-  // thinking block. A change here requires re-checking preview-to-label alignment.
-  assert.equal(labelCount(native), 2, "Pi's collapsed-label cardinality changed");
+  // The seam itself (issue #14 №3): Pi renders one collapsed label per adjacent
+  // thinking run. A change here requires re-checking preview-to-label alignment.
+  assert.equal(labelCount(native), 1, "Pi's collapsed-run label cardinality changed");
 
   const deduped = traceline.dedupeThinkingLabels(component as never, native, 80);
   assert.equal(labelCount(deduped), 0, "native placeholders should become trace previews");

--- a/tests/contract/pi-thinking-preview.test.ts
+++ b/tests/contract/pi-thinking-preview.test.ts
@@ -44,7 +44,7 @@ test("empty thinking blocks are skipped natively and do not shift Traceline prev
   );
 });
 
-test("three adjacent native blocks become one multiline preview across empty fragments", () => {
+test("one native run label becomes a multiline preview across adjacent empty fragments", () => {
   const { native, preview } = collapsedLines([
     { type: "thinking", thinking: "first adjacent step" },
     { type: "thinking", thinking: "" },
@@ -55,8 +55,8 @@ test("three adjacent native blocks become one multiline preview across empty fra
 
   assert.equal(
     native.filter((line) => line === "Thinking...").length,
-    3,
-    "Pi's label-per-non-empty-block contract changed: re-check grouping",
+    1,
+    "Pi's label-per-adjacent-run contract changed: re-check grouping",
   );
   assert.deepEqual(preview, [
     "",
@@ -86,7 +86,7 @@ test("tool calls and text keep native boundaries between thinking runs", () => {
   ]);
 });
 
-test("a single collapsed block keeps multiline and paragraph rendering", () => {
+test("a single collapsed block keeps multiline and prose paragraph rendering", () => {
   const { preview } = collapsedLines([
     { type: "thinking", thinking: "single first line\n\nsingle second line" },
   ]);
@@ -95,5 +95,20 @@ test("a single collapsed block keeps multiline and paragraph rendering", () => {
     "Thinking: single first line",
     "",
     "Thinking: single second line",
+  ]);
+});
+
+test("standalone summary paragraphs render as one tight native-backed sequence", () => {
+  const { native, preview } = collapsedLines([
+    { type: "thinking", thinking: "**Planning the change**\n\n**Implementing the renderer**" },
+    { type: "thinking", thinking: "**Verifying the result**\n\n**Preparing the report**" },
+  ]);
+  assert.equal(native.filter((line) => line === "Thinking...").length, 1);
+  assert.deepEqual(preview, [
+    "",
+    "Thinking: Planning the change",
+    "Thinking: Implementing the renderer",
+    "Thinking: Verifying the result",
+    "Thinking: Preparing the report",
   ]);
 });

--- a/tests/smoke/traceline-empty-thinking-smoke.mjs
+++ b/tests/smoke/traceline-empty-thinking-smoke.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// Resume a real Pi session whose assistant message contains three adjacent thinking
-// blocks with empty and whitespace-only fragments interleaved. The collapsed preview must
-// stay tight and aligned. A past Traceline implementation entered a synchronous loop on
-// an empty block, so every subprocess call is bounded and the uniquely launched Pi is
-// killed on timeout.
+// Resume a real Pi session whose assistant message contains adjacent thinking blocks,
+// standalone bold summary paragraphs, and empty fragments interleaved. The collapsed
+// preview must stay tight and aligned. A past Traceline implementation entered a
+// synchronous loop on an empty block, so every subprocess call is bounded and the
+// uniquely launched Pi is killed on timeout.
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -18,6 +18,7 @@ const previews = [
   "Thinking: first adjacent reasoning step",
   "Thinking: second adjacent reasoning step",
   "Thinking: third adjacent reasoning step",
+  "Thinking: fourth adjacent reasoning step",
 ];
 const hardDeadline = Date.now() + 45_000;
 let launchedPid;
@@ -84,11 +85,16 @@ function sessionEntries(cwd) {
       message: {
         role: "assistant",
         content: [
-          { type: "thinking", thinking: "first adjacent reasoning step" },
+          {
+            type: "thinking",
+            thinking: "**first adjacent reasoning step**\n\n**second adjacent reasoning step**",
+          },
           { type: "thinking", thinking: "" },
           { type: "thinking", thinking: " \n\t\n " },
-          { type: "thinking", thinking: "second adjacent reasoning step" },
-          { type: "thinking", thinking: "third adjacent reasoning step" },
+          {
+            type: "thinking",
+            thinking: "**third adjacent reasoning step**\n\n**fourth adjacent reasoning step**",
+          },
           { type: "text", text: sentinel },
         ],
         api: "anthropic-messages",

--- a/tests/traceline/thinking-preview.test.ts
+++ b/tests/traceline/thinking-preview.test.ts
@@ -14,7 +14,7 @@ function thinkingComp(content: Array<Record<string, unknown>>) {
   return { hiddenThinkingLabel: "Thinking...", lastMessage: { content } };
 }
 
-test("a single block preserves reasoning lines, paragraph breaks, and width", () => {
+test("a single block preserves reasoning lines, prose paragraph breaks, and width", () => {
   const multiline = thinkingComp([
     { type: "thinking", thinking: "\n  **first reasoning line**\nsecond reasoning line" },
   ]);
@@ -30,6 +30,15 @@ test("a single block preserves reasoning lines, paragraph breaks, and width", ()
     dedupeThinkingLabels(paragraphs, [LABEL]),
     [preview("first paragraph"), "", preview("second paragraph")],
     "long source blank runs collapse to one display line",
+  );
+
+  const mixedParagraphs = thinkingComp([
+    { type: "thinking", thinking: "**Planning summary**\n\nordinary prose paragraph\n\n**Next summary**" },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(mixedParagraphs, [LABEL]),
+    [preview("Planning summary"), "", preview("ordinary prose paragraph"), "", preview("Next summary")],
+    "standalone summaries do not erase real prose boundaries",
   );
 
   const literalStar = dedupeThinkingLabels(
@@ -60,6 +69,28 @@ test("three adjacent blocks form one tight multiline preview", () => {
       preview("first reasoning block"),
       preview("second reasoning block"),
       preview("third reasoning block"),
+    ],
+  );
+});
+
+test("standalone summary paragraphs stay tight within and across provider blocks", () => {
+  const sessionShape = thinkingComp([
+    {
+      type: "thinking",
+      thinking: "**Implementing conditional HUD rendering**\n\n**Assigning active inline renderer in factory**",
+    },
+    {
+      type: "thinking",
+      thinking: "**Refining editor text update flow**\n\n**Implementing dispatch control around edits**",
+    },
+  ]);
+  assert.deepEqual(
+    dedupeThinkingLabels(sessionShape, [LABEL]),
+    [
+      preview("Implementing conditional HUD rendering"),
+      preview("Assigning active inline renderer in factory"),
+      preview("Refining editor text update flow"),
+      preview("Implementing dispatch control around edits"),
     ],
   );
 });


### PR DESCRIPTION
## Summary
- keep consecutive standalone bold reasoning summaries tight in collapsed Traceline previews
- preserve paragraph breaks around ordinary prose
- update installed-Pi contracts for Pi 0.80.8's one-label-per-thinking-run behavior
- exercise the session-shaped payload in unit, contract, and real-TUI smoke coverage

## Verification
- `npm run check` (213 tests)
- `npm run test:smoke`
- exact reported session replay: 42 thinking rows, 0 internal blank rows
- visual verification of focused thinking sequence and surrounding real Pi transcript
