### PR TITLE
Traceline: exit drill mode on foreign modifier chords instead of eating them

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -527,6 +527,13 @@ Entry and exit:
   line); the editor draft is restored on exit
 - the transcript does not reflow: numbering re-inks the prefix of rows already
   on screen, and one line stays one line
+- the mode owns only its documented keys, all unmodified. A modifier chord it
+  does not understand (option+up, option+enter, ctrl+c, …) exits the mode at
+  once, from the hint bar or the pager alike, and is not consumed: pi restores
+  the editor synchronously, the same keystroke lands there, and it does what
+  it always does. Drill never silently eats a chord that means something
+  outside it. Re-pressing the entry chord therefore re-freezes the numbering
+  through its own shortcut, and a key release never exits
 
 Numbering:
 

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -67,6 +67,8 @@ Press `Alt+T` (or run `/drill`) to number the tool rows in place. The transcript
 - press `p` to expand or collapse the selected row in place, using Pi's native tool row
 - press `esc` to leave
 
+A modifier chord drill mode does not own (`Option+Up`, `Ctrl+C`, …) leaves the mode and still does its normal job: the editor is restored first, then the same keystroke lands in it. Drill mode never silently eats a shortcut that means something outside it.
+
 The pager shows the row's trace line, then the complete invocation and the complete result. Scroll with `j`/`k`, the arrow keys, the page keys or `g`/`G`. Press `h`/`l` to move to the neighbouring row without closing. Press `esc` to return to the numbered transcript, exactly as you left it.
 
 The most common case takes two keys: `Alt+T`, then `1` for the latest call.

--- a/extensions/pi-traceline/drill-input.ts
+++ b/extensions/pi-traceline/drill-input.ts
@@ -1,0 +1,56 @@
+// Drill mode's raw terminal-input hook (design language §9.13), fed by traceline's
+// onTerminalInput listener in index.ts. While the mode is active every mouse report is
+// consumed: the wheel scrolls the pager when open, else walks the selection (wheel up =
+// older); clicks and drags are swallowed so they never reach pi's editor as garbage
+// input. A foreign modifier chord ends the mode instead of dying in it: the exit is
+// synchronous (pi restores the editor inline in `close`) and the chord is deliberately
+// NOT consumed, so the very same keystroke lands in the restored editor and does what
+// it always does — option+up edits a queue, ctrl+c aborts, the entry chord re-freezes
+// the numbering through its own shortcut.
+
+import { isKeyRelease, parseKey } from "@earendil-works/pi-tui";
+import { drillState, exitDrillMode, setSelected } from "./drill.ts";
+
+const SGR_MOUSE_EVENT = /\x1b\[<(\d+);\d+;\d+([Mm])/g;
+
+/** Net wheel movement across a chunk of SGR mouse events: negative = wheel up. */
+export function wheelDelta(data: string): number {
+  let wheel = 0;
+  SGR_MOUSE_EVENT.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SGR_MOUSE_EVENT.exec(data))) {
+    if (match[2] !== "M") continue; // presses only; SGR release events end in lowercase m
+    const cb = Number(match[1]);
+    if ((cb & 64) === 0) continue; // not a wheel event
+    const dir = cb & 3; // 0 = wheel up, 1 = wheel down; 2/3 are horizontal, ignored
+    if (dir === 0 || dir === 1) wheel += dir === 0 ? -1 : 1;
+  }
+  return wheel;
+}
+
+export function handleDrillTerminalInput(data: string): { consume: true } | undefined {
+  const st = drillState();
+  if (!st) return undefined;
+  if (data.startsWith("\x1b[<") || data.startsWith("\x1b[M")) {
+    const wheel = wheelDelta(data);
+    if (wheel !== 0) {
+      if (st.pager) st.pager.scrollBy(wheel * 3);
+      else setSelected(st, st.selected - wheel);
+    }
+    return { consume: true };
+  }
+  if (isForeignChord(data)) exitDrillMode();
+  return undefined;
+}
+
+// The mode owns only unmodified keys (digits, j/k, arrows, p, esc, enter, …). A chord
+// carrying alt/ctrl/meta/super can never be one of them and can never be typed text,
+// so it can only mean "I want something outside the mode" (§9.13). Key releases are
+// ignored: the press already decided.
+const FOREIGN_CHORD_MODIFIER = /(?:^|\+)(?:alt|ctrl|meta|super)\+/;
+
+export function isForeignChord(data: string): boolean {
+  if (isKeyRelease(data)) return false;
+  const key = parseKey(data);
+  return key !== undefined && FOREIGN_CHORD_MODIFIER.test(key);
+}

