### PR TITLE
fix(traceline): make Ctrl+T override expanded tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Fix `pi-traceline` so `Ctrl+T` remains decisive after `Ctrl+O` expands every
+  tool row. Traceline now collapses Pi's global tool expansion before passing
+  the same keypress to Pi's native reasoning toggle, so returning to hidden
+  reasoning restores the one-line trace instead of leaving rows pinned open.
+
 ## 0.8.0 (2026-07-17)
 
 `pi-traceline` adds drill mode: inspect one tool call without expanding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.1 (2026-07-18)
 
 - Fix `pi-traceline` so `Ctrl+T` remains decisive after `Ctrl+O` expands every
   tool row. Traceline now collapses Pi's global tool expansion before passing

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -505,6 +505,11 @@ borrows from:
 - z2, native: Ctrl+T shows reasoning and native tool rows, untouched by
   traceline
 
+Ctrl+T is decisive over z1: when Pi's global Ctrl+O expansion is active,
+Traceline first collapses that expansion, then lets Pi's native reasoning toggle run.
+This guarantees that the next hidden-reasoning view is z0 rather than remaining pinned
+at z1. Ctrl+O can expand the rows again whenever z1 is wanted.
+
 An expanded row opts out of trace-block grammar: it breaks the rail block
 (§9.1), leaves its neighbours' fact and truncation columns (§9.7, §9.8), and
 never participates in a read fold (§9.9); a trace block that follows one starts

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -52,6 +52,8 @@ Traceline follows Pi's reasoning visibility setting. The full view reuses Pi's o
 - press `Ctrl+T` again to hide reasoning and show one line per tool call
 - press `Ctrl+O` (Pi's tool expansion) to expand or collapse every tool row in place while reasoning stays hidden
 
+`Ctrl+T` remains decisive after `Ctrl+O`: if every tool row is expanded, Traceline collapses that expansion before Pi toggles reasoning. The next hidden-reasoning view therefore returns to the trace instead of staying expanded. Press `Ctrl+O` again whenever you want the expanded tool view.
+
 The tool view reads its state from the live assistant row. It cannot get out of sync with the reasoning view. Traceline hides Pi's `Thinking blocks: hidden/visible` caption because the changing tool rows already show the state.
 
 Outside drill mode, Traceline does not enable mouse reporting or change terminal scrolling.

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -1,12 +1,5 @@
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
-import {
-  isKeyRelease,
-  isKeyRepeat,
-  matchesKey,
-  truncateToWidth,
-  visibleWidth,
-  type KeyId,
-} from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, type KeyId } from "@earendil-works/pi-tui";
 import { rawIndexAtVisibleIndex, rawIndexBeforeVisibleIndex, stripAnsi } from "../_lib/ansi.ts";
 import { booleanValue, positiveNumberValue, isJsonObject, stringValue } from "../_lib/boundary.ts";
 import { captureTui } from "../_lib/capture.ts";
@@ -59,6 +52,7 @@ import {
   type DiffStats,
 } from "./write-diff.ts";
 import { dedupeThinkingLabels } from "./thinking-preview.ts";
