### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0 (unreleased)
+## 0.7.0 (2026-07-16)
 
 New extension: `pi-meantime` (experimental, issue #26) answers "where did the
 time go?" pi's footer counts elapsed time; meantime decomposes it, in the same


### PR DESCRIPTION
## Summary
- finalize the existing `0.7.0` changelog with the release date
- release changes accumulated since `v0.6.2`: Meantime, Cachemire compaction splits, sibling-read folding, and one-line thinking runs

## Release verification
- `npm run check` (213 tests)
- `npm run test:smoke`
- `npm pack --dry-run --json` (50 files; all four extensions and shared runtime files present)
- npm authentication confirmed; `pine-of-glass@0.7.0` is available
