### PR TITLE
fix(traceline): flatten thinking runs to one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,12 +49,12 @@ currency. Design language grows a family row, latency/rate number grammar, and
   warning size threshold keeps its own row (still folding its own pages) and
   splits the run, as an error row already did, so ballooned reads stay visible
   in the size column. Ctrl+T's expanded view still shows every individual call.
-- Collapsed thinking previews keep consecutive standalone bold summaries tight.
-  OpenAI serializes these terse summaries as separate Markdown paragraphs; once
-  their emphasis is stripped, preserving every source blank line created an
-  artificial ladder of gaps. Ordinary prose paragraph breaks remain visible.
-  The installed-Pi contracts now track Pi 0.80.8's one native label per adjacent
-  thinking run.
+- Collapsed thinking previews flatten each adjacent thinking run to one line.
+  Every non-empty fragment appends with a ` · ` separator, regardless of source
+  newlines or Markdown paragraph boundaries. Width fitting middle-truncates the
+  line so both its opening context and newest thought survive. The installed-Pi
+  contracts track the one native label per adjacent thinking run introduced in
+  Pi 0.80.8.
 - Internal: the write pre-image snapshot and diff-stat parsing moved from
   `pi-traceline`'s `index.ts` into `write-diff.ts`; no behaviour change.
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -470,25 +470,20 @@ punctuate the wall; ambient green stays purged.
 
 ### 9.11 Collapsed thinking
 
-A collapsed thinking run stays compact without hiding its sequence. Each
-non-empty source line renders as `Thinking: <line>`. One or more consecutive
-empty source lines within ordinary prose render as one blank line, preserving
-real paragraph boundaries without reproducing arbitrary vertical whitespace.
-A blank run between consecutive standalone strong-emphasis summaries such as
-`**Planning the change**` disappears. Providers serialize adjacent terse
-summaries as separate Markdown paragraphs; the collapsed preview strips their
-emphasis, so retaining that paragraph spacing would turn a compact sequence into
-a ladder of artificial gaps.
+A collapsed thinking run is exactly one display line. Every non-empty source
+line from every adjacent thinking block is converted to plain inline text and
+appended after `Thinking:`, separated by ` · `. Source newlines and Markdown
+paragraph boundaries never become display rows. Empty or whitespace-only
+thinking fragments do not render and do not break the run.
 
-Adjacent thinking blocks form one logical multiline preview. Pi's one native
-label for the run expands to every preview line; extra labels and spacers from
-older label-per-block Pi versions also disappear. Empty or whitespace-only
-thinking fragments do not render and do not break the run. Any non-thinking
-content entry, including text, a tool call or another semantic block, ends the
-run and keeps the native boundary before the next preview. A non-empty payload
-that cannot yield a sanitized preview keeps one native label inside the run;
-consecutive such blocks fold. Native `Thinking...` labels with no matching
-content metadata retain the safe duplicate-label fallback.
+The line middle-truncates at the terminal width, preserving both its opening
+context and the newest appended thought. Pi's native run label becomes that one
+preview; extra labels and spacers from older label-per-block Pi versions also
+disappear. Any non-thinking content entry, including text, a tool call or
+another semantic block, ends the run and keeps the native boundary before the
+next one-line preview. A non-empty run that cannot yield sanitized text keeps
+one native label. Native `Thinking...` labels with no matching content metadata
+retain the safe duplicate-label fallback.
 
 With traceline loaded, Ctrl+T's effect is self-evident: every tool row collapses
 to a trace line or expands back. So traceline suppresses pi's

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -103,11 +103,11 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   are user-facing grammar).
 - **`toolStatus`**: result+`isError` → error; result+complete → success; partial/none →
   running.
-- **Collapsed thinking previews**: three adjacent non-empty blocks form one tight
-  multiline run; empty thinking fragments do not consume labels or break adjacency;
-  text, tools and other semantic content do; standalone strong-emphasis summary
-  paragraphs stay tight while ordinary prose paragraph breaks survive; fallback labels,
-  OSC marks and width bounds remain unchanged.
+- **Collapsed thinking previews**: three adjacent non-empty blocks and every non-empty
+  line inside them append into one ` · `-separated display row; source paragraph breaks
+  never add rows; empty thinking fragments do not consume labels or break adjacency;
+  text, tools and other semantic content do; fallback labels, OSC marks, middle-truncated
+  tail visibility and width bounds remain covered.
 
 ### contextimate
 
@@ -197,8 +197,9 @@ model call required:
 
 - `test:smoke:traceline` resumes a crafted session with adjacent collapsed thinking
   blocks, standalone strong-emphasis summary paragraphs, and empty or whitespace-only
