### PR TITLE
release: pine-of-glass v0.8.0 with Traceline drill mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ currency. Design language grows a family row, latency/rate number grammar, and
 - Internal: the write pre-image snapshot and diff-stat parsing moved from
   `pi-traceline`'s `index.ts` into `write-diff.ts`; no behaviour change.
 
+`pi-traceline` also adds drill mode: inspect one tool call without expanding
+everything and without moving the transcript.
+
+- Press `Alt+T` (configurable via `drillKey`, or run `/drill`) to number the
+  visible tool rows in place. Each row's rail becomes its number at identical
+  width, so nothing reflows; `1` is the most recent call and a folded read run
+  is one number (a wrapped dir fold wears it on its bullet line). A two-line
+  hint bar replaces the editor and restores your draft on exit.
+- Type a number (or press `enter`) to open that call in a full-screen pager
+  showing the trace lines, the complete invocation and the complete result.
+  `j`/`k` scroll, `h`/`l` move between rows without closing, `esc` returns to
+  the transcript exactly as you left it. The common case is two keys:
+  `Alt+T`, then `1`.
+- Press `p` to expand or collapse the selected row in place using Pi's native
+  tool row. Expanded rows now also render natively outside drill mode, so
+  Pi's `Ctrl+O` tool expansion works under traceline; an expanded row leaves
+  read folds and shared columns and rejoins them when collapsed.
+- Inside drill mode the mouse wheel moves the selection or scrolls the pager.
+  Mouse reporting turns on only while the mode is open and always turns off on
+  exit, so terminal text selection is never affected; `"drillMouse": false`
+  opts out.
+
 ## 0.6.2 (2026-07-14)
 
 - Fix a `pi-traceline` startup hang when a resumed session contains an empty or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.8.0 (2026-07-17)
+
+`pi-traceline` adds drill mode: inspect one tool call without expanding
+all tool output and without moving the transcript.
+
+- Press `Alt+T` (configurable via `drillKey`, or run `/drill`) to number the
+  visible tool rows in place. Each row's rail becomes its number at identical
+  width, so nothing reflows; `1` is the most recent call and a folded read run
+  is one number. A two-line hint bar replaces the editor and restores its draft
+  on exit.
+- Type a number (or press `enter`) to open that call in a full-screen pager
+  showing its trace lines, complete invocation and complete result. `j`/`k`
+  scroll, `h`/`l` move between rows without closing, and `esc` returns to the
+  numbered transcript exactly as it was. The common case is two keys:
+  `Alt+T`, then `1`.
+- Press `p` to expand or collapse the selected row using Pi's native tool row.
+  Expanded rows now also render natively outside drill mode, so Pi's `Ctrl+O`
+  tool expansion works under Traceline.
+- The mouse wheel moves the selection or scrolls the pager. Mouse reporting is
+  active only inside drill mode and always turns off on exit;
+  `"drillMouse": false` opts out.
+- Drill mode owns only its documented keys. An unrecognized modifier chord,
+  such as `Option+Up` or `Ctrl+C`, exits immediately without consuming the
+  input. Pi restores the editor synchronously, so the same keystroke reaches
+  its normal handler. This lets `Option+Up` open queue-edit mode in extensions
+  such as `pi-queue-steer` with one press instead of dying in Traceline.
+- On macOS, Alt-letter shortcuts require the terminal to send Option as Alt.
+  Ghostty supports `macos-option-as-alt = left`; cmux requires this in its
+  managed Ghostty config (or Terminal settings), followed by
+  `cmux reload-config`. Right Option remains available for character
+  composition. `/drill` remains a configuration-free fallback.
+
 ## 0.7.0 (2026-07-16)
 
 New extension: `pi-meantime` (experimental, issue #26) answers "where did the
@@ -57,28 +89,6 @@ currency. Design language grows a family row, latency/rate number grammar, and
   Pi 0.80.8.
 - Internal: the write pre-image snapshot and diff-stat parsing moved from
   `pi-traceline`'s `index.ts` into `write-diff.ts`; no behaviour change.
-
-`pi-traceline` also adds drill mode: inspect one tool call without expanding
-everything and without moving the transcript.
-
-- Press `Alt+T` (configurable via `drillKey`, or run `/drill`) to number the
-  visible tool rows in place. Each row's rail becomes its number at identical
-  width, so nothing reflows; `1` is the most recent call and a folded read run
-  is one number (a wrapped dir fold wears it on its bullet line). A two-line
-  hint bar replaces the editor and restores your draft on exit.
-- Type a number (or press `enter`) to open that call in a full-screen pager
-  showing the trace lines, the complete invocation and the complete result.
-  `j`/`k` scroll, `h`/`l` move between rows without closing, `esc` returns to
-  the transcript exactly as you left it. The common case is two keys:
-  `Alt+T`, then `1`.
-- Press `p` to expand or collapse the selected row in place using Pi's native
-  tool row. Expanded rows now also render natively outside drill mode, so
-  Pi's `Ctrl+O` tool expansion works under traceline; an expanded row leaves
-  read folds and shared columns and rejoins them when collapsed.
-- Inside drill mode the mouse wheel moves the selection or scrolls the pager.
-  Mouse reporting turns on only while the mode is open and always turns off on
-  exit, so terminal text selection is never affected; `"drillMouse": false`
-  opts out.
 
 ## 0.6.2 (2026-07-14)
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -527,6 +527,13 @@ Entry and exit:
   line); the editor draft is restored on exit
 - the transcript does not reflow: numbering re-inks the prefix of rows already
   on screen, and one line stays one line
+- the mode owns only its documented keys, all unmodified. A modifier chord it
+  does not understand (option+up, option+enter, ctrl+c, …) exits the mode at
+  once, from the hint bar or the pager alike, and is not consumed: pi restores
+  the editor synchronously, the same keystroke lands there, and it does what
+  it always does. Drill never silently eats a chord that means something
+  outside it. Re-pressing the entry chord therefore re-freezes the numbering
+  through its own shortcut, and a key release never exits
 
 Numbering:
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -233,7 +233,7 @@ In expanded audit views:
 Traceline collapses each tool call to one line. These rules make a run of those
 lines read as one calm block: dim apparatus, bold discriminators, status accents.
 Nothing in a trace row shares ink with assistant prose. The full invocation and
-output stay one Ctrl+T away.
+output stay one zoom away (§9.12).
 
 ### 9.1 The block
 
@@ -491,6 +491,94 @@ to a trace line or expands back. So traceline suppresses pi's
 `Thinking blocks: hidden/visible` status caption before it renders. The
 suppression is surgical: only that exact text at the chat tail matches. Every
 other status message announces an otherwise invisible action and passes through.
+
+### 9.12 The zoom ladder
+
+A trace line is the surface of a three-step ladder, and every deeper step
+renders with pi's own machinery, so each zoom looks exactly like the view it
+borrows from:
+
+- z0, trace: the one-line row. The default whenever reasoning is hidden
+- z1, expanded: pi's native tool row with full invocation and output, still
+  without reasoning. Ctrl+O (pi's tools-expand keybinding) toggles it globally;
+  drill mode (§9.13) pins it per row. Both write pi's own per-row `expanded`
+  flag, so there is exactly one expansion state and it cannot desync
+- z2, native: Ctrl+T shows reasoning and native tool rows, untouched by
+  traceline
+
+An expanded row opts out of trace-block grammar: it breaks the rail block
+(§9.1), leaves its neighbours' fact and truncation columns (§9.7, §9.8), and
+never participates in a read fold (§9.9); a trace block that follows one starts
+with its own blank line. Collapsing back restores all of it. Expansion is the
+one deliberate reflow in traceline: an expanded row grows in place and the
+transcript moves to make room. The zero-reflow surfaces are z0 and drill
+mode's numbering.
+
+### 9.13 Drill mode
+
+Drill mode answers "show me that row" without leaving the transcript: the live
+transcript is the picker, and every zoom target is named by a number in the
+row's own gutter.
+
+Entry and exit:
+
+- `alt+t` (configurable via `drillKey` in the family config) or `/drill`
+  enters; esc exits. Entering swaps the editor for a two-line hint bar in the
+  §8 header form (`[Traceline] drill · row 1 of 37` plus one dim key-hint
+  line); the editor draft is restored on exit
+- the transcript does not reflow: numbering re-inks the prefix of rows already
+  on screen, and one line stays one line
+
+Numbering:
+
+- the number cell replaces the rail at identical width: the six-column prefix
+  (§9.1) becomes a right-aligned number in the first three columns, a space,
+  the row's `›` bullet with its status ink, a space
+- 1 is the most recent visible target, counting up into history. A folded read
+  run (§9.9) is one target with one number; a multi-line dir fold wears it on
+  the bullet line, and its continuation lines keep the plain rail. Numbers
+  freeze on entry; rows that stream in during drill mode render as plain
+  unnumbered trace rows
+- an expanded row (§9.12 z1) takes its number on the blank spacer line pi
+  renders above the native row, in the same cell grammar; if that line is
+  missing, the row stays selectable but shows no number. Rows past 999 keep
+  the rail
+- the selected row's number wears accent bold; every other number is dim.
+  Selection is a legitimate accent use under §3's "sparingly": exactly one
+  cell wears it, and only inside an explicitly entered mode
+
+Selection:
+
+- digits type a number, which commits the moment no longer valid number could
+  follow (`5` opens instantly when 37 targets exist; `1` waits for a second
+  digit or enter). Backspace edits the buffer, enter forces the commit
+- `j`/`k` and the arrow keys step through targets in transcript order; enter
+  peeks the selection
+- `p` toggles the selected row's expansion (§9.12 z1) in place
+
+The peek pager:
+
+- enter (or a committed number) opens a full-screen overlay pager. The
+  transcript beneath is untouched, and esc returns to identical pixels
+- the pager is a §8 panel: a `[Traceline] peek · row 3 of 37` brand line, one
+  dim hint line, then the row's own trace lines as the anchor, the full
+  invocation from pi's call renderer with its real newlines, and the complete
+  result text, each section under a dim label. A folded read run renders one
+  invocation and result section per call
+- `j`/`k`, the arrows, page keys and `g`/`G` scroll; `h`/`l` and left/right
+  move to the neighbouring numbered target without closing; `p` toggles
+  expansion; digits jump; esc, enter or `q` closes back to drill mode
+
+Mouse:
+
+- the live transcript never owns mouse reporting: enabling it breaks terminal
+  text selection for the whole session, so z0 stays keyboard-and-scrollback
+  native. This is a hard rule, not a phasing decision
+- drill mode is a bounded exception: SGR mouse reporting is enabled on entry
+  and disabled on exit, on session shutdown and on process exit. The wheel
+  moves the selection (wheel up walks older rows); inside the pager it
+  scrolls. Every other mouse event is swallowed, never leaked to the editor.
+  `"drillMouse": false` in the family config opts out
 
 ## 10. Tempo facts
 

--- a/extensions/_lib/chat.ts
+++ b/extensions/_lib/chat.ts
@@ -41,6 +41,8 @@ export interface ToolRowDataLike {
   args?: ToolArgsLike;
   result?: ToolResultLike;
   isPartial?: unknown;
+  /** pi's per-row expansion flag: written by setExpanded(), read for the zoom ladder (design language §9.12). */
+  expanded?: unknown;
   cwd?: unknown;
   callRendererComponent?: ToolCallRendererLike;
   __tracelineWriteSnapshot?: unknown;

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -2,7 +2,7 @@
 
 `pi-traceline` turns each tool call into one line. Use it to see what Pi did, which files it changed and which tool results used the most context.
 
-Press `Ctrl+T` to switch between the trace and Pi's full tool output.
+Press `Ctrl+T` to switch between the trace and Pi's full tool output. Press `Alt+T` to drill into a single row without moving the transcript.
 
 ![Traceline showing one tool call per line](../../docs/img/pi-traceline-collapsed.png)
 
@@ -46,14 +46,40 @@ pi -e ./extensions/pi-traceline
 
 ## Switch between trace and detail
 
-Traceline follows Pi's reasoning visibility setting. It does not add a keybinding.
+Traceline follows Pi's reasoning visibility setting. The full view reuses Pi's own `Ctrl+T` keybinding.
 
 - press `Ctrl+T` to show Pi's reasoning and full tool output
 - press `Ctrl+T` again to hide reasoning and show one line per tool call
+- press `Ctrl+O` (Pi's tool expansion) to expand or collapse every tool row in place while reasoning stays hidden
 
 The tool view reads its state from the live assistant row. It cannot get out of sync with the reasoning view. Traceline hides Pi's `Thinking blocks: hidden/visible` caption because the changing tool rows already show the state.
 
-Traceline does not enable mouse reporting or change terminal scrolling.
+Outside drill mode, Traceline does not enable mouse reporting or change terminal scrolling.
+
+## Drill into one row
+
+`Ctrl+T` and `Ctrl+O` show everything at once. Drill mode shows one call.
+
+Press `Alt+T` (or run `/drill`) to number the tool rows in place. The transcript does not move or reflow: each row's rail becomes its number, and `1` is the most recent call. A folded read row is one number. A two-line hint bar replaces the editor while the mode is open; your draft comes back when you leave.
+
+- type a number to open that row in a full-screen pager; short numbers open instantly, and `enter` forces an ambiguous one
+- press `enter` to open the selected row, `j`/`k` or the arrow keys to move the selection
+- press `p` to expand or collapse the selected row in place, using Pi's native tool row
+- press `esc` to leave
+
+The pager shows the row's trace line, then the complete invocation and the complete result. Scroll with `j`/`k`, the arrow keys, the page keys or `g`/`G`. Press `h`/`l` to move to the neighbouring row without closing. Press `esc` to return to the numbered transcript, exactly as you left it.
+
+The most common case takes two keys: `Alt+T`, then `1` for the latest call.
+
+Inside drill mode the mouse wheel works: it moves the selection, or scrolls the pager. Traceline turns mouse reporting on only while drill mode is open and turns it off again on exit, so normal terminal text selection is never affected.
+
+Configure drill mode in the same config file as the size thresholds:
+
+```json
+{ "drillKey": "alt+d", "drillMouse": false }
+```
+
+`drillKey` changes the shortcut. `drillMouse: false` keeps mouse reporting off even inside drill mode.
 
 ## Find large tool results
 

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -83,6 +83,8 @@ Configure drill mode in the same config file as the size thresholds:
 
 `drillKey` changes the shortcut. `drillMouse: false` keeps mouse reporting off even inside drill mode.
 
+On macOS, an Alt-letter shortcut works only when the terminal sends Option as Alt. In Ghostty, set `macos-option-as-alt = left` in the active config. cmux users can set the same value in Terminal settings or in `~/Library/Application Support/com.cmuxterm.app/config.ghostty`, then run `cmux reload-config`. This leaves right Option available for character composition. The `/drill` command works without Option-as-Alt.
+
 ## Find large tool results
 
 Completed rows show their result size on a shared right edge. This makes unusually large results easy to spot.

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -67,6 +67,8 @@ Press `Alt+T` (or run `/drill`) to number the tool rows in place. The transcript
 - press `p` to expand or collapse the selected row in place, using Pi's native tool row
 - press `esc` to leave
 
+A modifier chord drill mode does not own (`Option+Up`, `Ctrl+C`, …) leaves the mode and still does its normal job: the editor is restored first, then the same keystroke lands in it. Drill mode never silently eats a shortcut that means something outside it.
+
 The pager shows the row's trace line, then the complete invocation and the complete result. Scroll with `j`/`k`, the arrow keys, the page keys or `g`/`G`. Press `h`/`l` to move to the neighbouring row without closing. Press `esc` to return to the numbered transcript, exactly as you left it.
 
 The most common case takes two keys: `Alt+T`, then `1` for the latest call.

--- a/extensions/pi-traceline/bash-preamble.ts
+++ b/extensions/pi-traceline/bash-preamble.ts
@@ -1,0 +1,133 @@
+// Leading-preamble reclaim for bash rows (design language §9.4): the pure string
+// grammar that splits a flattened bash body into top-level segments and classifies
+// its leading run. Rendering (the `⋯` fold, previous-row comparison, family ink)
+// stays in index.ts; everything here is plain text in, plain facts out.
+
+/** ↵ — marks a real newline in a flattened invocation (design language §1). */
+export const LINE_BREAK_MARK = "\u21b5";
+/** ⋯ — stands in for a preamble identical to the row above (design language §9.4). */
+export const PREAMBLE_MARK = "\u22ef";
+
+// Top-level segments of a flattened bash body, split on `&&`/`||`/`;`/`↵` outside
+// quotes, command substitutions and backticks. Only the leading preamble run is read
+// (the walk stops at the first real command), so heredoc bodies — which live only in
+// real segments — need no handling here.
+export function bashTopLevelSegments(body: string): { start: number; text: string }[] {
+  const segs: { start: number; text: string }[] = [];
+  let quote: "'" | '"' | undefined;
+  let paren = 0;
+  let backtick = false;
+  let segStart = 0;
+  const push = (end: number) => {
+    const raw = body.slice(segStart, end);
+    const lead = raw.length - raw.replace(/^\s+/, "").length;
+    const text = raw.trim();
+    if (text.length > 0) segs.push({ start: segStart + lead, text });
+  };
+  let i = 0;
+  while (i < body.length) {
+    const ch = body[i]!;
+    if (quote === "'") {
+      if (ch === "'") quote = undefined;
+      i++;
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === "\\") { i += 2; continue; }
+      if (ch === '"') quote = undefined;
+      i++;
+      continue;
+    }
+    if (backtick) {
+      if (ch === "`") backtick = false;
+      i++;
+      continue;
+    }
+    if (ch === "'") { quote = "'"; i++; continue; }
+    if (ch === '"') { quote = '"'; i++; continue; }
+    if (ch === "`") { backtick = true; i++; continue; }
+    if (ch === "\\") { i += 2; continue; }
+    if (ch === "(") { paren++; i++; continue; }
+    if (ch === ")") { if (paren > 0) paren--; i++; continue; }
+    if (paren === 0) {
+      if (body.startsWith("&&", i) || body.startsWith("||", i)) { push(i); i += 2; segStart = i; continue; }
+      if (ch === ";" || ch === LINE_BREAK_MARK) { push(i); i += 1; segStart = i; continue; }
+    }
+    i++;
+  }
+  push(body.length);
+  return segs;
+}
+
+// One env-assignment-only segment (`WORK=$(cat x)`, `A=1 B=2`) is setup, not a command,
+// so it situates; `FOO=bar cmd` is the command `cmd` and does not. Consumes each
+// `VAR=value` token quote/substitution-aware, then checks nothing but assignments remain.
+export function isEnvAssignmentOnly(text: string): boolean {
+  let i = 0;
+  while (i < text.length) {
+    while (i < text.length && /\s/.test(text[i]!)) i++;
+    if (i >= text.length) return true;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*=/.test(text.slice(i))) return false;
+    let quote: "'" | '"' | undefined;
+    let paren = 0;
+    let backtick = false;
+    while (i < text.length) {
+      const ch = text[i]!;
+      if (quote === "'") { if (ch === "'") quote = undefined; i++; continue; }
+      if (quote === '"') { if (ch === "\\") { i += 2; continue; } if (ch === '"') quote = undefined; i++; continue; }
+      if (backtick) { if (ch === "`") backtick = false; i++; continue; }
+      if (ch === "'") { quote = "'"; i++; continue; }
+      if (ch === '"') { quote = '"'; i++; continue; }
+      if (ch === "`") { backtick = true; i++; continue; }
+      if (ch === "\\") { i += 2; continue; }
+      if (ch === "(") { paren++; i++; continue; }
+      if (ch === ")") { if (paren > 0) paren--; i++; continue; }
+      if (paren === 0 && /\s/.test(ch)) break;
+      i++;
+    }
+  }
+  return true;
+}
+
+export type BashSegmentClass = "hygiene" | "context" | "real";
+
+// `set -…` is hygiene (drop-always); `cd`, `export …` and bare assignments situate
+// (fold-on-repeat); everything else is the reason the row exists and stops the run.
+export function classifyBashSegment(text: string): BashSegmentClass {
+  if (/^set(\s|$)/.test(text)) return "hygiene";
+  if (/^cd(\s|$)/.test(text)) return "context";
+  if (/^export\s+[A-Za-z_]/.test(text)) return "context";
+  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(text)) return isEnvAssignmentOnly(text) ? "context" : "real";
+  return "real";
+}
+
+export type BashPreambleRun = {
+  contextText: string; // situating context, joined; "" when the run has none
+  firstRealStart?: number; // body index of the first real command, if any
+  dropStart?: number; // body index just past a leading `set -…` run, when a drop applies
+};
+
+// The leading preamble run of a flattened bash body. contextText compares context
+// across rows (both computed from tildified bodies, so `cd ~/x` matches `cd ~/x`);
+// firstRealStart is where the `⋯` fold would point; dropStart marks where a leading
+// `set -…` run ends. dropStart stays undefined when the whole body is hygiene, so a
+// `set -e`-only row keeps its head and no row goes dark (§9.4).
+export function bashPreambleRun(body: string): BashPreambleRun {
+  const contextParts: string[] = [];
+  let firstRealStart: number | undefined;
+  let dropStart: number | undefined;
+  for (const seg of bashTopLevelSegments(body)) {
+    const cls = classifyBashSegment(seg.text);
+    if (cls === "real") {
+      firstRealStart = seg.start;
+      if (dropStart === undefined) dropStart = seg.start;
+      break;
+    }
+    if (cls === "context") {
+      contextParts.push(seg.text);
+      if (dropStart === undefined) dropStart = seg.start;
+    }
+    // a leading hygiene (`set`) segment leaves dropStart pointing just past it
+  }
+  return { contextText: contextParts.join("\n"), firstRealStart, dropStart };
+}

