### PR TITLE
fix(cachemire): isolate interactive session state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Cachemire: isolate interactive-session state.** Nested headless Pi
+  `AgentSession`s can load the same extension in the interactive process; their
+  lifecycle and provider events no longer overwrite the root session's ledger,
+  cache clock or model metadata. Reported in #44 and contributed in #45 by
+  @0xbentang (Ben Tang).
+
 ## 0.8.2 (2026-07-20)
 
 - Fix a crash when a truncated row contained a wide grapheme near the cut.

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -166,6 +166,12 @@ the event boundary and are never persisted: restored rows say `cause unknown` ra
 than reconstruct a diagnosis from vibes, and cachemire writes nothing into session
 entries or exports (UI-only contract).
 
+Only the Pi extension instance with an interactive UI may own that process-global
+working state. A nested headless `AgentSession` still loads the extension, but its
+lifecycle and provider events are ignored; it cannot overwrite the interactive
+ledger, cache clock or model metadata. The interactive instance releases ownership
+on `session_shutdown` so the next interactive lifecycle can claim it cleanly.
+
 This trade-off fits the current goal: live legibility (repo README, plan 1). Plan 2
 (post-hoc analysis of stored sessions and traces, RPC/remote runs, fleets of agent
 sessions) would need those request-time observations *after* the fact, which means

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,7 +53,7 @@ Layout:
 
 ```
 tests/
-  contract/pi-internals.test.ts      # layer 1: drift
+  contract/*.test.ts                 # layer 1: Pi drift and lifecycle contracts
   contextimate/*.test.ts             # layer 2/3
   traceline/*.test.ts                # layer 2
   cachemire/*.test.ts                # layer 2/3
@@ -64,10 +64,9 @@ scripts/dev/link-pi-runtime.sh
 
 ## Layer 1: contract tests against the installed Pi (drift)
 
-`tests/contract/pi-internals.test.ts` imports the real installed Pi and asserts every
-structural assumption the extensions make. Each assertion names the extension code that
-depends on it. When `pi update` breaks one, the failure message says exactly which seam
-moved.
+`tests/contract/*.test.ts` import the real installed Pi and assert every structural
+assumption the extensions make. Each assertion names the extension code that depends on
+it. When `pi update` breaks one, the failure message says exactly which seam moved.
 
 | Assumption | Depended on by |
 |---|---|
@@ -77,6 +76,7 @@ moved.
 | `ToolExecutionComponent` (or successor) instances satisfy `isToolRow`: `render`, `setExpanded`, `toolName` in instance; prototype is patchable | traceline prototype patch |
 | Assistant message component satisfies `isAssistantRow`: `setHideThinkingBlock` fn + `hideThinkingBlock` boolean | traceline collapse-state source of truth |
 | A collapsed `AssistantMessageComponent` skips empty thinking blocks, emits one label per adjacent thinking run, and keeps native spacers across tool and text boundaries | traceline grouped thinking previews |
+| Two extensions loaded through Pi's real factory loader and `ExtensionRunner` distinguish headless and interactive sessions through `ctx.hasUI`; a headless child cannot write into Cachemire's interactive ledger, while the root still can | cachemire process-global session ownership |
 | `ExtensionAPI` exposes `getActiveTools()` ⊆ `getAllTools()` by name; `ToolInfo` has `name`, `description`, `parameters`, `sourceInfo{scope,source,origin,path}`, `promptGuidelines` | contextimate tools section |
 
 Where instantiating real components is impractical, the contract test asserts on the

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -15,6 +15,7 @@ import {
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import { GLYPH, SCALE, SEP, ink, panelHeader, type Tone } from "../_lib/style.ts";
+import { settleDanglingSend } from "./lifecycle.ts";
 import { promptTokens, renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
 
 /**
@@ -648,27 +649,6 @@ function cacheClock(input: ClockInput): ClockState {
   return { phase: "warm-unknown", text: `cache likely warm \u00b7 ${formatDuration(since)} since last call` };
 }
 
-// --- aborted sends ----------------------------------------------------------------------
-
-/** Settle the clock anchor for a send that ended without billed usage (abort or error).
- * before_provider_request moves the anchor to the in-flight request optimistically —
- * right for every send whose usage arrives, including mid-stream aborts (Anthropic
- * delivers prompt-side usage in message_start, which survives an abort). What lands here
- * is the remainder: fast aborts and errors where usage never arrived, so nothing proves
- * the provider processed — and so refreshed or wrote — the prefix (on a first send there
- * may be no entry at all). The anchor rolls back to the last billed request, the only
- * provider-confirmed refresh; a first-send abort clears it outright (the clock hides).
- * If the aborted send did touch the cache after all, the next call resolves green
- * ("cache held") — the same correction path as any wrong prediction. */
-function settleDanglingSend(state: {
-  pendingRequestAt?: number;
-  prevCallRequestAt?: number;
-  lastRequestAt?: number;
-}): { changed: boolean; lastRequestAt?: number } {
-  if (state.pendingRequestAt === undefined) return { changed: false, lastRequestAt: state.lastRequestAt };
-  return { changed: true, lastRequestAt: state.prevCallRequestAt };
-}
-
 // --- ledger lines ----------------------------------------------------------------------
 
 // The family status scale (design language §1): ○ cold · ● hit · ◑ partial · ◌ miss.