-  fragments interleaved. It requires every preview row to render consecutively, then
-  proves Pi still handles `/quit`. A 45-second hard watchdog
+  fragments interleaved. It requires the whole run to render on exactly one preview row,
+  with the newest fragment visible after width fitting, then proves Pi still handles
+  `/quit`. A 45-second hard watchdog
   kills only the uniquely launched fixture process if rendering blocks, so the regression
   cannot leave a hot orphan behind.
 - The full startup smoke checks that the `[Contextimate]` block renders, that

--- a/docs/upstream-candidates.md
+++ b/docs/upstream-candidates.md
@@ -12,29 +12,31 @@ Entries pin the pi version inspected; internals drift, so re-verify before filin
 
 ---
 
-## 1. Doubled `Thinking...` lines when reasoning is hidden
+## 1. Doubled `Thinking...` lines when reasoning is hidden (resolved)
 
-**Observed:** pi 0.79.1 · live sessions, 2026-06-10 · diagnosed in
+**Observed:** Pi 0.79.1 · live sessions, 2026-06-10 · diagnosed in
 [pine-of-glass#14](https://github.com/tmustier/pine-of-glass/issues/14)
 
-With reasoning hidden (Ctrl+T), `AssistantMessageComponent` renders the collapsed
-`Thinking...` label **once per thinking block, not per message**
-(`dist/modes/interactive/components/assistant-message.js`: the content loop emits a
-label for each `thinking` block, with a spacer when more visible content follows). An
-assistant message containing adjacent thinking blocks therefore renders two or more
-consecutive `Thinking...` lines with nothing between them.
+**Resolved:** Pi 0.80.8 and 0.80.9 emit one collapsed label per adjacent thinking
+run. Traceline's installed-Pi contract pins that cardinality and still accepts the
+older label-per-block shape.
+
+In Pi 0.79.1, with reasoning hidden (Ctrl+T), `AssistantMessageComponent` rendered
+the collapsed `Thinking...` label **once per thinking block, not per message**
+(`dist/modes/interactive/components/assistant-message.js`: the content loop emitted
+a label for each `thinking` block, with a spacer when more visible content followed).
+An assistant message containing adjacent thinking blocks therefore rendered two or
+more consecutive `Thinking...` lines with nothing between them.
 
 Frequency evidence from one live session (`019eb262`): **24 instances** of adjacent
 thinking blocks within a single assistant message; **0** consecutive thinking-only
-messages, so the doubling is intra-message block adjacency (models emitting multiple
+messages, so the doubling was intra-message block adjacency (models emitting multiple
 reasoning segments per response), not message boundaries.
 
-Two native collapsed labels carry no more information than one; the duplication is
-purely an artifact of per-block rendering. Possible upstream direction: coalesce a
-*run* of adjacent thinking blocks into one collapsed label. `pi-traceline` now works
-around this downstream by patching assistant rows and replacing the placeholder with a
-`Thinking: <first reasoning line> ... (N lines)` preview, but the upstream rendering
-seam remains.
+Two native collapsed labels carried no more information than one; the duplication
+was purely an artifact of per-block rendering. Pi adopted the possible upstream
+direction and now coalesces an adjacent run into one collapsed label. Traceline
+replaces that label with one `Thinking: <fragment> · <fragment>` preview line.
 
 ## 2. Anthropic tool search (`defer_loading`) not wired through pi-ai
 

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -103,7 +103,7 @@ Traceline folds adjacent rows when repetition would hide the useful difference:
   then the basenames follow with their ranges. A long list wraps at file boundaries
   instead of truncating, and a file whose combined result grows past the warning
   threshold keeps its own row so the size column stays honest
-- adjacent collapsed thinking blocks become one multiline preview. Each reasoning line stays visible; real prose paragraphs keep their break, while consecutive bold summary paragraphs stay tight
+- adjacent collapsed thinking blocks become one `Thinking: …` line. Their non-empty fragments append with ` · ` separators; source newlines never add display rows, and middle truncation keeps the newest thought visible
 
 Text, tool calls and other content separate thinking previews. Visible prose between tool calls stops a row fold. Pi's full view always keeps the original rows.
 

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -114,9 +114,9 @@ import { dedupeThinkingLabels } from "./thinking-preview.ts";
  * consecutive reads of sibling files fold into a dir row that prints the shared
  * directory once and lists the basenames, wrapping at file boundaries when long
  * (§9.9) while a file whose combined result reaches warning severity keeps its own
- * row; and adjacent collapsed thinking blocks become one informative multiline preview.
- * Multiline reasoning keeps each non-empty source line and source blank lines, while
- * text, tool calls and other semantic content keep separate thinking runs separate.
+ * row; and adjacent collapsed thinking blocks append into one informative preview line.
+ * Source newlines never add display rows; text, tool calls and other semantic content
+ * keep separate thinking runs separate.
  *
  * Spacing: one blank line before a tool group (restoring the spacer pi drops), none
  * between consecutive tools.

--- a/extensions/pi-traceline/thinking-preview.ts
+++ b/extensions/pi-traceline/thinking-preview.ts
@@ -1,20 +1,19 @@
-import { Markdown, truncateToWidth, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
 
 import { OSC_SEQUENCE, rawIndexAtVisibleIndex, rawIndexBeforeVisibleIndex, stripAnsi } from "../_lib/ansi.ts";
 import type { AssistantRowDataLike } from "../_lib/chat.ts";
-import { ELLIPSIS } from "../_lib/style.ts";
+import { middleTruncate } from "../_lib/style.ts";
 
 const PREVIEW_RENDER_WIDTH = 10_000;
 
 // Pi renders one collapsed label per adjacent thinking run; older versions rendered one
-// per non-empty block. Traceline accepts both shapes and expands the run into one logical
-// multiline preview: every non-empty source line gets an informative `Thinking: …` row,
-// genuine prose paragraph breaks survive, provider summary paragraphs stay tight, and
-// native spacers between provider-split adjacent blocks disappear. Any non-thinking
-// content entry ends the run, even when Pi does not render that entry here (a tool call,
-// for example). Empty thinking fragments neither render nor break adjacency. Payloads
-// that cannot yield a safe preview keep one native label; labels without corresponding
-// payloads retain the duplicate-label fallback. OSC marks move to the last kept run line.
+// per non-empty block. Traceline accepts both shapes and replaces the whole run with one
+// `Thinking: …` line. Every non-empty source line appends with a middle-dot separator;
+// source newlines never become display rows. Any non-thinking content entry ends the run,
+// even when Pi does not render that entry here (a tool call, for example). Empty thinking
+// fragments neither render nor break adjacency. Runs that cannot yield a safe preview
+// keep one native label; labels without corresponding payloads retain the duplicate-label
+// fallback. OSC marks move to the one retained run line.
 function oscSequences(line: string): string {
   return (line.match(OSC_SEQUENCE) ?? []).join("");
 }
@@ -51,8 +50,6 @@ const plainMarkdownTheme: MarkdownTheme = {
   underline: (text) => text,
 };
 
-type ThinkingPreview = string | undefined;
-
 function sanitizeThinkingLine(rawLine: string): string {
   return stripAnsi(rawLine)
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
@@ -71,63 +68,22 @@ function markdownToPlainInline(markdown: string): string {
   return sanitizeThinkingLine(markdown);
 }
 
-type ThinkingSourceLine = {
-  sanitized: string;
-  standaloneSummary: boolean;
-};
-
-function isStandaloneStrongSummary(line: string): boolean {
-  for (const marker of ["**", "__"]) {
-    if (!line.startsWith(marker) || !line.endsWith(marker)) continue;
-    const body = line.slice(marker.length, -marker.length);
-    if (body.length > 0 && body === body.trim() && !body.includes(marker)) return true;
-  }
-  return false;
-}
-
-function nextNonEmptySourceLine(lines: ThinkingSourceLine[], start: number): ThinkingSourceLine | undefined {
-  for (let i = start; i < lines.length; i++) {
-    if (lines[i]!.sanitized) return lines[i];
-  }
-  return undefined;
-}
-
-function thinkingPreviewForTrace(text: string): ThinkingPreview[] {
-  const lines = text.split(/\r\n|\r|\n/).map((rawLine) => {
+function thinkingPreviewFragments(text: string): string[] {
+  const fragments: string[] = [];
+  for (const rawLine of text.split(/\r\n|\r|\n/)) {
     const sanitized = sanitizeThinkingLine(rawLine);
-    return { sanitized, standaloneSummary: isStandaloneStrongSummary(sanitized) };
-  });
-  const previews: ThinkingPreview[] = [];
-  let previousWasBlank = false;
-  let previousWasStandaloneSummary = false;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (!line.sanitized) {
-      // OpenAI reasoning summaries commonly arrive as standalone bold paragraphs.
-      // Once markdown styling is stripped they read as a list, not prose paragraphs,
-      // so keep consecutive summary rows tight while preserving every real prose break.
-      const next = nextNonEmptySourceLine(lines, i + 1);
-      const separatesSummaries = previousWasStandaloneSummary && next?.standaloneSummary === true;
-      if (!separatesSummaries && previews.length > 0 && !previousWasBlank) previews.push(undefined);
-      previousWasBlank = !separatesSummaries;
-      continue;
-    }
-    const plain = markdownToPlainInline(line.sanitized);
-    if (plain) {
-      previews.push(plain);
-      previousWasBlank = false;
-      previousWasStandaloneSummary = line.standaloneSummary;
-    }
+    if (!sanitized) continue;
+    const plain = markdownToPlainInline(sanitized);
+    if (plain) fragments.push(plain);
   }
-  while (previews.length > 0 && previews.at(-1) === undefined) previews.pop();
-  return previews;
+  return fragments;
 }
 
 const FALLBACK_LABEL = Symbol("fallback-label");
-type ThinkingPreviewRow = ThinkingPreview | typeof FALLBACK_LABEL;
+type ThinkingPreviewRow = string | typeof FALLBACK_LABEL;
 
 type ThinkingLabelPlan = {
-  rows: ThinkingPreviewRow[];
+  row: ThinkingPreviewRow;
   emitsGroup: boolean;
 };
 
@@ -136,22 +92,12 @@ function thinkingLabelPlans(comp: AssistantRowDataLike): ThinkingLabelPlan[] {
   if (!Array.isArray(content)) return [];
 
   const plans: ThinkingLabelPlan[] = [];
-  let blocks: ThinkingPreview[][] = [];
+  let blocks: string[][] = [];
   const flush = () => {
     if (blocks.length === 0) return;
-    const rows: ThinkingPreviewRow[] = [];
-    for (const previews of blocks) {
-      if (previews.some((preview) => preview !== undefined)) {
-        rows.push(...previews);
-      } else if (rows.at(-1) !== FALLBACK_LABEL) {
-        // A non-empty payload that sanitizes to nothing still needs one native label.
-        // Consecutive such blocks keep the old duplicate-label fold inside the run.
-        rows.push(FALLBACK_LABEL);
-      }
-    }
-    for (let i = 0; i < blocks.length; i++) {
-      plans.push({ rows, emitsGroup: i === 0 });
-    }
+    const fragments = blocks.flat();
+    const row: ThinkingPreviewRow = fragments.length > 0 ? fragments.join(" · ") : FALLBACK_LABEL;
+    for (let i = 0; i < blocks.length; i++) plans.push({ row, emitsGroup: i === 0 });
     blocks = [];
   };
 
@@ -160,7 +106,7 @@ function thinkingLabelPlans(comp: AssistantRowDataLike): ThinkingLabelPlan[] {
       if (typeof block.thinking === "string" && block.thinking.trim().length > 0) {
         // Pi skips empty thinking blocks, so only rendered blocks receive a label plan.
         // Empty fragments still leave `blocks` open and therefore preserve adjacency.
-        blocks.push(thinkingPreviewForTrace(block.thinking));
+        blocks.push(thinkingPreviewFragments(block.thinking));
       }
       continue;
     }
@@ -182,7 +128,7 @@ function replaceVisibleThinkingLabel(line: string, displayLabel: string, width?:
   // suffixes, but drop that old visible padding before fitting the longer preview.
   const suffix = width && width > 0 ? line.slice(end).replace(/[ \t]+$/g, "") : line.slice(end);
   const replaced = `${line.slice(0, start)}${displayLabel}${suffix}`;
-  return width && width > 0 ? truncateToWidth(replaced, Math.max(1, width), ELLIPSIS) : replaced;
+  return width && width > 0 ? middleTruncate(replaced, Math.max(1, width)) : replaced;
 }
 
 export function dedupeThinkingLabels(comp: AssistantRowDataLike, lines: string[], width?: number): string[] {
@@ -221,7 +167,7 @@ export function dedupeThinkingLabels(comp: AssistantRowDataLike, lines: string[]
           // Pi inserts a spacer between visible thinking blocks. The first label already
           // emitted this whole adjacent group, so remove only the blanks immediately
           // before its now-redundant continuation label. Transplant dropped OSC marks to
-          // the group's last preview now, never across a later semantic boundary.
+          // the group's one preview now, never across a later semantic boundary.
           let spacerMarks = "";
           while (out.length > 0 && stripAnsi(out.at(-1)!).trim().length === 0) {
             spacerMarks = `${oscSequences(out.pop()!)}${spacerMarks}`;
@@ -231,18 +177,11 @@ export function dedupeThinkingLabels(comp: AssistantRowDataLike, lines: string[]
         }
 
         flushPendingMarks();
-        let firstRow = true;
-        for (const row of plan.rows) {
-          if (row === undefined) {
-            out.push("");
-            continue;
-          }
-          // Only the first replacement inherits the native row's OSC zone marks.
-          // Synthetic continuation rows keep its SGR styling but must not duplicate OSC.
-          const template = firstRow ? line : line.replace(OSC_SEQUENCE, "");
-          out.push(row === FALLBACK_LABEL ? template : replaceVisibleThinkingLabel(template, `Thinking: ${row}`, width));
-          firstRow = false;
-        }
+        out.push(
+          plan.row === FALLBACK_LABEL
+            ? line
+            : replaceVisibleThinkingLabel(line, `Thinking: ${plan.row}`, width),
+        );
         activePreviewLineAt = out.length - 1;
         continue;
       }

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -194,7 +194,7 @@ test("real AssistantMessageComponent satisfies traceline's assistant duck type",
   assert.equal(peek.hideThinkingBlock, true, "hideThinkingBlock no longer mirrors setHideThinkingBlock — collapse state desyncs");
 });
 
-test("adjacent thinking blocks get one native run label; traceline expands their previews", () => {
+test("adjacent thinking blocks get one native run label; traceline appends one preview", () => {
   pi.initTheme(undefined, false);
   const component = new pi.AssistantMessageComponent(assistantMessage([
     { type: "thinking", thinking: "first reasoning segment" },
@@ -213,8 +213,8 @@ test("adjacent thinking blocks get one native run label; traceline expands their
   assert.equal(labelCount(deduped), 0, "native placeholders should become trace previews");
   assert.deepEqual(
     deduped.map((line) => traceline.stripAnsi(line).trim()),
-    ["", "Thinking: first reasoning segment", "Thinking: second reasoning segment"],
-    "adjacent source blocks remain visible without Pi's inter-label spacer",
+    ["", "Thinking: first reasoning segment · second reasoning segment"],
+    "adjacent source blocks append without Pi's inter-label spacer",
   );
 
   // pi marks the message's first and last lines with OSC 133 zone marks; the dedupe must

--- a/tests/contract/pi-thinking-preview.test.ts
+++ b/tests/contract/pi-thinking-preview.test.ts
@@ -44,7 +44,7 @@ test("empty thinking blocks are skipped natively and do not shift Traceline prev
   );
 });
 
-test("one native run label becomes a multiline preview across adjacent empty fragments", () => {
+test("one native run label becomes one appended preview across adjacent empty fragments", () => {
   const { native, preview } = collapsedLines([
     { type: "thinking", thinking: "first adjacent step" },
     { type: "thinking", thinking: "" },
@@ -60,9 +60,7 @@ test("one native run label becomes a multiline preview across adjacent empty fra
   );
   assert.deepEqual(preview, [
     "",
-    "Thinking: first adjacent step",
-    "Thinking: second adjacent step",
-    "Thinking: third adjacent step",
+    "Thinking: first adjacent step · second adjacent step · third adjacent step",
   ]);
 });
 
@@ -86,19 +84,17 @@ test("tool calls and text keep native boundaries between thinking runs", () => {
   ]);
 });
 
-test("a single collapsed block keeps multiline and prose paragraph rendering", () => {
+test("a single collapsed block flattens source lines and prose paragraphs", () => {
   const { preview } = collapsedLines([
     { type: "thinking", thinking: "single first line\n\nsingle second line" },
   ]);
   assert.deepEqual(preview, [
     "",
-    "Thinking: single first line",
-    "",
-    "Thinking: single second line",
+    "Thinking: single first line · single second line",
   ]);
 });
 
-test("standalone summary paragraphs render as one tight native-backed sequence", () => {
+test("standalone summary paragraphs append into one native-backed row", () => {
   const { native, preview } = collapsedLines([
     { type: "thinking", thinking: "**Planning the change**\n\n**Implementing the renderer**" },
     { type: "thinking", thinking: "**Verifying the result**\n\n**Preparing the report**" },
@@ -106,9 +102,6 @@ test("standalone summary paragraphs render as one tight native-backed sequence",
   assert.equal(native.filter((line) => line === "Thinking...").length, 1);
   assert.deepEqual(preview, [
     "",
-    "Thinking: Planning the change",
-    "Thinking: Implementing the renderer",
-    "Thinking: Verifying the result",
-    "Thinking: Preparing the report",
+    "Thinking: Planning the change · Imp…Verifying the result · Preparing the report",
   ]);
 });

--- a/tests/fixtures/goldens/traceline-rows-120.txt
+++ b/tests/fixtures/goldens/traceline-rows-120.txt
@@ -3,9 +3,7 @@ Let me look at the failing suite.
 
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5                                          1.4k ch
 
-Thinking: Checking the typecheck before the next command.
-Thinking: The previous test output was noisy.
-Thinking: Reading the paginated file next.
+Thinking: Checking the typecheck before the next comma…revious test output was noisy. · Reading the paginated file next.
   ▏ › $ ⋯ npm run typecheck                                                                                   14.2k ch
   ▏ › read ~/projects/pine-of-glass/extensions/pi-cachemire/index.ts:1-200,201-400,401-600          3 calls · 51.1k ch
   ▏ › read ~/projects/pine-of-glass/extensions/pi-cachemire/ render.ts:1-80, README.md:1-40          2 calls · 5.2k ch

--- a/tests/fixtures/goldens/traceline-rows-80.txt
+++ b/tests/fixtures/goldens/traceline-rows-80.txt
@@ -3,9 +3,7 @@ Let me look at the failing suite.
 
   ▏ › $ cd ~/projects/pine-of-glass && npm test 2>/dev/null | tail -5  1.4k ch
 
-Thinking: Checking the typecheck before the next command.
-Thinking: The previous test output was noisy.
-Thinking: Reading the paginated file next.
+Thinking: Checking the typecheck bef…s noisy. · Reading the paginated file next.
   ▏ › $ ⋯ npm run typecheck                                           14.2k ch
   ▏ › read ~/projects/pine-of…dex.ts:1-200,201-400,401-600  3 calls · 51.1k ch
   ▏ › read ~/projects/pine-of…ass/extensions/pi-cachemire/   2 calls · 5.2k ch

--- a/tests/smoke/traceline-empty-thinking-smoke.mjs
+++ b/tests/smoke/traceline-empty-thinking-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Resume a real Pi session whose assistant message contains adjacent thinking blocks,
 // standalone bold summary paragraphs, and empty fragments interleaved. The collapsed
-// preview must stay tight and aligned. A past Traceline implementation entered a
+// run must render as one appended line. A past Traceline implementation entered a
 // synchronous loop on an empty block, so every subprocess call is bounded and the
 // uniquely launched Pi is killed on timeout.
 import { spawnSync } from "node:child_process";
@@ -14,12 +14,8 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const extensionPath = join(repoRoot, "extensions", "pi-traceline", "index.ts");
 const tmuxSession = `pog-empty-thinking-${process.pid}`;
 const sentinel = "GROUPED_THINKING_RESUME_SENTINEL";
-const previews = [
-  "Thinking: first adjacent reasoning step",
-  "Thinking: second adjacent reasoning step",
-  "Thinking: third adjacent reasoning step",
-  "Thinking: fourth adjacent reasoning step",
-];
+const firstPreviewFragment = "Thinking: first adjacent reasoning step";
+const latestPreviewFragment = "fourth adjacent reasoning step";
 const hardDeadline = Date.now() + 45_000;
 let launchedPid;
 let fixtureHome;
@@ -55,6 +51,10 @@ function capturePane() {
   return run(["tmux", "capture-pane", "-p", "-t", tmuxSession, "-S", "-500"], {
     timeoutMs: 2_000,
   }).stdout ?? "";
+}
+
+function previewRows(pane) {
+  return pane.split("\n").map((line) => line.trim()).filter((line) => line.startsWith("Thinking: "));
 }
 
 function sleep(ms) {
@@ -184,19 +184,24 @@ try {
 
   while (Date.now() < hardDeadline && hasTmuxSession()) {
     lastPane = capturePane();
-    if (lastPane.includes(sentinel) && previews.every((preview) => lastPane.includes(preview))) break;
+    const rows = previewRows(lastPane);
+    if (
+      lastPane.includes(sentinel)
+      && rows.length === 1
+      && rows[0].includes(firstPreviewFragment)
+      && rows[0].includes(latestPreviewFragment)
+    ) break;
     sleep(250);
   }
   if (!lastPane.includes(sentinel)) {
     throw new Error(`resumed session did not render before the hard watchdog\n${lastPane}`);
   }
-  if (!previews.every((preview) => lastPane.includes(preview))) {
-    throw new Error(`collapsed preview lost adjacent thinking content\n${lastPane}`);
+  const rows = previewRows(lastPane);
+  if (rows.length !== 1) {
+    throw new Error(`collapsed thinking run rendered as ${rows.length} rows instead of one\n${lastPane}`);
   }
-  const paneLines = lastPane.split("\n").map((line) => line.trim());
-  const previewRows = previews.map((preview) => paneLines.indexOf(preview));
-  if (!previewRows.every((row, index) => index === 0 || row === previewRows[index - 1] + 1)) {
-    throw new Error(`adjacent thinking previews were separated by native spacers\n${lastPane}`);
+  if (!rows[0].includes(firstPreviewFragment) || !rows[0].includes(latestPreviewFragment)) {
+    throw new Error(`one-line preview lost its opening or newest fragment\n${lastPane}`);
   }
 
   run(["tmux", "send-keys", "-t", tmuxSession, "/quit", "Enter"], { timeoutMs: 2_000 });
@@ -204,7 +209,7 @@ try {
   while (Date.now() < exitDeadline && hasTmuxSession()) sleep(100);
   if (hasTmuxSession()) throw new Error("resumed Pi rendered but did not respond to /quit");
 
-  console.log("real-Pi grouped-thinking resume smoke passed");
+  console.log("real-Pi one-line thinking resume smoke passed");
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;

--- a/tests/traceline/thinking-preview.test.ts
+++ b/tests/traceline/thinking-preview.test.ts
@@ -1,5 +1,5 @@
 // Collapsed-thinking preview grammar (design language §9.11): adjacent provider
-// fragments form one multiline run, while every non-thinking content entry is a
+// fragments append into one display row, while every non-thinking content entry is a
 // semantic boundary. The installed-Pi suite separately pins native label spacing.
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -14,13 +14,13 @@ function thinkingComp(content: Array<Record<string, unknown>>) {
   return { hiddenThinkingLabel: "Thinking...", lastMessage: { content } };
 }
 
-test("a single block preserves reasoning lines, prose paragraph breaks, and width", () => {
+test("a single block appends every non-empty line into one width-bounded preview", () => {
   const multiline = thinkingComp([
     { type: "thinking", thinking: "\n  **first reasoning line**\nsecond reasoning line" },
   ]);
   assert.deepEqual(
     dedupeThinkingLabels(multiline, ["", LABEL]),
-    ["", preview("first reasoning line"), preview("second reasoning line")],
+    ["", preview("first reasoning line · second reasoning line")],
   );
 
   const paragraphs = thinkingComp([
@@ -28,8 +28,8 @@ test("a single block preserves reasoning lines, prose paragraph breaks, and widt
   ]);
   assert.deepEqual(
     dedupeThinkingLabels(paragraphs, [LABEL]),
-    [preview("first paragraph"), "", preview("second paragraph")],
-    "long source blank runs collapse to one display line",
+    [preview("first paragraph · second paragraph")],
+    "source paragraph breaks do not create display rows",
   );
 
   const mixedParagraphs = thinkingComp([
@@ -37,8 +37,8 @@ test("a single block preserves reasoning lines, prose paragraph breaks, and widt
   ]);
   assert.deepEqual(
     dedupeThinkingLabels(mixedParagraphs, [LABEL]),
-    [preview("Planning summary"), "", preview("ordinary prose paragraph"), "", preview("Next summary")],
-    "standalone summaries do not erase real prose boundaries",
+    [preview("Planning summary · ordinary prose paragraph · Next summary")],
+    "summary and prose fragments follow the same one-line rule",
   );
 
   const literalStar = dedupeThinkingLabels(
@@ -48,15 +48,21 @@ test("a single block preserves reasoning lines, prose paragraph breaks, and widt
   assert.equal(stripAnsi(literalStar).trim(), "Thinking: 2 * 3 = 6", "markdown rendering preserves genuine stars");
 
   const long = dedupeThinkingLabels(
-    thinkingComp([{ type: "thinking", thinking: "a very long reasoning preview" }]),
+    thinkingComp([{
+      type: "thinking",
+      thinking: "first framing thought\nintermediate detail that will be cut\nnewest appended thought",
+    }]),
     [LABEL],
-    18,
+    52,
   )[0]!;
-  assert.ok(stripAnsi(long).length <= 18, `preview must respect row width: ${stripAnsi(long)}`);
-  assert.ok(stripAnsi(long).startsWith("Thinking:"), stripAnsi(long));
+  const visibleLong = stripAnsi(long);
+  assert.ok(visibleLong.length <= 52, `preview must respect row width: ${visibleLong}`);
+  assert.ok(visibleLong.startsWith("Thinking: first"), visibleLong);
+  assert.ok(visibleLong.includes("…"), visibleLong);
+  assert.ok(visibleLong.endsWith("newest appended thought"), visibleLong);
 });
 
-test("three adjacent blocks form one tight multiline preview", () => {
+test("three adjacent blocks append into one preview row", () => {
   const adjacent = thinkingComp([
     { type: "thinking", thinking: "first reasoning block" },
     { type: "thinking", thinking: "second reasoning block" },
@@ -66,14 +72,12 @@ test("three adjacent blocks form one tight multiline preview", () => {
     dedupeThinkingLabels(adjacent, ["", LABEL, "", LABEL, "", LABEL]),
     [
       "",
-      preview("first reasoning block"),
-      preview("second reasoning block"),
-      preview("third reasoning block"),
+      preview("first reasoning block · second reasoning block · third reasoning block"),
     ],
   );
 });
 
-test("standalone summary paragraphs stay tight within and across provider blocks", () => {
+test("standalone summary paragraphs append within and across provider blocks", () => {
   const sessionShape = thinkingComp([
     {
       type: "thinking",
@@ -86,12 +90,10 @@ test("standalone summary paragraphs stay tight within and across provider blocks
   ]);
   assert.deepEqual(
     dedupeThinkingLabels(sessionShape, [LABEL]),
-    [
-      preview("Implementing conditional HUD rendering"),
-      preview("Assigning active inline renderer in factory"),
-      preview("Refining editor text update flow"),
-      preview("Implementing dispatch control around edits"),
-    ],
+    [preview(
+      "Implementing conditional HUD rendering · Assigning active inline renderer in factory · "
+      + "Refining editor text update flow · Implementing dispatch control around edits",
+    )],
   );
 });
 
@@ -104,7 +106,7 @@ test("empty thinking fragments neither consume labels nor break adjacency", () =
   ]);
   assert.deepEqual(
     dedupeThinkingLabels(interleaved, ["", LABEL, "", LABEL]),
-    ["", preview("first reasoning block"), preview("second reasoning block")],
+    ["", preview("first reasoning block · second reasoning block")],
   );
 });
 
@@ -154,8 +156,7 @@ test("OSC marks from grouped labels stay before later semantic content", () => {
     [LABEL, "", `${markedEnd}${LABEL}`, "", "visible boundary", LABEL],
   );
   assert.deepEqual(out, [
-    preview("first grouped step"),
-    `${markedEnd}${preview("second grouped step")}`,
+    `${markedEnd}${preview("first grouped step · second grouped step")}`,
     "",
     "visible boundary",
     preview("later separate step"),
@@ -188,8 +189,8 @@ test("fallback labels fold only within a known run and preserve OSC marks", () =
   ]);
   assert.deepEqual(
     dedupeThinkingLabels(mixedAdjacent, [LABEL, "", `${markedEnd}${LABEL}`]),
-    [preview("visible step"), `${markedEnd}${LABEL}`],
-    "an unpreviewable block keeps one fallback row and receives its native OSC mark",
+    [`${markedEnd}${preview("visible step")}`],
+    "an unpreviewable fragment adds no row and its native OSC mark reaches the run preview",
   );
 
   const controlOnlySeparated = thinkingComp([
@@ -212,9 +213,9 @@ test("fallback labels fold only within a known run and preserve OSC marks", () =
   const multiline = thinkingComp([{ type: "thinking", thinking: "first\nsecond" }]);
   const marked = `\x1b]133;C\x07${LABEL}`;
   const out = dedupeThinkingLabels(multiline, [marked]);
-  assert.equal(out.length, 2);
+  assert.equal(out.length, 1);
   assert.ok(out[0]!.startsWith("\x1b]133;C\x07"), `native zone mark must survive: ${JSON.stringify(out)}`);
-  assert.equal((out.join("").match(/\x1b\]133;C\x07/g) ?? []).length, 1, "synthetic rows do not duplicate OSC marks");
+  assert.equal((out.join("").match(/\x1b\]133;C\x07/g) ?? []).length, 1, "the one preview keeps one OSC mark");
 
   assert.deepEqual(
     dedupeThinkingLabels({ hiddenThinkingLabel: "Pondering…" }, ["Pondering…", "", "Pondering…"]),


### PR DESCRIPTION
## Summary
- flatten every adjacent collapsed thinking run to exactly one `Thinking: …` row
- append non-empty source fragments inline with ` · ` separators, regardless of prose or Markdown paragraph breaks
- middle-truncate the row so opening context and the newest appended thought remain visible
- update pure, installed-Pi, golden, and real-TUI smoke coverage to pin the one-line contract

## Verification
- `npm run check` (213 tests)
- `npm run test:smoke`
- exact reported session replay: 42 source fragments -> 1 display row
- focused and full-context visual verification in real Pi 0.80.9 TUI