--- a/extensions/pi-traceline/drill-input.ts
+++ b/extensions/pi-traceline/drill-input.ts
@@ -1,0 +1,56 @@
+// Drill mode's raw terminal-input hook (design language §9.13), fed by traceline's
+// onTerminalInput listener in index.ts. While the mode is active every mouse report is
+// consumed: the wheel scrolls the pager when open, else walks the selection (wheel up =
+// older); clicks and drags are swallowed so they never reach pi's editor as garbage
+// input. A foreign modifier chord ends the mode instead of dying in it: the exit is
+// synchronous (pi restores the editor inline in `close`) and the chord is deliberately
+// NOT consumed, so the very same keystroke lands in the restored editor and does what
+// it always does — option+up edits a queue, ctrl+c aborts, the entry chord re-freezes
+// the numbering through its own shortcut.
+
+import { isKeyRelease, parseKey } from "@earendil-works/pi-tui";
+import { drillState, exitDrillMode, setSelected } from "./drill.ts";
+
+const SGR_MOUSE_EVENT = /\x1b\[<(\d+);\d+;\d+([Mm])/g;
+
+/** Net wheel movement across a chunk of SGR mouse events: negative = wheel up. */
+export function wheelDelta(data: string): number {
+  let wheel = 0;
+  SGR_MOUSE_EVENT.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SGR_MOUSE_EVENT.exec(data))) {
+    if (match[2] !== "M") continue; // presses only; SGR release events end in lowercase m
+    const cb = Number(match[1]);
+    if ((cb & 64) === 0) continue; // not a wheel event
+    const dir = cb & 3; // 0 = wheel up, 1 = wheel down; 2/3 are horizontal, ignored
+    if (dir === 0 || dir === 1) wheel += dir === 0 ? -1 : 1;
+  }
+  return wheel;
+}
+
+export function handleDrillTerminalInput(data: string): { consume: true } | undefined {
+  const st = drillState();
+  if (!st) return undefined;
+  if (data.startsWith("\x1b[<") || data.startsWith("\x1b[M")) {
+    const wheel = wheelDelta(data);
+    if (wheel !== 0) {
+      if (st.pager) st.pager.scrollBy(wheel * 3);
+      else setSelected(st, st.selected - wheel);
+    }
+    return { consume: true };
+  }
+  if (isForeignChord(data)) exitDrillMode();
+  return undefined;
+}
+
+// The mode owns only unmodified keys (digits, j/k, arrows, p, esc, enter, …). A chord
+// carrying alt/ctrl/meta/super can never be one of them and can never be typed text,
+// so it can only mean "I want something outside the mode" (§9.13). Key releases are
+// ignored: the press already decided.
+const FOREIGN_CHORD_MODIFIER = /(?:^|\+)(?:alt|ctrl|meta|super)\+/;
+
+export function isForeignChord(data: string): boolean {
+  if (isKeyRelease(data)) return false;
+  const key = parseKey(data);
+  return key !== undefined && FOREIGN_CHORD_MODIFIER.test(key);
+}