+import { handleThinkingToggleTerminalInput } from "./thinking-toggle.ts";
 
 /**
  * pi-traceline — collapse each tool call to one scannable trace line so the full arc of
@@ -1727,7 +1721,7 @@ export default function piTraceline(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     // Capture the real TUI (passed synchronously to the widget factory), then patch only
     // extension-visible seams: requestRender for delayed tool-row patching, and raw
-    // terminal input for Ctrl+T key-release/repeat handling.
+    // terminal input for Ctrl+T expansion coordination plus release/repeat handling.
     g.__tracelineGetTheme = () => {
       try {
         return (ctx.ui as ExtensionUiWithTheme).theme;
@@ -1757,16 +1751,14 @@ export default function piTraceline(pi: ExtensionAPI) {
     });
 
     // Make reload/session-start idempotent: do not stack raw-input listeners.
-    // Ctrl+T itself remains Pi-native: Pi toggles reasoning visibility; this extension
-    // only changes how tool rows render while reasoning is hidden.
+    // Pi still owns Ctrl+T's reasoning toggle. Traceline only clears a conflicting
+    // Ctrl+O expansion first, then lets the same keypress continue to Pi (§9.12).
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = ctx.ui.onTerminalInput((data) => {
       // Drill mode owns mouse reports; a foreign chord exits it un-consumed (§9.13).
       const drill = handleDrillTerminalInput(data);
       if (drill) return drill;
-      if (!matchesKey(data, "ctrl+t")) return undefined;
-      if (isKeyRelease(data) || isKeyRepeat(data)) return { consume: true };
-      return undefined;
+      return handleThinkingToggleTerminalInput(data, ctx.ui);
     });
   });
 

--- a/extensions/pi-traceline/thinking-toggle.ts
+++ b/extensions/pi-traceline/thinking-toggle.ts
@@ -1,0 +1,18 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { isKeyRelease, isKeyRepeat, matchesKey } from "@earendil-works/pi-tui";
+
+// Ctrl+O's global expansion writes `expanded = true` onto every tool row. Without
+// clearing that state, a later Ctrl+T can hide reasoning while every row stays pinned
+// to z1's native renderer, so the trace appears not to toggle. Collapse z1 before the
+// key reaches Pi's native reasoning handler: Ctrl+T remains decisive, while Ctrl+O can
+// opt back into z1 afterwards. Release/repeat events are consumed as before so one
+// physical press produces one transition under the Kitty keyboard protocol.
+export function handleThinkingToggleTerminalInput(
+  data: string,
+  ui: Pick<ExtensionUIContext, "getToolsExpanded" | "setToolsExpanded">,
+): { consume: true } | undefined {
+  if (!matchesKey(data, "ctrl+t")) return undefined;
+  if (isKeyRelease(data) || isKeyRepeat(data)) return { consume: true };
+  if (ui.getToolsExpanded()) ui.setToolsExpanded(false);
+  return undefined;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-of-glass",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Observability extensions for the Pi coding agent",
   "license": "MIT",
   "type": "module",

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,7 +7,7 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 1258,
       "extensions/pi-contextimate/index.ts": 1959,
-      "extensions/pi-traceline/index.ts": 1779,
+      "extensions/pi-traceline/index.ts": 1771,
       "tests/cachemire/economics-and-render.test.ts": 352,
       "tests/contract/pi-internals.test.ts": 432,
       "tests/traceline/one-line.test.ts": 775

--- a/tests/smoke/traceline-drill-smoke.mjs
+++ b/tests/smoke/traceline-drill-smoke.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
-// Resume a real Pi session with two completed read rows, then walk drill mode end to
-// end (design language §9.13): Alt+T numbers the rows with zero reflow and swaps the
-// editor (and its draft) for the hint bar, a committed digit opens the peek pager on
-// the full result, esc unwinds to the numbered transcript and then back to the editor
-// with the draft intact, and a foreign chord (alt+up) exits the mode un-consumed so
-// the same press reaches the restored editor. Every subprocess call is bounded and
-// the uniquely launched Pi is killed on timeout.
+// Resume a real Pi session with two completed read rows, prove Ctrl+T returns from a
+// Ctrl+O-expanded view to the trace (design language §9.12), then walk drill mode end
+// to end (§9.13): Alt+T numbers the rows with zero reflow and swaps the editor (and
+// its draft) for the hint bar, a committed digit opens the peek pager on the full
+// result, esc unwinds to the numbered transcript and then back to the editor with the
+// draft intact, and a foreign chord (alt+up) exits the mode un-consumed so the same
+// press reaches the restored editor. Every subprocess call is bounded and the
+// uniquely launched Pi is killed on timeout.
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -71,6 +72,18 @@ function waitForPane(predicate) {
     sleep(200);
   }
   return pane;
+}
+
+function waitForHiddenThinking(settingsPath, expected) {
+  while (Date.now() < hardDeadline && hasTmuxSession()) {
+    try {
+      if (JSON.parse(readFileSync(settingsPath, "utf8")).hideThinkingBlock === expected) return true;
+    } catch {
+      // The settings write may be in flight; keep polling within the smoke deadline.
+    }
+    sleep(100);
+  }
+  return false;
 }
 
 function sessionEntries(cwd) {
@@ -197,7 +210,8 @@ fixtureHome = mkdtempSync(join(tmpdir(), "pog-drill-home-"));
 fixtureDir = mkdtempSync(join(tmpdir(), `${tmuxSession}-`));
 const agentDir = join(fixtureHome, ".pi", "agent");
 mkdirSync(agentDir, { recursive: true });
-writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ hideThinkingBlock: true }, null, 2));
+const settingsPath = join(agentDir, "settings.json");
+writeFileSync(settingsPath, JSON.stringify({ hideThinkingBlock: true }, null, 2));
 writeFileSync(join(agentDir, "trust.json"), JSON.stringify({ [fixtureDir]: true, [repoRoot]: true }, null, 2));
 writeFileSync(join(fixtureDir, "AGENTS.md"), "# Drill smoke\nFixture only.\n");
 const sessionFile = join(fixtureDir, "session.jsonl");
@@ -232,7 +246,25 @@ try {
   const beforeRows = traceRowsOf(resumed).map((line) => line.trimEnd());
   if (beforeRows.length !== 2) throw new Error(`expected two trace rows, saw:\n${resumed}`);
 
-  // 2. A draft, then Alt+T: hint bar replaces the editor, numbers land at equal width.
+  // 2. Ctrl+O opens z1. Ctrl+T still owns the next transition: it clears z1 before
+  // Pi shows reasoning, and a second Ctrl+T therefore returns to z0 trace rows.
+  sendKeys("C-o");
+  const expanded = waitForPane((pane) => pane.includes("DRILL_RESULT_ALPHA") && !traceRowsOf(pane).some((line) => line.includes("▏")));
+  if (!expanded.includes("DRILL_RESULT_ALPHA")) throw new Error(`Ctrl+O did not expand the native tool rows\n${expanded}`);
+  sendKeys("C-t");
+  if (!waitForHiddenThinking(settingsPath, false)) throw new Error("first Ctrl+T did not reach Pi's native reasoning toggle");
+  sendKeys("C-t");
+  if (!waitForHiddenThinking(settingsPath, true)) throw new Error("second Ctrl+T did not return to hidden reasoning");
+  const retraced = waitForPane((pane) => {
+    const rows = traceRowsOf(pane);
+    return rows.length === 2 && rows.every((line) => line.includes("▏"));
+  });
+  const retracedRows = traceRowsOf(retraced).map((line) => line.trimEnd());
+  if (retracedRows.join("\n") !== beforeRows.join("\n")) {
+    throw new Error(`Ctrl+T left Ctrl+O rows pinned open instead of restoring the trace\n${retraced}`);
+  }
+
+  // 3. A draft, then Alt+T: hint bar replaces the editor, numbers land at equal width.
   sendKeys(draft);
   const withDraft = waitForPane((pane) => pane.includes(draft));
   if (!withDraft.includes(draft)) throw new Error(`draft never appeared in the editor\n${withDraft}`);
@@ -251,14 +283,14 @@ try {
     throw new Error(`gutter numbers wrong (1 must be the most recent row)\n${numberedRows.join("\n")}`);
   }
 
-  // 3. Digit commit opens the pager on the older row's complete result.
+  // 4. Digit commit opens the pager on the older row's complete result.
   sendKeys("2");
   const peeking = waitForPane((pane) => pane.includes("peek · row 2 of 2"));
   if (!peeking.includes("peek · row 2 of 2")) throw new Error(`pager did not open on row 2\n${peeking}`);
   if (!peeking.includes("DRILL_RESULT_ALPHA")) throw new Error(`pager missing the full result text\n${peeking}`);
   if (!peeking.includes("invocation")) throw new Error(`pager missing the invocation section\n${peeking}`);
 
-  // 4. esc unwinds: pager → numbered transcript → editor with the draft intact.
+  // 5. esc unwinds: pager → numbered transcript → editor with the draft intact.
   sendKeys("Escape");
   const backToDrill = waitForPane((pane) => pane.includes("drill · row") && !pane.includes("peek · row"));
   if (!backToDrill.includes("drill · row")) throw new Error(`esc did not return to drill mode\n${backToDrill}`);
@@ -270,7 +302,7 @@ try {
     throw new Error(`exit did not restore the plain rail rows\n${restoredRows.join("\n")}`);
   }
 
-  // 5. A foreign chord (§9.13): alt+up exits the mode un-consumed and lands in the
+  // 6. A foreign chord (§9.13): alt+up exits the mode un-consumed and lands in the
   // restored editor in the same press — stock pi answers with its native dequeue status.
   sendKeys("M-t");
   const redrilling = waitForPane((pane) => pane.includes("drill · row 1 of 2"));

--- a/tests/traceline/thinking-toggle.test.ts
+++ b/tests/traceline/thinking-toggle.test.ts
@@ -1,0 +1,45 @@
+// Ctrl+T is decisive over Ctrl+O's global z1 expansion (design language §9.12):
+// Traceline collapses expanded tool rows before letting Pi's native reasoning toggle
+// handle the same press. Kitty release/repeat events remain consumed so one physical
+// press produces one transition.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { handleThinkingToggleTerminalInput } from "../../extensions/pi-traceline/thinking-toggle.ts";
+
+function toolsUi(expanded: boolean) {
+  const writes: boolean[] = [];
+  return {
+    writes,
+    ui: {
+      getToolsExpanded: () => expanded,
+      setToolsExpanded: (next: boolean) => {
+        expanded = next;
+        writes.push(next);
+      },
+    },
+  };
+}
+
+test("Ctrl+T collapses Ctrl+O expansion and continues to Pi's native toggle", () => {
+  const { ui, writes } = toolsUi(true);
+
+  assert.equal(handleThinkingToggleTerminalInput("\x14", ui), undefined, "press must continue to Pi");
+  assert.deepEqual(writes, [false], "expanded z1 rows must collapse before Pi toggles reasoning");
+});
+
+test("Ctrl+T leaves an already-collapsed tool view alone", () => {
+  const { ui, writes } = toolsUi(false);
+
+  assert.equal(handleThinkingToggleTerminalInput("\x14", ui), undefined);
+  assert.deepEqual(writes, [], "avoid a redundant global expansion write and render");
+});
+
+test("unrelated keys pass through; Kitty repeats and releases are consumed", () => {
+  const { ui, writes } = toolsUi(true);
+
+  assert.equal(handleThinkingToggleTerminalInput("x", ui), undefined);
+  assert.deepEqual(handleThinkingToggleTerminalInput("\x1b[116;5:2u", ui), { consume: true });
+  assert.deepEqual(handleThinkingToggleTerminalInput("\x1b[116;5:3u", ui), { consume: true });
+  assert.deepEqual(writes, [], "only a fresh Ctrl+T press may change expansion state");
+});


### PR DESCRIPTION
## Summary

- collapse Pi’s global Ctrl+O tool expansion before passing Ctrl+T to Pi’s reasoning toggle
- preserve Kitty repeat/release handling
- document the zoom-ladder precedence and add regression coverage
- release as pine-of-glass 0.8.1

## Verification

- `npm run check` (236 tests)
- `npm run test:smoke`
- `npm pack --dry-run`