### PR TITLE
Traceline: make middle truncation grapheme-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Traceline: keep wide-grapheme cuts on the exact alignment grid.** The v0.8.2
+  overflow fix safely dropped a grapheme that crossed a truncation boundary but
+  could leave that row one column short. Vacated cells are now padded so related
+  rows retain identical ellipsis and right-edge columns. Independently reported
+  and contributed in #43 by @KorenKrita.
+
 ## 0.8.2 (2026-07-20)
 
 - Fix a crash when a truncated row contained a wide grapheme near the cut.
@@ -7,10 +15,8 @@
   family row) counted characters against a terminal-column budget, so a 2-column
   grapheme such as an emoji could push the rendered line one column past the
   terminal width and Pi's render guard exited the session. Cuts are now measured
-  in columns and a grapheme straddling a cut is dropped whole; padding keeps the
-  row on its exact alignment grid without risking overflow (design language §9.8).
-  Independently reported by @KorenKrita in #43, who contributed the grapheme-safe
-  exact-alignment follow-up.
+  in columns and a grapheme straddling a cut is dropped from that side, leaving
+  the row one column short rather than one over (design language §9.8).
 
 ## 0.8.1 (2026-07-18)
 

--- a/extensions/_lib/style.ts
+++ b/extensions/_lib/style.ts
@@ -186,12 +186,33 @@ function activeSgrAt(line: string, rawIndex: number): string {
   return [...state.values()].join("");
 }
 
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function columnBoundary(
+  text: string,
+  target: number,
+  round: "down" | "up",
+): { plainIndex: number; column: number } {
+  let column = 0;
+  for (const { segment, index } of GRAPHEME_SEGMENTER.segment(text)) {
+    const nextColumn = column + visibleWidth(segment);
+    if (target <= column) return { plainIndex: index, column };
+    if (target < nextColumn) {
+      return round === "up"
+        ? { plainIndex: index + segment.length, column: nextColumn }
+        : { plainIndex: index, column };
+    }
+    column = nextColumn;
+  }
+  return { plainIndex: text.length, column };
+}
+
 export function middleTruncate(line: string, width: number, theme?: Theme): string {
   const maxWidth = Math.max(1, width);
   if (visibleWidth(line) <= maxWidth) return line;
 
   const vis = stripAnsi(line);
-  const visLen = vis.length;
+  const visLen = visibleWidth(vis);
   const ellipsisWidth = visibleWidth(ELLIPSIS);
   const budget = Math.max(1, maxWidth - ellipsisWidth); // reserve columns for the ellipsis
 
@@ -200,18 +221,22 @@ export function middleTruncate(line: string, width: number, theme?: Theme): stri
 
   // The cut is a column (design language §9.8): the tail is exactly `maxTail` wide and
   // the head exactly fills the rest, so every line truncated to the same budget cuts at
-  // identical columns and fills the budget exactly. No content-dependent snapping — a
-  // mid-token cut beside a dim ellipsis is legible; a wandering ellipsis column is not.
+  // identical columns and fills the budget exactly. Wide graphemes that cross either cut
+  // round out of the retained spans; padding keeps the ellipsis and right edge fixed.
   const tailStart = visLen - maxTail;
+  const tailBoundary = columnBoundary(vis, tailStart, "up");
   const dimEllipsis = ink(theme, "dim", ELLIPSIS);
-  const tailRawStart = rawIndexAtVisibleIndex(line, tailStart);
+  const tailRawStart = rawIndexAtVisibleIndex(line, tailBoundary.plainIndex);
   const tailRaw = `${activeSgrAt(line, tailRawStart)}${line.slice(tailRawStart)}`;
+  const tailPadding = Math.max(0, maxTail - (visLen - tailBoundary.column));
 
   const headEnd = budget - maxTail;
-  if (headEnd <= 0) return `${dimEllipsis}${tailRaw}`;
+  if (headEnd <= 0) return `${dimEllipsis}${" ".repeat(tailPadding)}${tailRaw}`;
 
-  const headRaw = line.slice(0, rawIndexAtVisibleIndex(line, headEnd));
-  return `${headRaw}${RESET}${dimEllipsis}${tailRaw}`;
+  const headBoundary = columnBoundary(vis, headEnd, "down");
+  const headRaw = line.slice(0, rawIndexAtVisibleIndex(line, headBoundary.plainIndex));
+  const headPadding = Math.max(0, headEnd - headBoundary.column);
+  return `${headRaw}${RESET}${" ".repeat(headPadding)}${dimEllipsis}${" ".repeat(tailPadding)}${tailRaw}`;
 }
 
 /** Quantities right (design language §5): body left, right-aligned suffix, ≥2-space gap

--- a/tests/traceline/thinking-preview.test.ts
+++ b/tests/traceline/thinking-preview.test.ts
@@ -4,6 +4,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { stripAnsi } from "../../extensions/_lib/ansi.ts";
 import { dedupeThinkingLabels } from "../../extensions/pi-traceline/thinking-preview.ts";
 
@@ -56,10 +57,17 @@ test("a single block appends every non-empty line into one width-bounded preview
     52,
   )[0]!;
   const visibleLong = stripAnsi(long);
-  assert.ok(visibleLong.length <= 52, `preview must respect row width: ${visibleLong}`);
+  assert.ok(visibleWidth(long) <= 52, `preview must respect row width: ${visibleLong}`);
   assert.ok(visibleLong.startsWith("Thinking: first"), visibleLong);
   assert.ok(visibleLong.includes("…"), visibleLong);
   assert.ok(visibleLong.endsWith("newest appended thought"), visibleLong);
+
+  const wide = dedupeThinkingLabels(
+    thinkingComp([{ type: "thinking", thinking: `提交内容 ${"analysis ".repeat(40)}` }]),
+    [LABEL],
+    187,
+  )[0]!;
+  assert.equal(visibleWidth(wide), 187, `wide-character preview must fit: ${stripAnsi(wide)}`);
 });
 
 test("three adjacent blocks append into one preview row", () => {

--- a/tests/traceline/truncation.test.ts
+++ b/tests/traceline/truncation.test.ts
@@ -49,6 +49,33 @@ test("tiny widths fall back without exceeding budget", () => {
   }
 });
 
+test("wide characters respect column budgets without splitting graphemes", () => {
+  const fixtures = [
+    `Thinking: 提交内容 ${"a".repeat(220)}`,
+    `head ${"👩‍💻".repeat(40)} tail ${"x".repeat(120)}`,
+  ];
+  const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+  for (const input of fixtures) {
+    const boundaries = new Set([...segmenter.segment(input)].map(({ index }) => index));
+    boundaries.add(input.length);
+
+    for (const width of [21, 52, 80, 187]) {
+      const out = middleTruncate(input, width);
+      const visible = stripAnsi(out);
+      const cut = visible.indexOf(ELLIPSIS);
+      const head = visible.slice(0, cut).trimEnd();
+      const tail = visible.slice(cut + ELLIPSIS.length).trimStart();
+
+      assert.equal(visibleWidth(out), width, `visible width must equal ${width}: ${JSON.stringify(visible)}`);
+      assert.ok(input.startsWith(head), `head must prefix the input: ${JSON.stringify(head)}`);
+      assert.ok(input.endsWith(tail), `tail must suffix the input: ${JSON.stringify(tail)}`);
+      assert.ok(boundaries.has(head.length), `head split a grapheme: ${JSON.stringify(head)}`);
+      assert.ok(boundaries.has(input.length - tail.length), `tail split a grapheme: ${JSON.stringify(tail)}`);
+    }
+  }
+});
+
 test("the cut is a column: equal budgets cut at identical columns and fill exactly (§9.8)", () => {
   const a = "$ git log --oneline --graph --decorate --all --color=never -n 50 | head -30";
   const b = "read ~/somewhere/completely/different/path/to/a/deeply/nested/file.tsx:12-400";


### PR DESCRIPTION
## Summary

- calculate middle-truncation cuts in terminal columns instead of UTF-16 code units
- round cuts away from partial grapheme clusters, then pad the skipped cell so the ellipsis and right edge stay aligned
- cover CJK and ZWJ emoji, including a collapsed thinking preview at 187 columns

## Problem

`middleTruncate` checked the final line with `visibleWidth`, but derived its head and tail cuts from `stripAnsi(line).length`. CJK text therefore occupied more terminal columns than the cut calculation allowed. A collapsed Traceline thinking preview could render wider than the terminal, which Pi's TUI correctly rejects.

The new column-boundary helper segments the ANSI-stripped text by grapheme, measures each segment with Pi TUI's `visibleWidth`, and maps the resulting UTF-16 offsets back to the ANSI-bearing source. If a wide grapheme crosses a cut, it is excluded whole and the missing cell is padded, preserving the existing fixed-column layout contract.

## Verification

- `PI_CACHE_RETENTION=short npm run check` (214 tests)
- `npm run test:smoke:traceline`
- direct 187-column CJK replay returns `visibleWidth === 187`