--- a/extensions/pi-traceline/drill-pager.ts
+++ b/extensions/pi-traceline/drill-pager.ts
@@ -1,0 +1,183 @@
+// The peek pager (design language §9.13): a full-screen overlay opened from drill mode.
+// The transcript beneath stays untouched, so esc returns to identical pixels. The panel
+// speaks the §8 header form, then anchors on the row's own trace line and shows the
+// full invocation (pi's call renderer, real newlines) and the complete result text,
+// each section under a dim label. A folded read run renders one invocation and result
+// section per call. Scrolling is offset-based line windowing; h/l switch to the
+// neighbouring numbered target without closing.
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { matchesKey, truncateToWidth, wrapTextWithAnsi, type Component, type KeyId, type TUI } from "@earendil-works/pi-tui";
+import type { ToolRowLike } from "../_lib/chat.ts";
+import { compactCount } from "../_lib/fmt.ts";
+import { ELLIPSIS, SEP, ink, type Tone } from "../_lib/style.ts";
+import { applyDigit, setSelected, togglePin, type DrillState } from "./drill.ts";
+
+const BOLD = "\x1b[1m";
+const BOLD_OFF = "\x1b[22m";
+const HEADER_LINES = 2;
+const FOOTER_LINES = 1;
+const SECTION_INDENT = "    ";
+
+type TerminalSizeLike = { terminal?: { rows?: number } };
+
+export class DrillPager implements Component {
+  private readonly st: DrillState;
+  private scroll = 0;
+  private tui: TerminalSizeLike | undefined;
+  private lastRowIndex: number;
+  private cache: { row: unknown; result: unknown; width: number; lines: string[] } | undefined;
+
+  constructor(st: DrillState) {
+    this.st = st;
+    this.lastRowIndex = st.selected;
+  }
+
+  attach(tui: TUI): void {
+    this.tui = tui as TerminalSizeLike;
+  }
+
+  scrollBy(delta: number): void {
+    this.scroll = Math.max(0, this.scroll + delta); // upper clamp happens at render, where the height is known
+    this.st.host.requestRender();
+  }
+
+  private viewport(): number {
+    const rows = this.tui?.terminal?.rows;
+    const height = typeof rows === "number" && rows > 0 ? rows : 24;
+    return Math.max(1, height - HEADER_LINES - FOOTER_LINES);
+  }
+
+  handleInput(data: string): void {
+    const st = this.st;
+    if (matchesKey(data, "escape") || matchesKey(data, "enter") || matchesKey(data, "q")) {
+      st.closePager?.();
+      return;
+    }
+    if (matchesKey(data, "up") || matchesKey(data, "k")) return this.scrollBy(-1);
+    if (matchesKey(data, "down") || matchesKey(data, "j")) return this.scrollBy(1);
+    if (matchesKey(data, "pageUp")) return this.scrollBy(-this.viewport());
+    if (matchesKey(data, "pageDown") || matchesKey(data, "space")) return this.scrollBy(this.viewport());
+    if (matchesKey(data, "g")) return this.scrollBy(-Number.MAX_SAFE_INTEGER);
+    if (matchesKey(data, "shift+g")) return this.scrollBy(Number.MAX_SAFE_INTEGER);
+    if (matchesKey(data, "left") || matchesKey(data, "h")) return setSelected(st, st.selected + 1); // older
+    if (matchesKey(data, "right") || matchesKey(data, "l")) return setSelected(st, st.selected - 1); // newer
+    if (matchesKey(data, "p")) return togglePin(st);
+    for (let d = 0; d <= 9; d++) {
+      if (matchesKey(data, String(d) as KeyId)) {
+        applyDigit(st, String(d));
+        return;
+      }
+    }
+  }
+
+  render(width: number): string[] {
+    const st = this.st;
+    const theme = st.host.theme();
+    if (this.lastRowIndex !== st.selected) {
+      this.lastRowIndex = st.selected;
+      this.scroll = 0;
+      this.cache = undefined;
+    }
+    const fit = (line: string) => truncateToWidth(line, Math.max(1, width), ELLIPSIS);
+    const row = st.rows[st.selected];
+    const brand = ink(theme, "accent", `${BOLD}[Traceline]${BOLD_OFF}`);
+    const pending = st.digits ? `${ink(theme, "dim", SEP)}${ink(theme, "accent", `#${st.digits}`)}` : "";
+    const head = `${brand} ${ink(theme, "dim", `peek${SEP}row ${st.selected + 1} of ${st.rows.length}`)}${pending}`;
+    const hint = `  ${ink(theme, "dim", `esc close${SEP}j/k scroll${SEP}h/l switch row${SEP}p expand${SEP}g/G ends`)}`;
+    if (!row) return [fit(head), fit(hint), fit(`  ${ink(theme, "dim", "row no longer available")}`)];
+
+    const body = this.bodyLines(row, width);
+    const viewport = this.viewport();
+    this.scroll = Math.min(this.scroll, Math.max(0, body.length - viewport));
+    const view = body.slice(this.scroll, this.scroll + viewport);
+    while (view.length < viewport) view.push(""); // cover the transcript to the full height
+    const from = body.length === 0 ? 0 : this.scroll + 1;
+    const to = Math.min(body.length, this.scroll + viewport);
+    const footer = `  ${ink(theme, "dim", `lines ${from}-${to} of ${body.length}`)}`;
+    return [head, hint, ...view, footer].map(fit);
+  }
+
+  private bodyLines(row: ToolRowLike, width: number): string[] {
+    const streaming = (this.st.host.runRows(row) ?? [row]).some((call) => call.isPartial === true);
+    const c = this.cache;
+    if (!streaming && c && c.row === row && c.result === row.result && c.width === width) return c.lines;
+    const lines = buildPagerBody(this.st, row, width);
+    this.cache = streaming ? undefined : { row, result: row.result, width, lines };
+    return lines;
+  }
+
+  invalidate(): void {
+    this.cache = undefined;
+  }
+}
+
+// --- body construction ------------------------------------------------------------------
+
+function buildPagerBody(st: DrillState, row: ToolRowLike, width: number): string[] {
+  const theme = st.host.theme();
+  const contentWidth = Math.max(20, width - SECTION_INDENT.length);
+  const lines: string[] = [...st.host.traceLines(row, width)];
+  const calls = st.host.runRows(row) ?? [row];
+  calls.forEach((call, index) => {
+    const callLabel = calls.length > 1 ? `${SEP}call ${index + 1} of ${calls.length}` : "";
+    lines.push("", `  ${ink(theme, "dim", `invocation${callLabel}`)}`);
+    for (const line of invocationLines(call, contentWidth)) lines.push(`${SECTION_INDENT}${line}`);
+    lines.push("", `  ${resultLabel(theme, st.host.statusTone(call), call)}`);
+    for (const line of resultLines(theme, call, contentWidth)) lines.push(`${SECTION_INDENT}${line}`);
+  });
+  return lines;
+}
+
+function invocationLines(call: ToolRowLike, width: number): string[] {
+  try {
+    const out = call.callRendererComponent?.render?.(width);
+    if (Array.isArray(out)) return out.map((line) => String(line));
+  } catch {
+    // Pi seam: a call renderer may throw mid-stream; fall through to the tool name.
+  }
+  return [typeof call.toolName === "string" ? call.toolName : "tool"];
+}
+
+function resultChars(call: ToolRowLike): number | undefined {
+  const content = call.result?.content;
+  if (!Array.isArray(content)) return undefined;
+  let sum = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const textBlock = block as { type?: unknown; text?: unknown };
+    if (textBlock.type === "text" && typeof textBlock.text === "string") sum += textBlock.text.length;
+  }
+  return sum;
+}
+
+function resultLabel(theme: Theme | undefined, tone: Tone, call: ToolRowLike): string {
+  const word = tone === "error" ? "failed" : tone === "success" ? "success" : "running";
+  const chars = resultChars(call);
+  const size = chars !== undefined ? ink(theme, "dim", `${SEP}${compactCount(chars)} ch`) : "";
+  return `${ink(theme, "dim", `result${SEP}`)}${ink(theme, tone, word)}${size}`;
+}
+
+function resultLines(theme: Theme | undefined, call: ToolRowLike, width: number): string[] {
+  const content = call.result?.content;
+  if (!Array.isArray(content)) return [ink(theme, "dim", "no output yet")];
+  const out: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const textBlock = block as { type?: unknown; text?: unknown };
+    if (textBlock.type === "text" && typeof textBlock.text === "string") {
+      const text = textBlock.text.replace(/\r\n?/g, "\n").replace(/\t/g, "    ");
+      for (const raw of text.split("\n")) {
+        if (raw.length === 0) {
+          out.push("");
+          continue;
+        }
+        for (const wrapped of wrapTextWithAnsi(raw, width)) out.push(wrapped);
+      }
+    } else {
+      out.push(ink(theme, "dim", `[${typeof textBlock.type === "string" ? textBlock.type : "block"}]`));
+    }
+  }
+  if (out.length === 0) out.push(ink(theme, "dim", "(empty result)"));
+  return out;
+}

--- a/extensions/pi-traceline/drill.ts
+++ b/extensions/pi-traceline/drill.ts
@@ -1,0 +1,348 @@
+// Drill mode (design language §9.13): the live transcript is the picker. Entry freezes
+// a numbered list of visible tool targets (1 = most recent), re-inks each row's
+// six-column prefix with its number at identical width (zero reflow), and swaps the
+// editor for a two-line hint bar that owns the keyboard. A committed number or enter
+// opens the peek pager (drill-pager.ts); `p` toggles the selected row's native
+// expansion (§9.12 z1) in place; esc restores the editor and its draft. SGR mouse
+// reporting, never enabled for the plain transcript, turns on only inside the mode and
+// off at exit/shutdown/process-exit, with every mouse event consumed. State lives on
+// globalThis so that after /reload the previously patched tool-row renderer and the
+// freshly loaded controller share it, exactly like traceline's other seam globals.
+
+import type { ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
+import { matchesKey, truncateToWidth, type Component, type KeyId } from "@earendil-works/pi-tui";
+import { stripAnsi } from "../_lib/ansi.ts";
+import { isToolRow, type ToolRowLike } from "../_lib/chat.ts";
+import { ELLIPSIS, SEP, ink, type Tone } from "../_lib/style.ts";
+import { DrillPager } from "./drill-pager.ts";
+
+const BOLD = "\x1b[1m";
+const BOLD_OFF = "\x1b[22m";
+
+/** Everything drill mode needs from traceline's render internals, injected by index.ts. */
+export type DrillHost = {
+  ui: ExtensionUIContext;
+  theme(): Theme | undefined;
+  chatChildren(): unknown[] | undefined;
+  requestRender(): void;
+  /** The row's trace-form lines at the given width (a fold carrier renders its fold,
+   * which may wrap over several lines for sibling-file dir folds, §9.9). */
+  traceLines(comp: ToolRowLike, width: number): string[];
+  /** All rows of the folded read run this row carries, when it carries one (§9.9). */
+  runRows(comp: ToolRowLike): ToolRowLike[] | undefined;
+  /** True when the row renders nothing because an earlier row carries its fold. */
+  hiddenByFold(comp: ToolRowLike): boolean;
+  statusTone(comp: ToolRowLike): Tone;
+  mouse: boolean;
+};
+
+export type DrillState = {
+  host: DrillHost;
+  /** Frozen targets, rows[0] = number 1 = most recent visible target (§9.13). */
+  rows: ToolRowLike[];
+  numbers: Map<unknown, number>;
+  selected: number;
+  digits: string;
+  pager?: DrillPager;
+  closeHint?: () => void;
+  closePager?: () => void;
+  mouseOn: boolean;
+};
+
+type DrillGlobal = typeof globalThis & {
+  __tracelineDrill?: DrillState;
+  __tracelineDrillMouseGuard?: boolean;
+};
+const g = globalThis as DrillGlobal;
+
+export function drillState(): DrillState | undefined {
+  return g.__tracelineDrill;
+}
+
+// --- numbering (rendered by index.ts's patched tool-row renderer) ----------------------
+
+// The number cell holds the rail's three columns exactly, so a numbered row stays one
+// line at the same width (§9.13). Numbers above 999 keep the rail (still j/k-reachable).
+const MAX_NUMBER = 999;
+
+function numberCell(theme: Theme | undefined, n: number, selected: boolean): string {
+  const cell = String(n).padStart(3);
+  return selected ? ink(theme, "accent", `${BOLD}${cell}${BOLD_OFF}`) : ink(theme, "dim", cell);
+}
+
+/** The six-column drill prefix for a numbered trace row, or undefined outside the mode. */
+export function drillTracePrefix(theme: Theme | undefined, comp: unknown, bulletInk: string): string | undefined {
+  const st = g.__tracelineDrill;
+  const n = st?.numbers.get(comp);
+  if (st === undefined || n === undefined || n > MAX_NUMBER) return undefined;
+  return `${numberCell(theme, n, st.rows[st.selected] === comp)} ${bulletInk} `;
+}
+
+// A native-rendered (expanded or z2) row takes its number on the blank spacer line pi
+// renders above the row (§9.13). Only a genuinely blank first line is replaced; any
+// other shape passes through untouched, so this can never reflow a native row.
+export function drillDecorateNativeRow(theme: Theme | undefined, comp: unknown, lines: unknown, bulletInk: string): unknown {
+  const st = g.__tracelineDrill;
+  if (!st || !Array.isArray(lines) || lines.length === 0) return lines;
+  const n = st.numbers.get(comp);
+  if (n === undefined || n > MAX_NUMBER) return lines;
+  const first = lines[0];
+  if (typeof first !== "string" || stripAnsi(first).trim() !== "") return lines;
+  return [`${numberCell(theme, n, st.rows[st.selected] === comp)} ${bulletInk}`, ...lines.slice(1)];
+}
+
+// --- mode lifecycle --------------------------------------------------------------------
+
+function collectTargets(host: DrillHost): ToolRowLike[] {
+  const sibs = host.chatChildren() ?? [];
+  const rows: ToolRowLike[] = [];
+  for (let i = sibs.length - 1; i >= 0; i--) {
+    const c = sibs[i];
+    if (isToolRow(c) && !host.hiddenByFold(c)) rows.push(c);
+  }
+  return rows;
+}
+
+export function enterDrillMode(host: DrillHost): void {
+  if (g.__tracelineDrill) return;
+  const rows = collectTargets(host);
+  if (rows.length === 0) {
+    host.ui.notify("traceline: no tool rows to drill into", "info");
+    return;
+  }
+  const st: DrillState = {
+    host,
+    rows,
+    numbers: new Map(rows.map((row, i) => [row as unknown, i + 1])),
+    selected: 0,
+    digits: "",
+    mouseOn: false,
+  };
+  g.__tracelineDrill = st;
+  if (host.mouse) enableMouse(st);
+  void host.ui
+    .custom<undefined>((_tui, _theme, _kb, done) => {
+      st.closeHint = () => done(undefined);
+      return new DrillHintBar(st);
+    })
+    .catch(() => undefined)
+    .finally(() => exitDrillMode());
+  host.requestRender();
+}
+
+/** Idempotent teardown: clears the state first, so re-entry from close callbacks no-ops. */
+export function exitDrillMode(): void {
+  const st = g.__tracelineDrill;
+  if (!st) return;
+  g.__tracelineDrill = undefined;
+  disableMouse(st);
+  try {
+    st.closePager?.();
+    st.closeHint?.();
+  } catch {
+    // Pi seam: a dispose-time close may throw during shutdown; state and mouse are already restored.
+  }
+  st.host.requestRender();
+}
+
+// --- selection -------------------------------------------------------------------------
+
+function clampIndex(st: DrillState, index: number): number {
+  return Math.min(Math.max(index, 0), st.rows.length - 1);
+}
+
+export function setSelected(st: DrillState, index: number): void {
+  st.selected = clampIndex(st, index);
+  st.digits = "";
+  st.host.requestRender();
+}
+
+export function togglePin(st: DrillState): void {
+  const row = st.rows[st.selected];
+  if (!row) return;
+  try {
+    row.setExpanded(row.expanded !== true);
+  } catch {
+    // Pi seam: never let a pin toggle break the mode.
+  }
+  st.host.requestRender();
+}
+
+// Digit-buffer grammar (§9.13): a buffer commits the moment no longer valid number
+// could follow; an impossible extension restarts the buffer from the new digit when
+// that digit is itself a valid target, else clears it.
+export function stepDigits(digits: string, ch: string, max: number): { digits: string; commit?: number } {
+  if (!/^[0-9]$/.test(ch)) return { digits };
+  for (const candidate of [digits + ch, ch]) {
+    const n = Number(candidate);
+    if (n >= 1 && n <= max) return n * 10 > max ? { digits: "", commit: n } : { digits: candidate };
+  }
+  return { digits: "" };
+}
+
+/** Feed a typed digit into the shared buffer; returns the committed number, if any. */
+export function applyDigit(st: DrillState, ch: string): number | undefined {
+  const step = stepDigits(st.digits, ch, st.rows.length);
+  st.digits = step.digits;
+  const target = step.commit ?? (st.digits ? Number(st.digits) : undefined); // pending previews too
+  if (target !== undefined) st.selected = clampIndex(st, target - 1);
+  st.host.requestRender();
+  return step.commit;
+}
+
+/** Commit whatever the buffer holds (enter); returns the number, if valid. */
+export function commitDigits(st: DrillState): number | undefined {
+  const n = Number(st.digits);
+  st.digits = "";
+  if (!Number.isInteger(n) || n < 1 || n > st.rows.length) return undefined;
+  st.selected = clampIndex(st, n - 1);
+  st.host.requestRender();
+  return n;
+}
+
+function typedDigit(data: string): string | undefined {
+  for (let d = 0; d <= 9; d++) if (matchesKey(data, String(d) as KeyId)) return String(d);
+  return undefined;
+}
+
+// --- the hint bar (replaces the editor while the mode is active) -----------------------
+
+export function openPager(st: DrillState): void {
+  if (st.pager) return st.host.requestRender();
+  const pager = new DrillPager(st);
+  st.pager = pager;
+  void st.host.ui
+    .custom<undefined>(
+      (tui, _theme, _kb, done) => {
+        pager.attach(tui);
+        st.closePager = () => done(undefined);
+        return pager;
+      },
+      { overlay: true, overlayOptions: () => ({ width: "100%", maxHeight: "100%", anchor: "top-left" }) },
+    )
+    .catch(() => undefined)
+    .finally(() => {
+      if (st.pager === pager) {
+        st.pager = undefined;
+        st.closePager = undefined;
+      }
+      st.host.requestRender();
+    });
+}
+
+class DrillHintBar implements Component {
+  private readonly st: DrillState;
+
+  constructor(st: DrillState) {
+    this.st = st;
+  }
+
+  render(width: number): string[] {
+    const st = this.st;
+    const theme = st.host.theme();
+    const brand = ink(theme, "accent", `${BOLD}[Traceline]${BOLD_OFF}`);
+    const pending = st.digits ? `${ink(theme, "dim", SEP)}${ink(theme, "accent", `#${st.digits}`)}` : "";
+    const head = `${brand} ${ink(theme, "dim", `drill${SEP}row ${st.selected + 1} of ${st.rows.length}`)}${pending}`;
+    const hint = `  ${ink(theme, "dim", `type a number${SEP}enter peek${SEP}p expand${SEP}j/k move${SEP}esc exit`)}`;
+    return [truncateToWidth(head, Math.max(1, width), ELLIPSIS), truncateToWidth(hint, Math.max(1, width), ELLIPSIS)];
+  }
+
+  handleInput(data: string): void {
+    const st = this.st;
+    if (matchesKey(data, "escape")) {
+      if (st.digits) {
+        st.digits = "";
+        st.host.requestRender();
+        return;
+      }
+      exitDrillMode();
+      return;
+    }
+    if (matchesKey(data, "enter")) {
+      if (st.digits) commitDigits(st);
+      openPager(st);
+      return;
+    }
+    if (matchesKey(data, "backspace")) {
+      st.digits = st.digits.slice(0, -1);
+      st.host.requestRender();
+      return;
+    }
+    if (matchesKey(data, "up") || matchesKey(data, "k")) return setSelected(st, st.selected + 1); // up = older
+    if (matchesKey(data, "down") || matchesKey(data, "j")) return setSelected(st, st.selected - 1);
+    if (matchesKey(data, "p")) return togglePin(st);
+    const digit = typedDigit(data);
+    if (digit !== undefined && applyDigit(st, digit) !== undefined) openPager(st);
+  }
+
+  invalidate(): void {}
+}
+
+// --- mouse (bounded to the mode; never active in the plain transcript) -----------------
+
+const MOUSE_ENABLE = "\x1b[?1000h\x1b[?1006h";
+const MOUSE_DISABLE = "\x1b[?1006l\x1b[?1000l";
+
+function enableMouse(st: DrillState): void {
+  if (st.mouseOn) return;
+  try {
+    process.stdout.write(MOUSE_ENABLE);
+  } catch {
+    return; // no mouse rather than a broken mode
+  }
+  st.mouseOn = true;
+  if (!g.__tracelineDrillMouseGuard) {
+    g.__tracelineDrillMouseGuard = true;
+    process.on("exit", () => {
+      // A crash mid-mode must not leave the terminal reporting mouse events.
+      if (g.__tracelineDrill?.mouseOn) writeIgnoringErrors(MOUSE_DISABLE);
+    });
+  }
+}
+
+function disableMouse(st: DrillState): void {
+  if (!st.mouseOn) return;
+  st.mouseOn = false;
+  writeIgnoringErrors(MOUSE_DISABLE);
+}
+
+function writeIgnoringErrors(sequence: string): void {
+  try {
+    process.stdout.write(sequence);
+  } catch {
+    // terminal already gone; nothing to restore
+  }
+}
+
+const SGR_MOUSE_EVENT = /\x1b\[<(\d+);\d+;\d+([Mm])/g;
+
+/** Net wheel movement across a chunk of SGR mouse events: negative = wheel up. */
+export function wheelDelta(data: string): number {
+  let wheel = 0;
+  SGR_MOUSE_EVENT.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SGR_MOUSE_EVENT.exec(data))) {
+    if (match[2] !== "M") continue; // presses only; SGR release events end in lowercase m
+    const cb = Number(match[1]);
+    if ((cb & 64) === 0) continue; // not a wheel event
+    const dir = cb & 3; // 0 = wheel up, 1 = wheel down; 2/3 are horizontal, ignored
+    if (dir === 0 || dir === 1) wheel += dir === 0 ? -1 : 1;
+  }
+  return wheel;
+}
+
+// Raw terminal-input hook (traceline's existing onTerminalInput listener): while the
+// mode is active every mouse report is consumed. The wheel scrolls the pager when open,
+// else walks the selection (wheel up = older, §9.13); clicks and drags are swallowed
+// so they never reach pi's editor as garbage input.
+export function handleDrillTerminalInput(data: string): { consume: true } | undefined {
+  const st = g.__tracelineDrill;
+  if (!st) return undefined;
+  if (!data.startsWith("\x1b[<") && !data.startsWith("\x1b[M")) return undefined;
+  const wheel = wheelDelta(data);
+  if (wheel !== 0) {
+    if (st.pager) st.pager.scrollBy(wheel * 3);
+    else setSelected(st, st.selected - wheel);
+  }
+  return { consume: true };
+}