--- a/extensions/pi-traceline/drill.ts
+++ b/extensions/pi-traceline/drill.ts
@@ -3,7 +3,9 @@
 // six-column prefix with its number at identical width (zero reflow), and swaps the
 // editor for a two-line hint bar that owns the keyboard. A committed number or enter
 // opens the peek pager (drill-pager.ts); `p` toggles the selected row's native
-// expansion (§9.12 z1) in place; esc restores the editor and its draft. SGR mouse
+// expansion (§9.12 z1) in place; esc restores the editor and its draft. A modifier
+// chord the mode does not own (option+up, ctrl+c, …) exits the same way without being
+// consumed, so the keystroke lands in the restored editor. SGR mouse
 // reporting, never enabled for the plain transcript, turns on only inside the mode and
 // off at exit/shutdown/process-exit, with every mouse event consumed. State lives on
 // globalThis so that after /reload the previously patched tool-row renderer and the
@@ -314,35 +316,5 @@ function writeIgnoringErrors(sequence: string): void {
   }
 }
 
-const SGR_MOUSE_EVENT = /\x1b\[<(\d+);\d+;\d+([Mm])/g;
-
-/** Net wheel movement across a chunk of SGR mouse events: negative = wheel up. */
-export function wheelDelta(data: string): number {
-  let wheel = 0;
-  SGR_MOUSE_EVENT.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = SGR_MOUSE_EVENT.exec(data))) {
-    if (match[2] !== "M") continue; // presses only; SGR release events end in lowercase m
-    const cb = Number(match[1]);
-    if ((cb & 64) === 0) continue; // not a wheel event
-    const dir = cb & 3; // 0 = wheel up, 1 = wheel down; 2/3 are horizontal, ignored
-    if (dir === 0 || dir === 1) wheel += dir === 0 ? -1 : 1;
-  }
-  return wheel;
-}
-
-// Raw terminal-input hook (traceline's existing onTerminalInput listener): while the
-// mode is active every mouse report is consumed. The wheel scrolls the pager when open,
-// else walks the selection (wheel up = older, §9.13); clicks and drags are swallowed
-// so they never reach pi's editor as garbage input.
-export function handleDrillTerminalInput(data: string): { consume: true } | undefined {
-  const st = g.__tracelineDrill;
-  if (!st) return undefined;
-  if (!data.startsWith("\x1b[<") && !data.startsWith("\x1b[M")) return undefined;
-  const wheel = wheelDelta(data);
-  if (wheel !== 0) {
-    if (st.pager) st.pager.scrollBy(wheel * 3);
-    else setSelected(st, st.selected - wheel);
-  }
-  return { consume: true };
-}
+// The raw terminal-input hook (mouse consumption + foreign-chord exit) lives in
+// drill-input.ts; index.ts feeds it traceline's onTerminalInput listener.

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -45,9 +45,9 @@ import {
   drillTracePrefix,
   enterDrillMode,
   exitDrillMode,
-  handleDrillTerminalInput,
   type DrillHost,
 } from "./drill.ts";