@@ -860,6 +840,7 @@ interface CachemireState {
 type CachemireGlobal = typeof globalThis & {
   __piCachemire?: CachemireState;
   __piCachemireTimer?: ReturnType<typeof setInterval>;
+  __piCachemireOwner?: symbol;
 };
 const g = globalThis as CachemireGlobal;
 
@@ -937,8 +918,13 @@ function resolveNotice(text: string): void {
 
 export default function piCachemire(pi: ExtensionAPI): void {
   const s = state();
+  const ownerToken = Symbol("pi-cachemire-owner");
+  const ownsState = () => g.__piCachemireOwner === ownerToken;
 
   pi.on("session_start", async (_event, ctx) => {
+    if (!ctx.hasUI) return;
+    if (g.__piCachemireOwner !== undefined && !ownsState()) return;
+    g.__piCachemireOwner = ownerToken;
     s.config = loadConfig(process.cwd());
     const { messages } = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId());
     s.records = restoreFromMessages(messages as unknown as Array<Record<string, unknown>>);
@@ -990,11 +976,14 @@ export default function piCachemire(pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", async () => {
+    if (!ownsState()) return;
     if (g.__piCachemireTimer) clearInterval(g.__piCachemireTimer);
     g.__piCachemireTimer = undefined;
+    g.__piCachemireOwner = undefined;
   });
 
   pi.on("before_provider_request", async (event) => {
+    if (!ownsState()) return;
     s.pendingFingerprint = fingerprintPayload(event.payload);
     s.pendingRequestAt = Date.now();
     // TTL anchor = request start: providers read/refresh/write cache entries while
@@ -1041,6 +1030,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
   });
 
   pi.on("model_select", async (event) => {
+    if (!ownsState()) return;
     const model = event.model;
     s.rates = model.cost;
     s.modelLabel = `${model.provider}/${model.id}`;
@@ -1057,6 +1047,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
   });
 
   pi.on("thinking_level_select", async (event, ctx) => {
+    if (!ownsState()) return;
     // First flip in a session: the event's own previousLevel is the level every billed
     // call so far used — a baseline that needs no session_start timing assumptions.
     s.lastCallThinkingLevel ??= event.previousLevel;
@@ -1070,19 +1061,23 @@ export default function piCachemire(pi: ExtensionAPI): void {
   });
 
   pi.on("agent_start", async () => {
+    if (!ownsState()) return;
     s.run = { startedAt: Date.now(), calls: 0, input: 0, cacheRead: 0, cacheWrite: 0, output: 0, costUsd: 0 };
   });
 
   pi.on("session_before_compact", async () => {
+    if (!ownsState()) return;
     s.inCompaction = true;
   });
 
   pi.on("session_compact", async () => {
+    if (!ownsState()) return;
     s.inCompaction = false;
     s.compacted = true;
   });
 
   pi.on("message_end", async (event) => {
+    if (!ownsState()) return;
     const message = event.message;
     if (message.role !== "assistant") return;
     const usage = message.usage;
@@ -1185,6 +1180,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
   });
 
   pi.on("agent_end", async () => {
+    if (!ownsState()) return;
     // A notice whose call never produced usage (abort/error) must not dangle as "breaking".
     resolveNotice(econLine("dim", "cache \u00b7 send ended without usage (aborted?) \u00b7 outcome unknown"));
     // Same honesty for the clock: a send that never produced usage must not keep the TTL
@@ -1206,7 +1202,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
   pi.registerCommand("cache", {
     description: "Show the cachemire cache & loop ledger",
     handler: async (_args, ctx) => {
-      if (!ctx.hasUI) return;
+      if (!ownsState() || !ctx.hasUI) return;
       const lines = renderLedger(s.records, {
         providerLabel: s.providerLabel,
         window: s.window,

--- a/extensions/pi-cachemire/lifecycle.ts
+++ b/extensions/pi-cachemire/lifecycle.ts
@@ -1,0 +1,15 @@
+/** Settle the clock anchor for a send that ended without billed usage (abort or error).
+ * before_provider_request moves the anchor to the in-flight request optimistically,
+ * which is right for every send whose usage arrives. What lands here is the remainder:
+ * fast aborts and errors where usage never arrived, so nothing proves the provider
+ * processed, refreshed, or wrote the prefix. The anchor rolls back to the last billed
+ * request, the only provider-confirmed refresh. On a first-send abort it clears outright.
+ * If the aborted send did touch the cache after all, the next call resolves green. */
+export function settleDanglingSend(state: {
+  pendingRequestAt?: number;
+  prevCallRequestAt?: number;
+  lastRequestAt?: number;
+}): { changed: boolean; lastRequestAt?: number } {
+  if (state.pendingRequestAt === undefined) return { changed: false, lastRequestAt: state.lastRequestAt };
+  return { changed: true, lastRequestAt: state.prevCallRequestAt };
+}

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -5,7 +5,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 1258,
+      "extensions/pi-cachemire/index.ts": 1254,
       "extensions/pi-contextimate/index.ts": 1959,
       "extensions/pi-traceline/index.ts": 1815,
       "tests/cachemire/economics-and-render.test.ts": 352,

--- a/tests/cachemire/session-isolation.test.ts
+++ b/tests/cachemire/session-isolation.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+import piCachemire from "../../extensions/pi-cachemire/index.ts";
+
+type Handler = (...args: unknown[]) => unknown;
+
+function extensionProbe(): { pi: ExtensionAPI; handlers: Map<string, Handler[]>; commands: Map<string, Handler> } {
+  const handlers = new Map<string, Handler[]>();
+  const commands = new Map<string, Handler>();
+  const pi = {
+    on(event: string, handler: Handler): void {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+    },
+    registerCommand(name: string, options: { handler: Handler }): void {
+      commands.set(name, options.handler);
+    },
+    getThinkingLevel(): string {
+      return "off";
+    },
+  } as unknown as ExtensionAPI;
+  piCachemire(pi);
+  return { pi, handlers, commands };
+}
+
+function sessionContext(id: string, notifications?: string[]): unknown {
+  const ui = {
+    theme: undefined,
+    setWidget(): void {},
+    notify(text: string): void {
+      notifications?.push(text);
+    },
+  };
+  return {
+    hasUI: notifications !== undefined,
+    ui,
+    model: {
+      id,
+      provider: id === "root" ? "anthropic" : "ollama-cloud",
+      reasoning: false,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+    sessionManager: {
+      getSessionId: () => id,
+      getEntries: () => [],
+      getLeafId: () => undefined,
+    },
+  };
+}
+
+async function fire(probe: ReturnType<typeof extensionProbe>, event: string, ...args: unknown[]): Promise<void> {
+  for (const handler of probe.handlers.get(event) ?? []) await handler(...args);
+}
+
+const usage = (input: number) => ({
+  input,
+  output: 10,
+  cacheRead: 0,
+  cacheWrite: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+});
+
+test("a headless child activation cannot write through the interactive session", async () => {
+  const root = extensionProbe();
+  const child = extensionProbe();
+  const rootNotifications: string[] = [];
+
+  await fire(child, "session_start", {}, sessionContext("child"));
+  await fire(root, "session_start", {}, sessionContext("root", rootNotifications));
+
+  try {
+    await fire(child, "agent_start", {}, sessionContext("child"));
+    await fire(child, "before_provider_request", { payload: { model: "glm-5.2", messages: [] } });
+    await fire(child, "message_end", { message: { role: "assistant", usage: usage(32_800) } });
+    await fire(child, "before_provider_request", { payload: { model: "glm-5.2", messages: [] } });
+    await fire(child, "message_end", { message: { role: "assistant", usage: usage(33_000) } });
+    await fire(child, "agent_end", {});
+    await fire(child, "session_shutdown", {});
+    await root.commands.get("cache")?.("", sessionContext("root", rootNotifications));
+  } finally {
+    await fire(root, "session_shutdown", {});
+  }
+
+  assert.equal(rootNotifications.length, 1);
+  assert.match(rootNotifications[0]!, /no model calls yet/);
+});

--- a/tests/contract/cachemire-lifecycle.test.ts
+++ b/tests/contract/cachemire-lifecycle.test.ts
@@ -1,0 +1,139 @@
+// Installed-Pi lifecycle contract for Cachemire's process-global state. The extension
+// loader and both ExtensionRunner instances are real; core actions and UI output are
+// inert boundary adapters because their behaviour is not under test.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import * as pi from "@earendil-works/pi-coding-agent";
+
+import piCachemire from "../../extensions/pi-cachemire/index.ts";
+import { assistantMessage } from "../helpers.ts";
+
+const piRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"))), "..");
+
+type PiExtension = ConstructorParameters<typeof pi.ExtensionRunner>[0][number];
+type MinimalUi = {
+  theme: undefined;
+  setWidget: (key: string, widget: unknown) => void;
+  notify: (text: string) => void;
+};
+
+test("real ExtensionRunner keeps a headless child out of Cachemire's interactive state", async () => {
+  const loader = await import(pathToFileURL(join(piRoot, "dist/core/extensions/loader.js")).href) as {
+    loadExtensionFromFactory: (
+      factory: typeof piCachemire,
+      cwd: string,
+      eventBus: ReturnType<typeof pi.createEventBus>,
+      runtime: ReturnType<typeof pi.createExtensionRuntime>,
+      extensionPath?: string,
+    ) => Promise<PiExtension>;
+  };
+  assert.equal(
+    typeof loader.loadExtensionFromFactory,
+    "function",
+    "Pi's factory loader moved; Cachemire's nested-runner lifecycle contract needs a new seam",
+  );
+
+  const cwd = tmpdir();
+  const makeRunner = async (ui?: MinimalUi) => {
+    const runtime = pi.createExtensionRuntime();
+    const extension = await loader.loadExtensionFromFactory(
+      piCachemire,
+      cwd,
+      pi.createEventBus(),
+      runtime,
+      "pi-cachemire-contract",
+    );
+    const runner = new pi.ExtensionRunner(
+      [extension],
+      runtime,
+      cwd,
+      pi.SessionManager.inMemory(cwd),
+      {} as never,
+    );
+    runner.bindCore(
+      { getThinkingLevel: (): "off" => "off" } as never,
+      {
+        getModel: () => undefined,
+        isIdle: () => true,
+        isProjectTrusted: () => true,
+        getSignal: () => undefined,
+        abort: () => {},
+        hasPendingMessages: () => false,
+        shutdown: () => {},
+        getContextUsage: () => undefined,
+        compact: () => {},
+        getSystemPrompt: () => "",
+      },
+    );
+    if (ui) runner.setUIContext(ui as never, "tui");
+    const errors: string[] = [];
+    runner.onError((error) => errors.push(`${error.event}: ${error.error}`));
+    return { runner, errors };
+  };
+
+  const notifications: string[] = [];
+  const rootUi: MinimalUi = {
+    theme: undefined,
+    setWidget(_key, widget): void {
+      if (typeof widget === "function") widget({ requestRender: () => {} });
+    },
+    notify(text): void {
+      notifications.push(text);
+    },
+  };
+  const root = await makeRunner(rootUi);
+  const child = await makeRunner();
+  const billedMessage = (model: string, input: number) => assistantMessage([], {
+    model,
+    usage: {
+      input,
+      output: 10,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: input + 10,
+      cost: { total: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+  });
+  const showRootLedger = async () => {
+    const command = root.runner.getCommand("cache");
+    assert.ok(command, "real Pi loader did not register Cachemire's /cache command");
+    await command.handler("", root.runner.createCommandContext());
+  };
+
+  assert.equal(child.runner.hasUI(), false, "Pi no longer marks the SDK-style runner headless");
+  assert.equal(root.runner.hasUI(), true, "Pi no longer marks the interactive runner as UI-owning");
+
+  try {
+    // Production seam from issue #44: two real Pi extension instances share one process,
+    // but only the runner with a UI may own Cachemire's process-global state.
+    await child.runner.emit({ type: "session_start", reason: "startup" });
+    await root.runner.emit({ type: "session_start", reason: "startup" });
+    await child.runner.emitBeforeProviderRequest({ model: "child", messages: [] });
+    await child.runner.emitMessageEnd({
+      type: "message_end",
+      message: billedMessage("child", 32_800),
+    });
+    await showRootLedger();
+
+    await root.runner.emitBeforeProviderRequest({ model: "root", messages: [] });
+    await root.runner.emitMessageEnd({
+      type: "message_end",
+      message: billedMessage("root", 1_000),
+    });
+    await showRootLedger();
+  } finally {
+    await child.runner.emit({ type: "session_shutdown", reason: "quit" });
+    await root.runner.emit({ type: "session_shutdown", reason: "quit" });
+  }
+
+  assert.deepEqual(child.errors, [], "headless child lifecycle raised a real-runner error");
+  assert.deepEqual(root.errors, [], "interactive root lifecycle raised a real-runner error");
+  assert.equal(notifications.length, 2, "each /cache invocation should reach the root UI once");
+  assert.match(notifications[0]!, /no model calls yet/, "the child call leaked into the root ledger");
+  assert.match(notifications[1]!, /\b1\.0k\b/, "the root no longer records its own call");
+  assert.doesNotMatch(notifications[1]!, /32\.8k/, "the child call contaminated the root ledger");
+});


### PR DESCRIPTION
## Summary

- let the first UI-bound Cachemire activation own the process-global state
- keep headless in-process child activations from mutating or rendering through it
- add a regression test covering child-first startup, model calls, and shutdown

This uses conservative owner-only tracking rather than independent state for every
in-process session. Print and JSON sessions now leave Cachemire inert; RPC remains
enabled because it exposes UI support.

The unavailable-cache-telemetry behavior from #44 is intentionally deferred. It needs
a separate neutral classification and rendering decision.

The existing aborted-send helper moved to `lifecycle.ts` so the oversized entry point's
enforced line budget continues to shrink.

## Verification

- `npm run check`
- 214 tests passed

Part of #44.