--- a/extensions/pi-traceline/drill.ts
+++ b/extensions/pi-traceline/drill.ts
@@ -3,7 +3,9 @@
 // six-column prefix with its number at identical width (zero reflow), and swaps the
 // editor for a two-line hint bar that owns the keyboard. A committed number or enter
 // opens the peek pager (drill-pager.ts); `p` toggles the selected row's native
-// expansion (§9.12 z1) in place; esc restores the editor and its draft. SGR mouse
+// expansion (§9.12 z1) in place; esc restores the editor and its draft. A modifier
+// chord the mode does not own (option+up, ctrl+c, …) exits the same way without being
+// consumed, so the keystroke lands in the restored editor. SGR mouse
 // reporting, never enabled for the plain transcript, turns on only inside the mode and
 // off at exit/shutdown/process-exit, with every mouse event consumed. State lives on
 // globalThis so that after /reload the previously patched tool-row renderer and the
@@ -314,35 +316,5 @@ function writeIgnoringErrors(sequence: string): void {
   }
 }
 
-const SGR_MOUSE_EVENT = /\x1b\[<(\d+);\d+;\d+([Mm])/g;
-
-/** Net wheel movement across a chunk of SGR mouse events: negative = wheel up. */
-export function wheelDelta(data: string): number {
-  let wheel = 0;
-  SGR_MOUSE_EVENT.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = SGR_MOUSE_EVENT.exec(data))) {
-    if (match[2] !== "M") continue; // presses only; SGR release events end in lowercase m
-    const cb = Number(match[1]);
-    if ((cb & 64) === 0) continue; // not a wheel event
-    const dir = cb & 3; // 0 = wheel up, 1 = wheel down; 2/3 are horizontal, ignored
-    if (dir === 0 || dir === 1) wheel += dir === 0 ? -1 : 1;
-  }
-  return wheel;
-}
-
-// Raw terminal-input hook (traceline's existing onTerminalInput listener): while the
-// mode is active every mouse report is consumed. The wheel scrolls the pager when open,
-// else walks the selection (wheel up = older, §9.13); clicks and drags are swallowed
-// so they never reach pi's editor as garbage input.
-export function handleDrillTerminalInput(data: string): { consume: true } | undefined {
-  const st = g.__tracelineDrill;
-  if (!st) return undefined;
-  if (!data.startsWith("\x1b[<") && !data.startsWith("\x1b[M")) return undefined;
-  const wheel = wheelDelta(data);
-  if (wheel !== 0) {
-    if (st.pager) st.pager.scrollBy(wheel * 3);
-    else setSelected(st, st.selected - wheel);
-  }
-  return { consume: true };
-}
+// The raw terminal-input hook (mouse consumption + foreign-chord exit) lives in
+// drill-input.ts; index.ts feeds it traceline's onTerminalInput listener.

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -45,9 +45,9 @@ import {
   drillTracePrefix,
   enterDrillMode,
   exitDrillMode,
-  handleDrillTerminalInput,
   type DrillHost,
 } from "./drill.ts";