+import { handleDrillTerminalInput } from "./drill-input.ts";
 import { commonDirSegments, compactReadDisplay, cwdRelativePath, lineRange, readDirKey } from "./path-rows.ts";
 import { recordFacts, type RecordTone } from "./records.ts";
 import {
@@ -1761,7 +1761,7 @@ export default function piTraceline(pi: ExtensionAPI) {
     // only changes how tool rows render while reasoning is hidden.
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = ctx.ui.onTerminalInput((data) => {
-      // Drill mode owns every mouse report while active (§9.13), and nothing else.
+      // Drill mode owns mouse reports; a foreign chord exits it un-consumed (§9.13).
       const drill = handleDrillTerminalInput(data);
       if (drill) return drill;
       if (!matchesKey(data, "ctrl+t")) return undefined;

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -9,7 +9,7 @@
       "extensions/pi-contextimate/index.ts": 1959,
       "extensions/pi-traceline/index.ts": 1779,
       "tests/cachemire/economics-and-render.test.ts": 352,
-      "tests/contract/pi-internals.test.ts": 411,
+      "tests/contract/pi-internals.test.ts": 432,
       "tests/traceline/one-line.test.ts": 775
     }
   }

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -347,6 +347,27 @@ test("showExtensionCustom seam: editor swap/restore + overlay close drill mode r
   assert.ok(declarations.includes("custom<T>(factory: (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: T) => void)"), "custom factory signature drifted — hint bar and pager factories break");
 });
 
+test("foreign-chord exit seam: listeners precede focus dispatch; close() restores inline", () => {
+  // Drill's foreign-chord exit (§9.13) rides two orderings inside one input dispatch:
+  // the extension input listener exits the mode, pi restores the editor synchronously
+  // inside showExtensionCustom's close(), and only then does tui resolve the focused
+  // component — so the very same keystroke lands in the restored editor.
+  const tuiRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-tui"))), "..");
+  const tuiSource = readFileSync(join(tuiRoot, "dist/tui.js"), "utf8");
+  const listenerLoop = tuiSource.indexOf("for (const listener of this.inputListeners)");
+  const focusDispatch = tuiSource.indexOf("this.focusedComponent.handleInput(data)");
+  assert.ok(listenerLoop !== -1, "input-listener loop gone — the foreign-chord hook never runs");
+  assert.ok(focusDispatch !== -1, "focused-component dispatch gone — re-verify tui input routing");
+  assert.ok(listenerLoop < focusDispatch, "listeners no longer run before focus dispatch — a foreign chord would hit the dead hint bar");
+
+  const source = readFileSync(join(piRoot, "dist/modes/interactive/interactive-mode.js"), "utf8");
+  const closeBody = source.slice(source.indexOf("async showExtensionCustom")).slice(0, 2_000);
+  const restoreAt = closeBody.indexOf("restoreEditor();");
+  const resolveAt = closeBody.indexOf("resolve(result);");
+  assert.ok(restoreAt !== -1 && resolveAt !== -1, "close() body drifted — re-verify the synchronous editor restore");
+  assert.ok(restoreAt < resolveAt, "close() no longer restores the editor before resolving — the flowed-through chord would land in a void");
+});
+
 test("pi-tui overlay focus restore + terminal dimensions the drill pager reads", () => {
   const tuiRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-tui"))), "..");
   const tuiSource = readFileSync(join(tuiRoot, "dist/tui.js"), "utf8");

--- a/tests/smoke/traceline-drill-smoke.mjs
+++ b/tests/smoke/traceline-drill-smoke.mjs
@@ -3,8 +3,9 @@
 // end (design language §9.13): Alt+T numbers the rows with zero reflow and swaps the
 // editor (and its draft) for the hint bar, a committed digit opens the peek pager on
 // the full result, esc unwinds to the numbered transcript and then back to the editor
-// with the draft intact. Every subprocess call is bounded and the uniquely launched Pi
-// is killed on timeout.
+// with the draft intact, and a foreign chord (alt+up) exits the mode un-consumed so
+// the same press reaches the restored editor. Every subprocess call is bounded and
+// the uniquely launched Pi is killed on timeout.
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -268,6 +269,21 @@ try {
   if (restoredRows.join("\n") !== beforeRows.join("\n")) {
     throw new Error(`exit did not restore the plain rail rows\n${restoredRows.join("\n")}`);
   }
+
+  // 5. A foreign chord (§9.13): alt+up exits the mode un-consumed and lands in the
+  // restored editor in the same press — stock pi answers with its native dequeue status.
+  sendKeys("M-t");
+  const redrilling = waitForPane((pane) => pane.includes("drill · row 1 of 2"));
+  if (!redrilling.includes("drill · row 1 of 2")) throw new Error(`hint bar did not reappear for the chord step\n${redrilling}`);
+  sendKeys("M-Up");
+  const chordExit = waitForPane(
+    (pane) => !pane.includes("drill · row") && pane.includes("No queued messages to restore"),
+  );
+  if (chordExit.includes("drill · row")) throw new Error(`alt+up did not exit drill mode\n${chordExit}`);
+  if (!chordExit.includes("No queued messages to restore")) {
+    throw new Error(`alt+up did not reach the restored editor in the same press\n${chordExit}`);
+  }
+  if (!chordExit.includes(draft)) throw new Error(`editor draft lost across the chord exit\n${chordExit}`);
 
   sendKeys("C-c");
   sendKeys("/quit", "Enter");

--- a/tests/traceline/drill.test.ts
+++ b/tests/traceline/drill.test.ts
@@ -15,11 +15,10 @@ import {
   drillTracePrefix,
   enterDrillMode,
   exitDrillMode,
-  handleDrillTerminalInput,
   stepDigits,
-  wheelDelta,
   type DrillHost,
 } from "../../extensions/pi-traceline/drill.ts";
+import { handleDrillTerminalInput, isForeignChord, wheelDelta } from "../../extensions/pi-traceline/drill-input.ts";
 import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
 
 const { foldedReadLines, isExpandedToolRow, leadingBlank, oneLine, readRun, renderTraceRow, setTracelineChat, statusTone, stripAnsi } = internals;
@@ -295,4 +294,40 @@ test("terminal-input hook consumes all mouse reports while active, none outside"
   assert.equal(drillState()!.selected, 1, "wheel up walks to the older row");
   assert.deepEqual(handleDrillTerminalInput("\x1b[<0;3;3M"), { consume: true }, "clicks are swallowed, not leaked");
   assert.equal(handleDrillTerminalInput("plain keys"), undefined, "keyboard input passes through");
+});
+
+// --- foreign chords (§9.13: the mode never silently eats an app-level keystroke) --------
+
+test("isForeignChord: modifier chords only, presses only", () => {
+  assert.equal(isForeignChord("\x1b[1;3A"), true, "alt+up is foreign");
+  assert.equal(isForeignChord("\x1b\r"), true, "alt+enter is foreign");
+  assert.equal(isForeignChord("\x03"), true, "ctrl+c is foreign — abort must not die in the mode");
+  assert.equal(isForeignChord("\x1bt"), true, "the entry chord is foreign too: it re-freezes via its shortcut");
+  assert.equal(isForeignChord("\x1b[1;3:3A"), false, "a key release never exits");
+  for (const own of ["\x1b", "\r", "k", "j", "p", "5", "G", " ", "\x7f", "\x1b[A", "\x1b[5~"]) {
+    assert.equal(isForeignChord(own), false, `mode-owned or plain key treated as foreign: ${JSON.stringify(own)}`);
+  }
+});
+
+test("a foreign chord exits the mode synchronously and is not consumed", () => {
+  const rows = [toolComp({ args: { path: "/tmp/aaa/a.ts" } }), toolComp({ args: { path: "/tmp/bbb/b.ts" } })];
+  enterDrillMode(makeHost(rows));
+  assert.equal(handleDrillTerminalInput("5"), undefined);
+  assert.ok(drillState(), "the mode's own keys must not exit");
+  assert.equal(handleDrillTerminalInput("\x1b"), undefined);
+  assert.ok(drillState(), "esc belongs to the hint bar, not the hook");
+  assert.equal(handleDrillTerminalInput("\x1b[1;3A"), undefined, "the chord must flow on to the restored editor");
+  // Synchronous on purpose: pi dispatches this same keystroke to the focused component
+  // right after the listener returns, so the editor must already be restored.
+  assert.equal(drillState(), undefined, "exit must complete before the hook returns");
+});
+
+test("a foreign chord exits from the pager too", () => {
+  const rows = Array.from({ length: 3 }, (_, i) => toolComp({ args: { path: `/tmp/d${i}/f${i}.ts` } }));
+  const calls: CustomCall[] = [];
+  enterDrillMode(makeHost(rows, calls));
+  calls[0]!.component.handleInput!("3");
+  assert.ok(drillState()!.pager, "sanity: a committed digit opened the pager");
+  assert.equal(handleDrillTerminalInput("\x1b[1;3A"), undefined);
+  assert.equal(drillState(), undefined, "the chord ends the whole mode, pager included");
 });


### PR DESCRIPTION
Tracks #46.

## Problem

While drill mode owns the keyboard, any chord it does not match dies silently in the hint bar or pager. `option+up` is the sharpest casualty: no queue-extension edit mode, no native `app.message.dequeue`, no feedback — the composer just looks dead until you notice the two-line bar and press esc. `ctrl+c` (abort) was equally dead while the mode was open.

## Fix

The raw terminal-input hook now treats an unowned `alt`/`ctrl`/`meta` chord as "I want something outside the mode":

- it exits drill mode synchronously (from the hint bar or the pager alike), and
- it deliberately does **not** consume the chord, so the very same keystroke lands in the restored editor and does its normal job — `option+up` edits a queue, `ctrl+c` aborts, the entry chord re-freezes the numbering through its own shortcut.

This rides two pi orderings, both now pinned by a contract test: tui consults extension input listeners *before* resolving the focused component, and `showExtensionCustom`'s `close()` restores the editor inline before resolving. Key releases never exit (the press already decided); plain printable keys stay swallowed so stray typing cannot leak into the transcript.

The hook (`wheelDelta`, `handleDrillTerminalInput`, new `isForeignChord`) moves to `drill-input.ts` to keep `drill.ts` inside its context budget; behavior of the mouse path is unchanged.

## Verification

- `npm run check` green (233 tests): new unit tests pin the chord taxonomy (presses only, modifier chords only) and the synchronous un-consumed exit from both the hint bar and the pager.
- New contract test pins the listener-before-focus dispatch order and the inline editor restore.
- `npm run test:smoke:drill` green, extended with the end-to-end proof: in real pi, with drill open, a single `alt+up` exits the mode **and** triggers stock pi's "No queued messages to restore" status in the same press, with the editor draft intact.
- Manually verified the user-material path in a real pi session (tmux): `pi-queue-steer` + patched traceline, agent mid-run, one queued row, drill open → one press of `option+up` closes drill and opens queue-edit mode.

## Docs

Design language §9.13 records the rule; the traceline README documents it for users.