+import { handleDrillTerminalInput } from "./drill-input.ts";
 import { commonDirSegments, compactReadDisplay, cwdRelativePath, lineRange, readDirKey } from "./path-rows.ts";
 import { recordFacts, type RecordTone } from "./records.ts";
 import {
@@ -1761,7 +1761,7 @@ export default function piTraceline(pi: ExtensionAPI) {
     // only changes how tool rows render while reasoning is hidden.
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = ctx.ui.onTerminalInput((data) => {
-      // Drill mode owns every mouse report while active (§9.13), and nothing else.
+      // Drill mode owns mouse reports; a foreign chord exits it un-consumed (§9.13).
       const drill = handleDrillTerminalInput(data);
       if (drill) return drill;
       if (!matchesKey(data, "ctrl+t")) return undefined;

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -1,13 +1,14 @@
-import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import {
   isKeyRelease,
   isKeyRepeat,
   matchesKey,
   truncateToWidth,
   visibleWidth,
+  type KeyId,
 } from "@earendil-works/pi-tui";
 import { rawIndexAtVisibleIndex, rawIndexBeforeVisibleIndex, stripAnsi } from "../_lib/ansi.ts";
-import { positiveNumberValue, isJsonObject } from "../_lib/boundary.ts";
+import { booleanValue, positiveNumberValue, isJsonObject, stringValue } from "../_lib/boundary.ts";
 import { captureTui } from "../_lib/capture.ts";
 import {
   findChatContainer,
@@ -38,6 +39,15 @@ import {
   type SizeThresholds,
   type Tone,
 } from "../_lib/style.ts";
+import { LINE_BREAK_MARK, PREAMBLE_MARK, bashPreambleRun, type BashPreambleRun } from "./bash-preamble.ts";
+import {
+  drillDecorateNativeRow,
+  drillTracePrefix,
+  enterDrillMode,
+  exitDrillMode,
+  handleDrillTerminalInput,
+  type DrillHost,
+} from "./drill.ts";
 import { commonDirSegments, compactReadDisplay, cwdRelativePath, lineRange, readDirKey } from "./path-rows.ts";
 import { recordFacts, type RecordTone } from "./records.ts";
 import {
@@ -153,9 +163,7 @@ const TOOL_PREFIX_VISIBLE_WIDTH = TOOL_INDENT.length + 2 + 1 + TOOL_AFTER_BULLET
 // gutter, so the suffix column never touches the terminal edge.
 const TOOL_RIGHT_MARGIN = 2;
 const ONE_LINE_CAPTURE_WIDTH = 10_000;
-const LINE_BREAK_MARK = "\u21b5"; // ↵ — marks a real newline in a flattened invocation
-const PREAMBLE_MARK = "\u22ef"; // ⋯ — stands in for a preamble identical to the row above
-const TRACELINE_PATCH_VERSION = 27;
+const TRACELINE_PATCH_VERSION = 28;
 const TRACELINE_ASSISTANT_PATCH_VERSION = 4;
 
 // --- theme-derived ink (design language §3) --------------------------------------------
@@ -281,8 +289,14 @@ function discriminatorInk(comp: ToolRowDataLike | undefined, text: string): stri
 // Every trace row indents one gutter, then opens with the dim ▏ rail (design language
 // §1/§5/§9.1): the block nests under the narrative line that motivated it, consecutive
 // rows fuse into one visible block, and the blank spacer before a group ends the rail.
-function toolPrefix(tone: Tone): string {
-  return `${TOOL_INDENT}${dim(TOOL_RAIL)} ${ink(currentTheme(), tone, TOOL_BULLET)}${TOOL_AFTER_BULLET}`;
+// While drill mode is active (§9.13), a numbered row swaps the rail cell for its
+// right-aligned number at identical width, so numbering never reflows the transcript.
+function toolPrefix(tone: Tone, comp?: ToolRowDataLike): string {
+  const bullet = ink(currentTheme(), tone, TOOL_BULLET);
+  return (
+    drillTracePrefix(currentTheme(), comp, bullet) ??
+    `${TOOL_INDENT}${dim(TOOL_RAIL)} ${bullet}${TOOL_AFTER_BULLET}`
+  );
 }
 
 function formatCharCount(value: number): string {
@@ -297,15 +311,21 @@ let sizeThresholds: SizeThresholds = SIZE_THRESHOLDS;
 type TracelineConfig = {
   sizeWarningChars?: number;
   sizeErrorChars?: number;
+  drillKey?: string;
+  drillMouse?: boolean;
 };
 
 function parseTracelineConfig(value: unknown): TracelineConfig {
   if (!isJsonObject(value)) return {};
   const sizeWarningChars = positiveNumberValue(value.sizeWarningChars);
   const sizeErrorChars = positiveNumberValue(value.sizeErrorChars);
+  const drillKey = stringValue(value.drillKey);
+  const drillMouse = booleanValue(value.drillMouse);
   return {
     ...(sizeWarningChars !== undefined ? { sizeWarningChars: Math.floor(sizeWarningChars) } : {}),
     ...(sizeErrorChars !== undefined ? { sizeErrorChars: Math.floor(sizeErrorChars) } : {}),
+    ...(drillKey !== undefined && drillKey.length > 0 ? { drillKey } : {}),
+    ...(drillMouse !== undefined ? { drillMouse } : {}),
   };
 }
 
@@ -365,7 +385,8 @@ function inlineMutationRow(comp: ToolRowDataLike | undefined): boolean {
 function blockToolRows(comp: ToolRowLike): ToolRowLike[] {
   const found = componentLocation(comp);
   if (!found) return [comp];
-  const breaksBlock = (c: unknown) => !isToolRow(c) && !isEmptyConnector(c);
+  // An expanded row (§9.12 z1) renders native and breaks the trace block like prose.
+  const breaksBlock = (c: unknown) => (!isToolRow(c) && !isEmptyConnector(c)) || isExpandedToolRow(c);
   let start = found.index;
   for (let j = found.index - 1; j >= 0; j--) {
     if (breaksBlock(found.sibs[j])) break;
@@ -1089,9 +1110,9 @@ function traceRowAvailable(width: number): number {
 
 // The one row form shared by single rows and folded read runs: body left, the block's
 // reserved fact-suffix column right (§9.8/§9.1), behind the railed status prefix.
-function fitTraceRow(tone: Tone, body: string, suffix: string, reserve: number, width: number): string {
+function fitTraceRow(comp: ToolRowDataLike | undefined, tone: Tone, body: string, suffix: string, reserve: number, width: number): string {
   const fitted = rightAlignSuffix(body, suffix, traceRowAvailable(width), currentTheme(), reserve);
-  return truncateToWidth(`${toolPrefix(tone)}${fitted}`, Math.max(1, width), ELLIPSIS);
+  return truncateToWidth(`${toolPrefix(tone, comp)}${fitted}`, Math.max(1, width), ELLIPSIS);
 }
 
 function oneLine(comp: ToolRowLike, width: number): string {
@@ -1106,6 +1127,7 @@ function oneLine(comp: ToolRowLike, width: number): string {
   const facts = blockFacts(rows);
   const available = traceRowAvailable(width);
   return fitTraceRow(
+    comp,
     statusTone(comp),
     invocationInk(comp, available),
     toolFactSuffix(comp, available, facts),
@@ -1124,129 +1146,8 @@ function oneLine(comp: ToolRowLike, width: number): string {
 // `set -…` hygiene drops like the `(timeout Ns)` suffix, and the `cd`/assignment context
 // folds to a dim `⋯` when it repeats the previous bash row's (§9.4).
 
-// Top-level segments of a flattened bash body, split on `&&`/`||`/`;`/`↵` outside
-// quotes, command substitutions and backticks. Only the leading preamble run is read
-// (the walk stops at the first real command), so heredoc bodies — which live only in
-// real segments — need no handling here.
-function bashTopLevelSegments(body: string): { start: number; text: string }[] {
-  const segs: { start: number; text: string }[] = [];
-  let quote: "'" | '"' | undefined;
-  let paren = 0;
-  let backtick = false;
-  let segStart = 0;
-  const push = (end: number) => {
-    const raw = body.slice(segStart, end);
-    const lead = raw.length - raw.replace(/^\s+/, "").length;
-    const text = raw.trim();
-    if (text.length > 0) segs.push({ start: segStart + lead, text });
-  };
-  let i = 0;
-  while (i < body.length) {
-    const ch = body[i]!;
-    if (quote === "'") {
-      if (ch === "'") quote = undefined;
-      i++;
-      continue;
-    }
-    if (quote === '"') {
-      if (ch === "\\") { i += 2; continue; }
-      if (ch === '"') quote = undefined;
-      i++;
-      continue;
-    }
-    if (backtick) {
-      if (ch === "`") backtick = false;
-      i++;
-      continue;
-    }
-    if (ch === "'") { quote = "'"; i++; continue; }
-    if (ch === '"') { quote = '"'; i++; continue; }
-    if (ch === "`") { backtick = true; i++; continue; }
-    if (ch === "\\") { i += 2; continue; }
-    if (ch === "(") { paren++; i++; continue; }
-    if (ch === ")") { if (paren > 0) paren--; i++; continue; }
-    if (paren === 0) {
-      if (body.startsWith("&&", i) || body.startsWith("||", i)) { push(i); i += 2; segStart = i; continue; }
-      if (ch === ";" || ch === LINE_BREAK_MARK) { push(i); i += 1; segStart = i; continue; }
-    }
-    i++;
-  }
-  push(body.length);
-  return segs;
-}
-
-// One env-assignment-only segment (`WORK=$(cat x)`, `A=1 B=2`) is setup, not a command,
-// so it situates; `FOO=bar cmd` is the command `cmd` and does not. Consumes each
-// `VAR=value` token quote/substitution-aware, then checks nothing but assignments remain.
-function isEnvAssignmentOnly(text: string): boolean {
-  let i = 0;
-  while (i < text.length) {
-    while (i < text.length && /\s/.test(text[i]!)) i++;
-    if (i >= text.length) return true;
-    if (!/^[A-Za-z_][A-Za-z0-9_]*=/.test(text.slice(i))) return false;
-    let quote: "'" | '"' | undefined;
-    let paren = 0;
-    let backtick = false;
-    while (i < text.length) {
-      const ch = text[i]!;
-      if (quote === "'") { if (ch === "'") quote = undefined; i++; continue; }
-      if (quote === '"') { if (ch === "\\") { i += 2; continue; } if (ch === '"') quote = undefined; i++; continue; }
-      if (backtick) { if (ch === "`") backtick = false; i++; continue; }
-      if (ch === "'") { quote = "'"; i++; continue; }
-      if (ch === '"') { quote = '"'; i++; continue; }
-      if (ch === "`") { backtick = true; i++; continue; }
-      if (ch === "\\") { i += 2; continue; }
-      if (ch === "(") { paren++; i++; continue; }
-      if (ch === ")") { if (paren > 0) paren--; i++; continue; }
-      if (paren === 0 && /\s/.test(ch)) break;
-      i++;
-    }
-  }
-  return true;
-}
-
-type BashSegmentClass = "hygiene" | "context" | "real";
-
-// `set -…` is hygiene (drop-always); `cd`, `export …` and bare assignments situate
-// (fold-on-repeat); everything else is the reason the row exists and stops the run.
-function classifyBashSegment(text: string): BashSegmentClass {
-  if (/^set(\s|$)/.test(text)) return "hygiene";
-  if (/^cd(\s|$)/.test(text)) return "context";
-  if (/^export\s+[A-Za-z_]/.test(text)) return "context";
-  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(text)) return isEnvAssignmentOnly(text) ? "context" : "real";
-  return "real";
-}
-
-type BashPreambleRun = {
-  contextText: string; // situating context, joined; "" when the run has none
-  firstRealStart?: number; // body index of the first real command, if any
-  dropStart?: number; // body index just past a leading `set -…` run, when a drop applies
-};
-
-// The leading preamble run of a flattened bash body. contextText compares context
-// across rows (both computed from tildified bodies, so `cd ~/x` matches `cd ~/x`);
-// firstRealStart is where the `⋯` fold would point; dropStart marks where a leading
-// `set -…` run ends. dropStart stays undefined when the whole body is hygiene, so a
-// `set -e`-only row keeps its head and no row goes dark (§9.4).
-function bashPreambleRun(body: string): BashPreambleRun {
-  const contextParts: string[] = [];
-  let firstRealStart: number | undefined;
-  let dropStart: number | undefined;
-  for (const seg of bashTopLevelSegments(body)) {
-    const cls = classifyBashSegment(seg.text);
-    if (cls === "real") {
-      firstRealStart = seg.start;
-      if (dropStart === undefined) dropStart = seg.start;
-      break;
-    }
-    if (cls === "context") {
-      contextParts.push(seg.text);
-      if (dropStart === undefined) dropStart = seg.start;
-    }
-    // a leading hygiene (`set`) segment leaves dropStart pointing just past it
-  }
-  return { contextText: contextParts.join("\n"), firstRealStart, dropStart };
-}
+// The segment grammar behind the reclaim (top-level splitting, env-assignment
+// detection, hygiene/context/real classification) lives in bash-preamble.ts.
 
 // The previous bash row within the same visual group: reads and other tools interleave
 // freely, but visible prose opens a new paragraph — a `⋯` must never point across one.
@@ -1327,6 +1228,7 @@ function readPath(comp: ToolRowDataLike): string | undefined {
 function foldableReadPath(comp: ToolRowDataLike): string | undefined {
   const path = readPath(comp);
   if (path === undefined) return undefined;
+  if (comp.expanded === true) return undefined; // an expanded row (§9.12) never folds
   return toolStatus(comp) === "error" ? undefined : path;
 }
 
@@ -1444,7 +1346,8 @@ function foldedReadLines(rows: ToolRowLike[], width: number): string[] {
       .filter(Boolean)
       .join(",");
     const body = `${verbInk(last, "read")} ${dim(dir)}${discriminatorInk(last, base)}${ink(theme, "warning", ranges ? `:${ranges}` : "")}`;
-    return [fitTraceRow(tone, body, suffix, reserve, width)];
+    // rows[0] is the carrier: in drill mode the fold is one target and rows[0] renders it.
+    return [fitTraceRow(rows[0], tone, body, suffix, reserve, width)];
   }
 
   // Sibling files fold into one dir row (§9.9): the shared directory prints once
@@ -1516,7 +1419,7 @@ function foldedReadLines(rows: ToolRowLike[], width: number): string[] {
   return lines.map((line) =>
     line.continuation
       ? truncateToWidth(`${contPrefix}${middleTruncate(line.ink, contBudget, theme)}`, Math.max(1, width), ELLIPSIS)
-      : fitTraceRow(tone, line.ink, suffix, reserve, width),
+      : fitTraceRow(rows[0], tone, line.ink, suffix, reserve, width),
   );
 }
 
@@ -1561,6 +1464,12 @@ function isCollapsedThinkingRow(c: unknown): boolean {
   return hasThinking;
 }
 
+// An expanded row (design language §9.12 z1): pi's native render, traceline's grammar
+// opts it out of folds, blocks and shared columns.
+function isExpandedToolRow(c: unknown): boolean {
+  return isToolRow(c) && c.expanded === true;
+}
+
 // One blank line before a tool *group*, none within it: walk back past invisible
 // connector turns; tight if the nearest visible sibling is another collapsed tool row
 // or the collapsed thinking-label line that motivated this call.
@@ -1570,6 +1479,7 @@ function leadingBlank(comp: ToolRowDataLike): boolean {
   const { sibs, index } = found;
   for (let j = index - 1; j >= 0; j--) {
     const prev = sibs[j];
+    if (isExpandedToolRow(prev)) return true; // a native-rendered block above → new trace block
     if (isToolRow(prev)) return false; // adjacent (through connectors) to another tool
     if (isEmptyConnector(prev)) continue; // skip invisible tool-call-only turns
     if (isCollapsedThinkingRow(prev)) return false; // tight under its Thinking... line
@@ -1666,7 +1576,12 @@ function patchToolRowPrototype(proto: ToolRowPrototypeLike): void {
     // One guard, one policy: any failure on traceline's path falls back to the
     // native render — never let pi-traceline break a render.
     try {
-      if (displayMode() === "native") return original.call(this, width);
+      if (displayMode() === "native" || this.expanded === true) {
+        // Native-rendered rows (z2, or an expanded z1 row) still take their drill
+        // number on the leading blank spacer line while drill mode is active (§9.13).
+        const bullet = ink(currentTheme(), statusTone(this), TOOL_BULLET);
+        return drillDecorateNativeRow(currentTheme(), this, original.call(this, width), bullet);
+      }
       return renderTraceRow(this, width);
     } catch {
       return original.call(this, width);
@@ -1740,6 +1655,9 @@ export const internals = {
   oneLine,
   leadingBlank,
   renderTraceRow,
+  isExpandedToolRow,
+  statusTone,
+  foldedReadLines,
   // repetition folding + preamble reclaim + thinking-label preview/dedupe (issue #14)
   bashPreambleRun,
   bashPreambleRunOf,
@@ -1758,6 +1676,54 @@ export const internals = {
 };
 
 export default function piTraceline(pi: ExtensionAPI) {
+  const config: TracelineConfig = Object.assign(
+    {},
+    ...configPaths("pi-traceline", process.cwd()).map(
+      (path) => readJsonConfig(path, parseTracelineConfig) ?? {},
+    ),
+  );
+
+  // Drill mode (§9.13) lives in drill.ts / drill-pager.ts; this host hands it just the
+  // render internals it needs. Entry points: a shortcut (alt+t by default, `drillKey`
+  // in the family config to rebind) plus /drill for discoverability.
+  const drillHost = (ui: ExtensionUIContext): DrillHost => ({
+    ui,
+    theme: currentTheme,
+    chatChildren,
+    requestRender: () => {
+      try {
+        g.__tracelineTui?.requestRender();
+      } catch {
+        /* never let drill mode break a render */
+      }
+    },
+    traceLines: (comp, width) => {
+      const run = readRun(comp);
+      return run && run.index === 0 ? foldedReadLines(run.rows, width) : [oneLine(comp, width)];
+    },
+    runRows: (comp) => {
+      const run = readRun(comp);
+      return run && run.index === 0 ? run.rows : undefined;
+    },
+    // Only one-line mode folds reads away; in native mode every row is its own target.
+    hiddenByFold: (comp) => displayMode() === "oneLine" && (readRun(comp)?.index ?? 0) > 0,
+    statusTone,
+    mouse: config.drillMouse !== false,
+  });
+  const startDrill = (ctx: { ui: ExtensionUIContext; hasUI: boolean }) => {
+    if (!ctx.hasUI) return;
+    enterDrillMode(drillHost(ctx.ui));
+  };
+  // SAFETY: drillKey comes from user config; an unknown key id just never matches.
+  pi.registerShortcut((config.drillKey ?? "alt+t") as KeyId, {
+    description: "traceline: drill into tool rows (number, peek, pin)",
+    handler: async (ctx) => startDrill(ctx),
+  });
+  pi.registerCommand("drill", {
+    description: "traceline: number the visible tool rows; type one to peek",
+    handler: async (_args, ctx) => startDrill(ctx),
+  });
+
   pi.on("session_start", async (_event, ctx) => {
     // Capture the real TUI (passed synchronously to the widget factory), then patch only
     // extension-visible seams: requestRender for delayed tool-row patching, and raw
@@ -1769,12 +1735,6 @@ export default function piTraceline(pi: ExtensionAPI) {
         return undefined;
       }
     };
-    const config = Object.assign(
-      {},
-      ...configPaths("pi-traceline", process.cwd()).map(
-        (path) => readJsonConfig(path, parseTracelineConfig) ?? {},
-      ),
-    );
     configureSizeThresholds(config);
     captureTui(ctx.ui, "__pi_traceline_capture", (tui) => {
       const t = tui as TracelineTuiLike;
@@ -1801,6 +1761,9 @@ export default function piTraceline(pi: ExtensionAPI) {
     // only changes how tool rows render while reasoning is hidden.
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = ctx.ui.onTerminalInput((data) => {
+      // Drill mode owns every mouse report while active (§9.13), and nothing else.
+      const drill = handleDrillTerminalInput(data);
+      if (drill) return drill;
       if (!matchesKey(data, "ctrl+t")) return undefined;
       if (isKeyRelease(data) || isKeyRepeat(data)) return { consume: true };
       return undefined;
@@ -1808,6 +1771,7 @@ export default function piTraceline(pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
+    exitDrillMode(); // restores the editor and turns mouse reporting off
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = undefined;
   });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "node --test 'tests/**/*.test.ts'",
     "check": "npm run lint && npm run typecheck && npm test",
     "test:smoke:traceline": "node tests/smoke/traceline-empty-thinking-smoke.mjs",
-    "test:smoke": "npm run test:smoke:traceline && node tests/smoke/startup-smoke.mjs"
+    "test:smoke:drill": "node tests/smoke/traceline-drill-smoke.mjs",
+    "test:smoke": "npm run test:smoke:traceline && npm run test:smoke:drill && node tests/smoke/startup-smoke.mjs"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-of-glass",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Observability extensions for the Pi coding agent",
   "license": "MIT",
   "type": "module",

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -9,7 +9,7 @@
       "extensions/pi-contextimate/index.ts": 1959,
       "extensions/pi-traceline/index.ts": 1779,
       "tests/cachemire/economics-and-render.test.ts": 352,
-      "tests/contract/pi-internals.test.ts": 411,
+      "tests/contract/pi-internals.test.ts": 432,
       "tests/traceline/one-line.test.ts": 775
     }
   }

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,8 +7,9 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 1258,
       "extensions/pi-contextimate/index.ts": 1959,
-      "extensions/pi-traceline/index.ts": 1815,
+      "extensions/pi-traceline/index.ts": 1779,
       "tests/cachemire/economics-and-render.test.ts": 352,
+      "tests/contract/pi-internals.test.ts": 411,
       "tests/traceline/one-line.test.ts": 775
     }
   }

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -347,6 +347,27 @@ test("showExtensionCustom seam: editor swap/restore + overlay close drill mode r
   assert.ok(declarations.includes("custom<T>(factory: (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: T) => void)"), "custom factory signature drifted — hint bar and pager factories break");
 });
 
+test("foreign-chord exit seam: listeners precede focus dispatch; close() restores inline", () => {
+  // Drill's foreign-chord exit (§9.13) rides two orderings inside one input dispatch:
+  // the extension input listener exits the mode, pi restores the editor synchronously
+  // inside showExtensionCustom's close(), and only then does tui resolve the focused
+  // component — so the very same keystroke lands in the restored editor.
+  const tuiRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-tui"))), "..");
+  const tuiSource = readFileSync(join(tuiRoot, "dist/tui.js"), "utf8");
+  const listenerLoop = tuiSource.indexOf("for (const listener of this.inputListeners)");
+  const focusDispatch = tuiSource.indexOf("this.focusedComponent.handleInput(data)");
+  assert.ok(listenerLoop !== -1, "input-listener loop gone — the foreign-chord hook never runs");
+  assert.ok(focusDispatch !== -1, "focused-component dispatch gone — re-verify tui input routing");
+  assert.ok(listenerLoop < focusDispatch, "listeners no longer run before focus dispatch — a foreign chord would hit the dead hint bar");
+
+  const source = readFileSync(join(piRoot, "dist/modes/interactive/interactive-mode.js"), "utf8");
+  const closeBody = source.slice(source.indexOf("async showExtensionCustom")).slice(0, 2_000);
+  const restoreAt = closeBody.indexOf("restoreEditor();");
+  const resolveAt = closeBody.indexOf("resolve(result);");
+  assert.ok(restoreAt !== -1 && resolveAt !== -1, "close() body drifted — re-verify the synchronous editor restore");
+  assert.ok(restoreAt < resolveAt, "close() no longer restores the editor before resolving — the flowed-through chord would land in a void");
+});
+
 test("pi-tui overlay focus restore + terminal dimensions the drill pager reads", () => {
   const tuiRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-tui"))), "..");
   const tuiSource = readFileSync(join(tuiRoot, "dist/tui.js"), "utf8");

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -320,6 +320,67 @@ test("Ctrl+T status line: pi's showStatus tail shape traceline suppresses", () =
 });
 
 // ---------------------------------------------------------------------------------------
+// Drill mode's Pi seams (design language §9.13): the custom-UI editor swap, the overlay
+// pager, and the expanded-row spacer line the number cell replaces.
+
+test("showExtensionCustom seam: editor swap/restore + overlay close drill mode rides", () => {
+  const source = readFileSync(join(piRoot, "dist/modes/interactive/interactive-mode.js"), "utf8");
+  assert.ok(
+    source.includes("custom: (factory, options) => this.showExtensionCustom(factory, options)"),
+    "ctx.ui.custom wiring gone — drill mode cannot open its hint bar or pager",
+  );
+  const custom = source.slice(source.indexOf("async showExtensionCustom"));
+  assert.ok(custom.includes("const savedText = this.editor.getText();"), "editor draft no longer saved — exiting drill mode would eat the user's draft");
+  for (const anchor of [
+    "this.editorContainer.clear();",
+    "this.editorContainer.addChild(this.editor);",
+    "this.editor.setText(savedText);",
+    "this.ui.setFocus(this.editor);",
+  ]) {
+    assert.ok(custom.includes(anchor), `editor restore step gone (${anchor}) — drill exit strands the editor`);
+  }
+  assert.ok(custom.includes("this.ui.hideOverlay()"), "overlay close no longer hides — the pager would never leave the screen");
+
+  const declarations = readFileSync(join(piRoot, "dist/core/extensions/types.d.ts"), "utf8");
+  assert.ok(declarations.includes("registerShortcut(shortcut: KeyId"), "registerShortcut signature drifted — the alt+t entry point dies");
+  assert.ok(declarations.includes("onTerminalInput(handler: TerminalInputHandler)"), "onTerminalInput gone — drill's mouse routing dies");
+  assert.ok(declarations.includes("custom<T>(factory: (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: T) => void)"), "custom factory signature drifted — hint bar and pager factories break");
+});
+
+test("pi-tui overlay focus restore + terminal dimensions the drill pager reads", () => {
+  const tuiRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-tui"))), "..");
+  const tuiSource = readFileSync(join(tuiRoot, "dist/tui.js"), "utf8");
+  assert.ok(
+    tuiSource.includes("preFocus: this.focusedComponent"),
+    "showOverlay no longer records pre-overlay focus — closing the pager would not return keys to the hint bar",
+  );
+  assert.ok(
+    tuiSource.includes("overlayLines.slice(0, maxHeight)"),
+    "overlay no longer clips lines to maxHeight — re-verify the pager's self-windowing assumption",
+  );
+  const tuiDecl = readFileSync(join(tuiRoot, "dist/tui.d.ts"), "utf8");
+  assert.ok(tuiDecl.includes("terminal: Terminal;"), "TUI.terminal gone — the pager loses its height source");
+});
+
+test("real expanded tool row: setExpanded mirrors .expanded and leads with a blank spacer", () => {
+  pi.initTheme(undefined, false);
+  const comp = new pi.ToolExecutionComponent("read", "tool-drill", { path: "/tmp/x.txt" }, undefined, undefined, {} as never, tmpdir());
+  comp.updateResult({ content: [{ type: "text", text: "hello ".repeat(40) }], isError: false }, false);
+  const peek = comp as unknown as { expanded?: boolean };
+  assert.equal(peek.expanded ?? false, false, "rows must start collapsed");
+  comp.setExpanded(true);
+  assert.equal(peek.expanded, true, "expanded flag no longer mirrors setExpanded — drill pins and §9.12 z1 desync");
+  assert.equal(traceline.isExpandedToolRow(comp), true, "real expanded row must match the z1 duck type");
+
+  // The number cell rides the blank spacer line pi renders above a native row (§9.13).
+  // If this softens, drill numbering on expanded rows silently degrades (row stays
+  // selectable but shows no number) — this contract names the drift instead.
+  const lines = comp.render(80);
+  assert.ok(Array.isArray(lines) && lines.length > 1, "expanded render shape drifted");
+  assert.equal(traceline.stripAnsi(lines[0] as string).trim(), "", "expanded native render no longer leads with a blank spacer line");
+});
+
+// ---------------------------------------------------------------------------------------
 // Settings + ExtensionAPI declaration anchors (source-text tripwires).
 
 test("ExtensionAPI still declares the tool surface contextimate reads", () => {

--- a/tests/smoke/traceline-drill-smoke.mjs
+++ b/tests/smoke/traceline-drill-smoke.mjs
@@ -3,8 +3,9 @@
 // end (design language §9.13): Alt+T numbers the rows with zero reflow and swaps the
 // editor (and its draft) for the hint bar, a committed digit opens the peek pager on
 // the full result, esc unwinds to the numbered transcript and then back to the editor
-// with the draft intact. Every subprocess call is bounded and the uniquely launched Pi
-// is killed on timeout.
+// with the draft intact, and a foreign chord (alt+up) exits the mode un-consumed so
+// the same press reaches the restored editor. Every subprocess call is bounded and
+// the uniquely launched Pi is killed on timeout.
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -268,6 +269,21 @@ try {
   if (restoredRows.join("\n") !== beforeRows.join("\n")) {
     throw new Error(`exit did not restore the plain rail rows\n${restoredRows.join("\n")}`);
   }
+
+  // 5. A foreign chord (§9.13): alt+up exits the mode un-consumed and lands in the
+  // restored editor in the same press — stock pi answers with its native dequeue status.
+  sendKeys("M-t");
+  const redrilling = waitForPane((pane) => pane.includes("drill · row 1 of 2"));
+  if (!redrilling.includes("drill · row 1 of 2")) throw new Error(`hint bar did not reappear for the chord step\n${redrilling}`);
+  sendKeys("M-Up");
+  const chordExit = waitForPane(
+    (pane) => !pane.includes("drill · row") && pane.includes("No queued messages to restore"),
+  );
+  if (chordExit.includes("drill · row")) throw new Error(`alt+up did not exit drill mode\n${chordExit}`);
+  if (!chordExit.includes("No queued messages to restore")) {
+    throw new Error(`alt+up did not reach the restored editor in the same press\n${chordExit}`);
+  }
+  if (!chordExit.includes(draft)) throw new Error(`editor draft lost across the chord exit\n${chordExit}`);
 
   sendKeys("C-c");
   sendKeys("/quit", "Enter");

--- a/tests/smoke/traceline-drill-smoke.mjs
+++ b/tests/smoke/traceline-drill-smoke.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// Resume a real Pi session with two completed read rows, then walk drill mode end to
+// end (design language §9.13): Alt+T numbers the rows with zero reflow and swaps the
+// editor (and its draft) for the hint bar, a committed digit opens the peek pager on
+// the full result, esc unwinds to the numbered transcript and then back to the editor
+// with the draft intact. Every subprocess call is bounded and the uniquely launched Pi
+// is killed on timeout.
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const extensionPath = join(repoRoot, "extensions", "pi-traceline", "index.ts");
+const tmuxSession = `pog-drill-${process.pid}`;
+const readySentinel = "DRILL_SMOKE_READY";
+const alphaResult = `DRILL_RESULT_ALPHA ${"a".repeat(160)}`;
+const betaResult = `DRILL_RESULT_BETA ${"b".repeat(160)}`;
+const draft = "drill smoke draft";
+const hardDeadline = Date.now() + 60_000;
+let launchedPid;
+let fixtureHome;
+let fixtureDir;
+
+function remainingMs(cap = 5_000) {
+  return Math.max(1, Math.min(cap, hardDeadline - Date.now()));
+}
+
+function run(args, options = {}) {
+  return spawnSync(args[0], args.slice(1), {
+    encoding: "utf8",
+    timeout: remainingMs(options.timeoutMs),
+    ...options.spawn,
+  });
+}
+
+function cleanupRun(args) {
+  return spawnSync(args[0], args.slice(1), { encoding: "utf8", timeout: 2_000 });
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function hasTmuxSession() {
+  return run(["tmux", "has-session", "-t", tmuxSession], { timeoutMs: 2_000 }).status === 0;
+}
+
+function capturePane() {
+  return run(["tmux", "capture-pane", "-p", "-t", tmuxSession, "-S", "-500"], {
+    timeoutMs: 2_000,
+  }).stdout ?? "";
+}
+
+function sendKeys(...keys) {
+  return run(["tmux", "send-keys", "-t", tmuxSession, ...keys], { timeoutMs: 2_000 });
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// Poll the pane until predicate(pane) holds; returns the pane text either way.
+function waitForPane(predicate) {
+  let pane = "";
+  while (Date.now() < hardDeadline && hasTmuxSession()) {
+    pane = capturePane();
+    if (predicate(pane)) return pane;
+    sleep(200);
+  }
+  return pane;
+}
+
+function sessionEntries(cwd) {
+  const iso = "2026-07-16T09:00:00.000Z";
+  const timestamp = Date.parse(iso);
+  const usage = {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+  const assistantShell = { api: "anthropic-messages", provider: "anthropic", model: "claude-opus-4-8", usage };
+  return [
+    { type: "session", version: 3, id: "00000001", parentId: null, timestamp: iso, cwd },
+    {
+      type: "message",
+      id: "00000002",
+      parentId: "00000001",
+      timestamp: iso,
+      message: { role: "user", content: [{ type: "text", text: "Resume the drill smoke fixture." }], timestamp },
+    },
+    {
+      type: "message",
+      id: "00000003",
+      parentId: "00000002",
+      timestamp: iso,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-alpha", name: "read", arguments: { path: join(cwd, "alpha.txt"), offset: 1, limit: 40 } }],
+        ...assistantShell,
+        stopReason: "toolUse",
+        timestamp: timestamp + 1,
+      },
+    },
+    {
+      type: "message",
+      id: "00000004",
+      parentId: "00000003",
+      timestamp: iso,
+      message: {
+        role: "toolResult",
+        toolCallId: "call-alpha",
+        toolName: "read",
+        content: [{ type: "text", text: alphaResult }],
+        isError: false,
+        timestamp: timestamp + 2,
+      },
+    },
+    {
+      type: "message",
+      id: "00000005",
+      parentId: "00000004",
+      timestamp: iso,
+      message: {
+        role: "assistant",
+        // a different directory on purpose: consecutive sibling reads would fold into one dir row (§9.9)
+        content: [{ type: "toolCall", id: "call-beta", name: "read", arguments: { path: join(cwd, "sub", "beta.txt"), offset: 1, limit: 40 } }],
+        ...assistantShell,
+        stopReason: "toolUse",
+        timestamp: timestamp + 3,
+      },
+    },
+    {
+      type: "message",
+      id: "00000006",
+      parentId: "00000005",
+      timestamp: iso,
+      message: {
+        role: "toolResult",
+        toolCallId: "call-beta",
+        toolName: "read",
+        content: [{ type: "text", text: betaResult }],
+        isError: false,
+        timestamp: timestamp + 4,
+      },
+    },
+    {
+      type: "message",
+      id: "00000007",
+      parentId: "00000006",
+      timestamp: iso,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: readySentinel }],
+        ...assistantShell,
+        stopReason: "stop",
+        timestamp: timestamp + 5,
+      },
+    },
+  ];
+}
+
+function cleanupLaunchedPi() {
+  if (Number.isInteger(launchedPid)) {
+    const panePid = Number.parseInt(
+      cleanupRun(["tmux", "display-message", "-p", "-t", tmuxSession, "#{pane_pid}"]).stdout?.trim() ?? "",
+      10,
+    );
+    const command = cleanupRun(["ps", "-p", String(launchedPid), "-o", "command="]).stdout ?? "";
+    const fixtureOwned = command.includes(tmuxSession) || (fixtureDir && command.includes(fixtureDir));
+    if (panePid === launchedPid || fixtureOwned) {
+      try {
+        process.kill(launchedPid, "SIGKILL");
+      } catch (error) {
+        if (error?.code !== "ESRCH") throw error;
+      }
+    }
+  }
+  cleanupRun(["tmux", "kill-session", "-t", tmuxSession]);
+}
+
+if (run(["tmux", "-V"]).status !== 0) {
+  console.error("tmux not available: real-Pi drill smoke requires tmux");
+  process.exit(2);
+}
+if (run(["pi", "--version"]).status !== 0) {
+  console.error("pi not on PATH: real-Pi drill smoke requires an installed Pi");
+  process.exit(2);
+}
+
+fixtureHome = mkdtempSync(join(tmpdir(), "pog-drill-home-"));
+fixtureDir = mkdtempSync(join(tmpdir(), `${tmuxSession}-`));
+const agentDir = join(fixtureHome, ".pi", "agent");
+mkdirSync(agentDir, { recursive: true });
+writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ hideThinkingBlock: true }, null, 2));
+writeFileSync(join(agentDir, "trust.json"), JSON.stringify({ [fixtureDir]: true, [repoRoot]: true }, null, 2));
+writeFileSync(join(fixtureDir, "AGENTS.md"), "# Drill smoke\nFixture only.\n");
+const sessionFile = join(fixtureDir, "session.jsonl");
+writeFileSync(sessionFile, `${sessionEntries(fixtureDir).map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+
+try {
+  const command = [
+    "exec env",
+    `HOME=${shellQuote(fixtureHome)}`,
+    "pi",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "-e",
+    shellQuote(extensionPath),
+    "--session",
+    shellQuote(sessionFile),
+  ].join(" ");
+  const launch = run(["tmux", "new-session", "-d", "-s", tmuxSession, "-x", "110", "-y", "32", command]);
+  if (launch.status !== 0) throw new Error(`tmux launch failed: ${launch.stderr?.trim()}`);
+
+  const pidResult = run(["tmux", "display-message", "-p", "-t", tmuxSession, "#{pane_pid}"], { timeoutMs: 2_000 });
+  launchedPid = Number.parseInt(pidResult.stdout?.trim() ?? "", 10);
+  if (!Number.isInteger(launchedPid)) throw new Error("could not identify the isolated Pi pane PID");
+
+  // 1. Resume renders both trace rows.
+  const resumed = waitForPane((pane) =>
+    pane.includes(readySentinel) && pane.includes("alpha.txt") && pane.includes("beta.txt"));
+  if (!resumed.includes(readySentinel)) throw new Error(`resumed session did not render\n${resumed}`);
+  const traceRowsOf = (pane) => pane.split("\n").filter((line) => /alpha\.txt|beta\.txt/.test(line));
+  const beforeRows = traceRowsOf(resumed).map((line) => line.trimEnd());
+  if (beforeRows.length !== 2) throw new Error(`expected two trace rows, saw:\n${resumed}`);
+
+  // 2. A draft, then Alt+T: hint bar replaces the editor, numbers land at equal width.
+  sendKeys(draft);
+  const withDraft = waitForPane((pane) => pane.includes(draft));
+  if (!withDraft.includes(draft)) throw new Error(`draft never appeared in the editor\n${withDraft}`);
+  sendKeys("M-t");
+  const drilling = waitForPane((pane) => pane.includes("drill · row 1 of 2"));
+  if (!drilling.includes("drill · row 1 of 2")) throw new Error(`hint bar did not appear\n${drilling}`);
+  if (drilling.includes(draft)) throw new Error(`draft still visible while the hint bar owns the editor slot\n${drilling}`);
+  const numberedRows = traceRowsOf(drilling).map((line) => line.trimEnd());
+  if (numberedRows.length !== 2) throw new Error(`numbering changed the row count\n${drilling}`);
+  for (const [i, row] of numberedRows.entries()) {
+    if (row.slice(6) !== beforeRows[i].slice(6)) {
+      throw new Error(`numbering reflowed a row body\nbefore: ${beforeRows[i]}\nafter:  ${row}`);
+    }
+  }
+  if (!/^\s*2 › /.test(numberedRows[0]) || !/^\s*1 › /.test(numberedRows[1])) {
+    throw new Error(`gutter numbers wrong (1 must be the most recent row)\n${numberedRows.join("\n")}`);
+  }
+
+  // 3. Digit commit opens the pager on the older row's complete result.
+  sendKeys("2");
+  const peeking = waitForPane((pane) => pane.includes("peek · row 2 of 2"));
+  if (!peeking.includes("peek · row 2 of 2")) throw new Error(`pager did not open on row 2\n${peeking}`);
+  if (!peeking.includes("DRILL_RESULT_ALPHA")) throw new Error(`pager missing the full result text\n${peeking}`);
+  if (!peeking.includes("invocation")) throw new Error(`pager missing the invocation section\n${peeking}`);
+
+  // 4. esc unwinds: pager → numbered transcript → editor with the draft intact.
+  sendKeys("Escape");
+  const backToDrill = waitForPane((pane) => pane.includes("drill · row") && !pane.includes("peek · row"));
+  if (!backToDrill.includes("drill · row")) throw new Error(`esc did not return to drill mode\n${backToDrill}`);
+  sendKeys("Escape");
+  const restored = waitForPane((pane) => pane.includes(draft) && !pane.includes("drill · row"));
+  if (!restored.includes(draft)) throw new Error(`editor draft not restored after exit\n${restored}`);
+  const restoredRows = traceRowsOf(restored).map((line) => line.trimEnd());
+  if (restoredRows.join("\n") !== beforeRows.join("\n")) {
+    throw new Error(`exit did not restore the plain rail rows\n${restoredRows.join("\n")}`);
+  }
+
+  sendKeys("C-c");
+  sendKeys("/quit", "Enter");
+  const exitDeadline = Math.min(hardDeadline, Date.now() + 5_000);
+  while (Date.now() < exitDeadline && hasTmuxSession()) sleep(100);
+  if (hasTmuxSession()) throw new Error("drill smoke rendered but Pi did not respond to /quit");
+
+  console.log("real-Pi drill-mode smoke passed");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  cleanupLaunchedPi();
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+  if (fixtureHome) rmSync(fixtureHome, { recursive: true, force: true });
+}

--- a/tests/traceline/drill.test.ts
+++ b/tests/traceline/drill.test.ts
@@ -1,0 +1,298 @@
+// Drill mode (design language §9.13): digit grammar, zero-reflow numbering, expanded-row
+// (§9.12 z1) grammar opt-outs, and the full hint-bar → pager keyboard flow against a
+// fake ExtensionUIContext. Comps are the same synthetic duck types the other suites
+// use; the contract suite proves the duck type (including the expanded flag and the
+// blank leading spacer line of a native render) matches the real installed pi.
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+
+import { internals } from "../../extensions/pi-traceline/index.ts";
+import {
+  drillDecorateNativeRow,
+  drillState,
+  drillTracePrefix,
+  enterDrillMode,
+  exitDrillMode,
+  handleDrillTerminalInput,
+  stepDigits,
+  wheelDelta,
+  type DrillHost,
+} from "../../extensions/pi-traceline/drill.ts";
+import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
+
+const { foldedReadLines, isExpandedToolRow, leadingBlank, oneLine, readRun, renderTraceRow, setTracelineChat, statusTone, stripAnsi } = internals;
+
+function toolComp(overrides: Partial<ToolRowLike> = {}): ToolRowLike {
+  const args = overrides.args ?? { path: "/tmp/demo/file.ts", offset: 1, limit: 40 };
+  return {
+    toolName: "read",
+    result: { content: [{ type: "text", text: "x".repeat(1437) }], isError: false },
+    isPartial: false,
+    render: () => [],
+    setExpanded(expanded: boolean) {
+      (this as { expanded?: boolean }).expanded = expanded;
+    },
+    callRendererComponent: { render: () => [`read ${String(args.path)}:1-40`] },
+    ...overrides,
+    args,
+  } as ToolRowLike;
+}
+
+type FakeComponent = { render(width: number): string[]; handleInput?(data: string): void };
+type CustomCall = { component: FakeComponent; overlay: boolean };
+
+function fakeUiContext(calls: CustomCall[], notifications: string[]): ExtensionUIContext {
+  return {
+    custom<T>(
+      factory: (tui: unknown, theme: unknown, kb: unknown, done: (result: T) => void) => unknown,
+      options?: { overlay?: boolean },
+    ): Promise<T> {
+      return new Promise<T>((resolve) => {
+        const component = factory({ terminal: { rows: 16, columns: 80 } }, undefined, undefined, resolve);
+        calls.push({ component: component as FakeComponent, overlay: options?.overlay === true });
+      });
+    },
+    notify(message: string) {
+      notifications.push(message);
+    },
+  } as unknown as ExtensionUIContext;
+}
+
+function makeHost(children: unknown[], calls: CustomCall[] = [], notifications: string[] = []): DrillHost {
+  setTracelineChat({ children });
+  return {
+    ui: fakeUiContext(calls, notifications),
+    theme: () => undefined,
+    chatChildren: () => children,
+    requestRender: () => {},
+    traceLines: (comp, width) => {
+      const run = readRun(comp);
+      return run && run.index === 0 ? foldedReadLines(run.rows, width) : [oneLine(comp, width)];
+    },
+    runRows: (comp) => {
+      const run = readRun(comp);
+      return run && run.index === 0 ? run.rows : undefined;
+    },
+    hiddenByFold: (comp) => (readRun(comp)?.index ?? 0) > 0,
+    statusTone: (comp) => statusTone(comp),
+    mouse: false,
+  };
+}
+
+const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+beforeEach(() => {
+  exitDrillMode();
+  setTracelineChat(undefined);
+});
+afterEach(() => {
+  exitDrillMode();
+  setTracelineChat(undefined);
+});
+
+// --- digit grammar ----------------------------------------------------------------------
+
+test("stepDigits: commits when no longer number could follow, else stays pending", () => {
+  assert.deepEqual(stepDigits("", "5", 37), { digits: "", commit: 5 }); // 50 > 37
+  assert.deepEqual(stepDigits("", "1", 37), { digits: "1" }); // 1, 1x both possible
+  assert.deepEqual(stepDigits("1", "2", 37), { digits: "", commit: 12 });
+  assert.deepEqual(stepDigits("", "1", 9), { digits: "", commit: 1 }); // single-digit block
+});
+
+test("stepDigits: zero and impossible extensions restart or clear the buffer", () => {
+  assert.deepEqual(stepDigits("", "0", 37), { digits: "" });
+  assert.deepEqual(stepDigits("3", "9", 37), { digits: "", commit: 9 }); // 39 invalid → restart at 9
+  assert.deepEqual(stepDigits("1", "8", 200), { digits: "18" }); // 18, 18x both possible
+  assert.deepEqual(stepDigits("1", "8", 120), { digits: "", commit: 18 }); // no 18x fits under 120
+  assert.deepEqual(stepDigits("", "7", 5), { digits: "" }); // no valid reading at all
+});
+
+// --- numbering: zero reflow -------------------------------------------------------------
+
+test("drill numbering re-inks the six-column prefix at identical width", () => {
+  const rows = [toolComp(), toolComp({ args: { path: "/tmp/elsewhere/other.ts" } })];
+  const host = makeHost(rows);
+  const before = renderTraceRow(rows[1]!, 80);
+  enterDrillMode(host);
+  const after = renderTraceRow(rows[1]!, 80);
+
+  assert.equal(after.length, before.length, "numbering must not change a row's line count");
+  const beforeLine = stripAnsi(before[before.length - 1]!);
+  const afterLine = stripAnsi(after[after.length - 1]!);
+  assert.equal(afterLine.length, beforeLine.length, "numbering must not change a row's width");
+  assert.match(afterLine, /^ {2}1 › /, "newest row wears number 1 in the rail cell");
+  assert.equal(afterLine.slice(6), beforeLine.slice(6), "body and suffix untouched beyond the prefix");
+});
+
+test("selection wears accent bold; other numbers are dim; strangers keep the rail", () => {
+  const rows = [toolComp({ args: { path: "/tmp/aaa/a.ts" } }), toolComp({ args: { path: "/tmp/bbb/b.ts" } })];
+  enterDrillMode(makeHost(rows));
+  const selected = drillTracePrefix(undefined, rows[1], "›")!; // rows[1] is newest = number 1 = selected
+  const other = drillTracePrefix(undefined, rows[0], "›")!;
+  assert.ok(selected.includes("\x1b[1m"), "selected number must be bold");
+  assert.ok(!other.includes("\x1b[1m"), "unselected numbers stay dim, not bold");
+  assert.equal(visibleWidth(selected), 6, "drill prefix must hold the rail prefix's six columns");
+  assert.equal(visibleWidth(other), 6);
+  assert.equal(stripAnsi(other), "  2 › ");
+  assert.equal(drillTracePrefix(undefined, toolComp(), "›"), undefined, "rows streamed in after entry stay unnumbered");
+});
+
+test("numbers above 999 keep the rail; outside the mode the prefix is untouched", () => {
+  const rows = [toolComp()];
+  enterDrillMode(makeHost(rows));
+  drillState()!.numbers.set(rows[0], 1000);
+  assert.equal(drillTracePrefix(undefined, rows[0], "›"), undefined);
+  exitDrillMode();
+  assert.equal(drillTracePrefix(undefined, rows[0], "›"), undefined);
+});
+
+test("drillDecorateNativeRow numbers only a genuinely blank leading spacer line", () => {
+  const rows = [toolComp()];
+  enterDrillMode(makeHost(rows));
+  const decorated = drillDecorateNativeRow(undefined, rows[0], ["", "read file", "output"], "›") as string[];
+  assert.equal(stripAnsi(decorated[0]!).trim(), "1 ›", "blank spacer line takes the number cell");
+  assert.deepEqual(decorated.slice(1), ["read file", "output"], "native lines below stay untouched");
+  const untouched = ["not blank", "output"];
+  assert.equal(drillDecorateNativeRow(undefined, rows[0], untouched, "›"), untouched, "non-blank first line passes through");
+  assert.deepEqual(drillDecorateNativeRow(undefined, toolComp(), ["", "x"], "›"), ["", "x"], "strangers pass through unnumbered");
+});
+
+// --- expanded rows (§9.12 z1) opt out of trace-block grammar ----------------------------
+
+test("an expanded read never folds, and a trace block after it starts with a blank", () => {
+  const page1 = toolComp({ args: { path: "/tmp/demo/file.ts", offset: 1, limit: 200 } });
+  const page2 = toolComp({ args: { path: "/tmp/demo/file.ts", offset: 201, limit: 200 } });
+  setTracelineChat({ children: [page1, page2] });
+  assert.ok(readRun(page2), "sanity: adjacent same-file reads fold");
+
+  page2.setExpanded(true);
+  assert.equal(isExpandedToolRow(page2), true);
+  assert.equal(readRun(page2), undefined, "an expanded row must leave the read run");
+  assert.equal(readRun(page1), undefined, "a one-row remainder is no run at all");
+
+  const after = toolComp({ args: { path: "/tmp/demo/zeta.ts" } });
+  setTracelineChat({ children: [page1, page2, after] });
+  assert.equal(leadingBlank(after), true, "a trace block after an expanded row starts with its own blank");
+  page2.setExpanded(false);
+  assert.equal(leadingBlank(after), false, "collapsing back restores the tight group");
+});
+
+// --- the mode end to end -----------------------------------------------------------------
+
+test("drill flow: enter, digit auto-commit to pager, h/l switch, esc unwinds", async () => {
+  // one directory per row: sibling reads in one dir would fold into a single target (§9.9)
+  const rows = Array.from({ length: 12 }, (_, i) => toolComp({ args: { path: `/tmp/d${i}/f${i}.ts` } }));
+  const calls: CustomCall[] = [];
+  const notifications: string[] = [];
+  const host = makeHost(rows, calls, notifications);
+
+  enterDrillMode(host);
+  assert.ok(drillState(), "mode state installed");
+  assert.equal(calls.length, 1, "hint bar replaces the editor");
+  assert.equal(calls[0]!.overlay, false);
+  enterDrillMode(host);
+  assert.equal(calls.length, 1, "re-entry is a no-op while active");
+
+  const hint = calls[0]!.component;
+  const hintLines = hint.render(80);
+  assert.equal(hintLines.length, 2, "hint bar is exactly two lines");
+  assert.match(stripAnsi(hintLines[0]!), /\[Traceline\] drill · row 1 of 12/);
+
+  hint.handleInput!("k"); // older
+  assert.equal(drillState()!.selected, 1);
+  hint.handleInput!("j"); // newer
+  assert.equal(drillState()!.selected, 0);
+
+  hint.handleInput!("1"); // 1 pending: 10-12 still possible
+  assert.equal(drillState()!.digits, "1");
+  assert.equal(calls.length, 1, "pending digit must not open the pager");
+  hint.handleInput!("0"); // 10 commits: 100 > 12
+  assert.equal(calls.length, 2, "committed number opens the pager");
+  assert.equal(calls[1]!.overlay, true, "pager rides the overlay path");
+  assert.equal(drillState()!.selected, 9);
+
+  const pager = calls[1]!.component;
+  const pagerLines = pager.render(80);
+  assert.equal(pagerLines.length, 16, "pager fills the full terminal height");
+  assert.match(stripAnsi(pagerLines[0]!), /\[Traceline\] peek · row 10 of 12/);
+  const pagerText = pagerLines.map((line) => stripAnsi(line)).join("\n");
+  assert.match(pagerText, /read \/tmp\/d2\/f2\.ts:1-40/, "invocation section shows the call renderer's line");
+  assert.match(pagerText, /result · success · 1\.4k ch/, "result label carries status and size");
+  assert.match(pagerText, /xxxx/, "result text is present");
+
+  pager.handleInput!("h"); // older without closing
+  assert.match(stripAnsi(pager.render(80)[0]!), /row 11 of 12/);
+  pager.handleInput!("l");
+  assert.match(stripAnsi(pager.render(80)[0]!), /row 10 of 12/);
+
+  pager.handleInput!("\x1b"); // esc closes the pager only
+  await settle();
+  assert.ok(drillState(), "mode survives closing the pager");
+  assert.equal(drillState()!.pager, undefined);
+
+  hint.handleInput!("\x1b"); // esc exits the mode
+  await settle();
+  assert.equal(drillState(), undefined, "esc tears the mode down");
+  assert.deepEqual(notifications, []);
+});
+
+test("drill refuses an empty transcript with a notify instead of a dead mode", () => {
+  const calls: CustomCall[] = [];
+  const notifications: string[] = [];
+  enterDrillMode(makeHost([], calls, notifications));
+  assert.equal(drillState(), undefined);
+  assert.equal(calls.length, 0);
+  assert.equal(notifications.length, 1);
+});
+
+test("p toggles the selected row's expansion in place", () => {
+  const rows = [toolComp()];
+  const calls: CustomCall[] = [];
+  enterDrillMode(makeHost(rows, calls));
+  const hint = calls[0]!.component;
+  hint.handleInput!("p");
+  assert.equal(rows[0]!.expanded, true, "pin writes pi's own expanded flag");
+  hint.handleInput!("p");
+  assert.equal(rows[0]!.expanded, false);
+});
+
+test("a folded read run is one numbered target", () => {
+  const page1 = toolComp({ args: { path: "/tmp/demo/file.ts", offset: 1, limit: 200 } });
+  const page2 = toolComp({ args: { path: "/tmp/demo/file.ts", offset: 201, limit: 200 } });
+  const other = toolComp({ args: { path: "/tmp/other-dir/other.ts" } });
+  enterDrillMode(makeHost([page1, page2, other]));
+  const st = drillState()!;
+  assert.equal(st.rows.length, 2, "the fold collapses to one target");
+  assert.equal(st.rows[0], other, "newest row is number 1");
+  assert.equal(st.rows[1], page1, "the fold's carrier (its first row) is the target");
+  exitDrillMode();
+
+  // §9.9's sibling-file dir fold is also one target, carried by its first row.
+  const sibling = toolComp({ args: { path: "/tmp/demo/sibling.ts" } });
+  enterDrillMode(makeHost([page1, page2, sibling]));
+  const dirFold = drillState()!;
+  assert.equal(dirFold.rows.length, 1, "a sibling dir fold is one target");
+  assert.equal(dirFold.rows[0], page1, "the dir fold's carrier is its first row");
+});
+
+// --- mouse -------------------------------------------------------------------------------
+
+test("wheelDelta reads SGR wheel presses and ignores releases and buttons", () => {
+  assert.equal(wheelDelta("\x1b[<64;10;5M"), -1); // wheel up
+  assert.equal(wheelDelta("\x1b[<65;10;5M\x1b[<65;10;5M"), 2); // two wheel downs
+  assert.equal(wheelDelta("\x1b[<0;10;5M\x1b[<0;10;5m"), 0); // click press+release
+  assert.equal(wheelDelta("\x1b[<68;10;5M"), -1); // shift+wheel up still scrolls
+});
+
+test("terminal-input hook consumes all mouse reports while active, none outside", () => {
+  assert.equal(handleDrillTerminalInput("\x1b[<64;1;1M"), undefined, "inactive: nothing consumed");
+  const rows = [toolComp({ args: { path: "/tmp/aaa/a.ts" } }), toolComp({ args: { path: "/tmp/bbb/b.ts" } })];
+  enterDrillMode(makeHost(rows));
+  assert.equal(drillState()!.selected, 0);
+  assert.deepEqual(handleDrillTerminalInput("\x1b[<64;1;1M"), { consume: true });
+  assert.equal(drillState()!.selected, 1, "wheel up walks to the older row");
+  assert.deepEqual(handleDrillTerminalInput("\x1b[<0;3;3M"), { consume: true }, "clicks are swallowed, not leaked");
+  assert.equal(handleDrillTerminalInput("plain keys"), undefined, "keyboard input passes through");
+});

--- a/tests/traceline/drill.test.ts
+++ b/tests/traceline/drill.test.ts
@@ -15,11 +15,10 @@ import {
   drillTracePrefix,
   enterDrillMode,
   exitDrillMode,
-  handleDrillTerminalInput,
   stepDigits,
-  wheelDelta,
   type DrillHost,
 } from "../../extensions/pi-traceline/drill.ts";
+import { handleDrillTerminalInput, isForeignChord, wheelDelta } from "../../extensions/pi-traceline/drill-input.ts";
 import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
 
 const { foldedReadLines, isExpandedToolRow, leadingBlank, oneLine, readRun, renderTraceRow, setTracelineChat, statusTone, stripAnsi } = internals;
@@ -295,4 +294,40 @@ test("terminal-input hook consumes all mouse reports while active, none outside"
   assert.equal(drillState()!.selected, 1, "wheel up walks to the older row");
   assert.deepEqual(handleDrillTerminalInput("\x1b[<0;3;3M"), { consume: true }, "clicks are swallowed, not leaked");
   assert.equal(handleDrillTerminalInput("plain keys"), undefined, "keyboard input passes through");
+});
+
+// --- foreign chords (§9.13: the mode never silently eats an app-level keystroke) --------
+
+test("isForeignChord: modifier chords only, presses only", () => {
+  assert.equal(isForeignChord("\x1b[1;3A"), true, "alt+up is foreign");
+  assert.equal(isForeignChord("\x1b\r"), true, "alt+enter is foreign");
+  assert.equal(isForeignChord("\x03"), true, "ctrl+c is foreign — abort must not die in the mode");
+  assert.equal(isForeignChord("\x1bt"), true, "the entry chord is foreign too: it re-freezes via its shortcut");
+  assert.equal(isForeignChord("\x1b[1;3:3A"), false, "a key release never exits");
+  for (const own of ["\x1b", "\r", "k", "j", "p", "5", "G", " ", "\x7f", "\x1b[A", "\x1b[5~"]) {
+    assert.equal(isForeignChord(own), false, `mode-owned or plain key treated as foreign: ${JSON.stringify(own)}`);
+  }
+});
+
+test("a foreign chord exits the mode synchronously and is not consumed", () => {
+  const rows = [toolComp({ args: { path: "/tmp/aaa/a.ts" } }), toolComp({ args: { path: "/tmp/bbb/b.ts" } })];
+  enterDrillMode(makeHost(rows));
+  assert.equal(handleDrillTerminalInput("5"), undefined);
+  assert.ok(drillState(), "the mode's own keys must not exit");
+  assert.equal(handleDrillTerminalInput("\x1b"), undefined);
+  assert.ok(drillState(), "esc belongs to the hint bar, not the hook");
+  assert.equal(handleDrillTerminalInput("\x1b[1;3A"), undefined, "the chord must flow on to the restored editor");
+  // Synchronous on purpose: pi dispatches this same keystroke to the focused component
+  // right after the listener returns, so the editor must already be restored.
+  assert.equal(drillState(), undefined, "exit must complete before the hook returns");
+});
+
+test("a foreign chord exits from the pager too", () => {
+  const rows = Array.from({ length: 3 }, (_, i) => toolComp({ args: { path: `/tmp/d${i}/f${i}.ts` } }));
+  const calls: CustomCall[] = [];
+  enterDrillMode(makeHost(rows, calls));
+  calls[0]!.component.handleInput!("3");
+  assert.ok(drillState()!.pager, "sanity: a committed digit opened the pager");
+  assert.equal(handleDrillTerminalInput("\x1b[1;3A"), undefined);
+  assert.equal(drillState(), undefined, "the chord ends the whole mode, pager included");
 });


### PR DESCRIPTION
## Release

Ship Traceline drill mode as `pine-of-glass` v0.8.0.

## What users get

- `Alt+T` (or `/drill`) numbers visible tool rows in place without moving or reflowing the transcript.
- A number opens that call in a full-screen pager with the complete invocation and result; `j`/`k` scroll, `h`/`l` move between rows, and `esc` unwinds exactly.
- `p` expands or collapses the selected native Pi tool row; Pi's existing `Ctrl+O` expansion now composes correctly with compact Traceline rows.
- Mouse wheel navigation is scoped to drill mode and always cleaned up on exit; `drillMouse: false` opts out.
- Unowned modifier chords now exit drill mode without being consumed. A single `Option+Up` therefore restores the editor and opens queue-edit mode in extensions such as `pi-queue-steer`; `Ctrl+C` abort also keeps working.
- macOS setup is documented: Alt-letter shortcuts require Option-as-Alt. Ghostty supports `macos-option-as-alt = left`; cmux needs that in its Terminal settings or managed Ghostty config, then `cmux reload-config`. `/drill` remains the fallback.

## Release hygiene

- Bumps `package.json` from 0.7.0 to 0.8.0.
- Moves drill notes out of the already-published 0.7.0 changelog section into a dated 0.8.0 section.
- Adds `test:smoke:drill` to the aggregate real-Pi smoke suite.

## Verification

- `npm run check`: green, 233 tests.
- `npm run test:smoke`: green (Traceline resume, drill flow-through, full startup/reload suite).
- `npm pack --dry-run`: 54 files; `drill.ts`, `drill-input.ts`, and `drill-pager.ts` all present.
- `git diff --check`: green.
- npm preflight: authenticated as `tmustier`; current published/latest version is 0.7.0.
- Live user path already verified in cmux: with left Option-as-Alt active, `Alt+T` enters drill mode; while drill is open, one `Option+Up` exits and opens `pi-queue-steer` edit mode.

Closes #46 through the released mainline fix.
