### PR TITLE
fix(style): measure middleTruncate cuts in columns, not characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.2 (unreleased)
+
+- Fix a crash when a truncated row contained a wide grapheme near the cut.
+  `middleTruncate` (shared by Traceline's thinking previews and every fitted
+  family row) counted characters against a terminal-column budget, so a 2-column
+  grapheme such as an emoji could push the rendered line one column past the
+  terminal width and Pi's render guard exited the session. Cuts are now measured
+  in columns and a grapheme straddling a cut is dropped from that side, leaving
+  the row one column short rather than one over (design language §9.8).
+
 ## 0.8.1 (2026-07-18)
 
 - Fix `pi-traceline` so `Ctrl+T` remains decisive after `Ctrl+O` expands every

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -384,9 +384,12 @@ The right-aligned suffix carries facts in columns that align down the block:
 Truncation columns are deterministic and block-scoped. Every row in a block
 shares one body budget: the width left after the block's widest fact suffix. A
 truncated row cuts at exact columns: the head fills its share, a dim `…`, then a
-tail of exactly the reserved width, ending flush where the suffix column begins.
-Rows that fit their budget simply end early, like prose. A mid-token cut beside a
-dim ellipsis is legible; a wandering ellipsis column is not.
+tail of the reserved width, ending flush where the suffix column begins. Cuts are
+measured in terminal columns, never characters: a wide grapheme (emoji, CJK)
+straddling a cut is dropped from that side, leaving the row one column short
+rather than one over, since an over-wide row is a hard render error. Rows that
+fit their budget simply end early, like prose. A mid-token cut beside a dim
+ellipsis is legible; a wandering ellipsis column is not.
 
 ### 9.9 Folded reads
 

--- a/extensions/_lib/style.ts
+++ b/extensions/_lib/style.ts
@@ -186,31 +186,71 @@ function activeSgrAt(line: string, rawIndex: number): string {
   return [...state.values()].join("");
 }
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/**
+ * Cut points for middleTruncate as code-unit indices into the *stripped* line,
+ * measured in terminal columns. Counting raw characters instead under-charges wide
+ * graphemes (emoji, CJK): the TUI measures the rendered line with visibleWidth() and
+ * hard-crashes on any overflow, so a 1-column miscount is fatal. A grapheme
+ * straddling a cut is dropped from that side — the result may be one column short,
+ * never one over.
+ */
+function columnCuts(vis: string, headCols: number, tailCols: number): { headEnd: number; tailStart: number } {
+  const segments = [...graphemeSegmenter.segment(vis)].map((s) => ({
+    index: s.index,
+    length: s.segment.length,
+    width: visibleWidth(s.segment),
+  }));
+  const totalCols = segments.reduce((acc, s) => acc + s.width, 0);
+
+  let headEnd = 0;
+  let cols = 0;
+  for (const s of segments) {
+    if (cols + s.width > headCols) break;
+    cols += s.width;
+    headEnd = s.index + s.length;
+  }
+
+  const tailStartCol = totalCols - tailCols;
+  let tailStart = vis.length;
+  cols = 0;
+  for (const s of segments) {
+    if (cols >= tailStartCol) {
+      tailStart = s.index;
+      break;
+    }
+    cols += s.width;
+  }
+
+  return { headEnd, tailStart };
+}
+
 export function middleTruncate(line: string, width: number, theme?: Theme): string {
   const maxWidth = Math.max(1, width);
   if (visibleWidth(line) <= maxWidth) return line;
 
   const vis = stripAnsi(line);
-  const visLen = vis.length;
   const ellipsisWidth = visibleWidth(ELLIPSIS);
   const budget = Math.max(1, maxWidth - ellipsisWidth); // reserve columns for the ellipsis
 
   const maxTail = Math.min(budget - MIN_HEAD_COLS, Math.max(12, Math.floor(budget * TAIL_RATIO)));
   if (maxTail < 1) return truncateToWidth(line, maxWidth, ELLIPSIS);
 
-  // The cut is a column (design language §9.8): the tail is exactly `maxTail` wide and
-  // the head exactly fills the rest, so every line truncated to the same budget cuts at
-  // identical columns and fills the budget exactly. No content-dependent snapping — a
-  // mid-token cut beside a dim ellipsis is legible; a wandering ellipsis column is not.
-  const tailStart = visLen - maxTail;
+  // The cut is a column (design language §9.8): the tail is at most `maxTail` columns
+  // wide and the head fills the rest, so every line truncated to the same budget cuts
+  // at identical columns and fills the budget exactly (one column short when a wide
+  // grapheme straddles a cut). No content-dependent snapping — a mid-token cut beside
+  // a dim ellipsis is legible; a wandering ellipsis column is not.
+  const headCols = budget - maxTail;
+  const cuts = columnCuts(vis, headCols, maxTail);
   const dimEllipsis = ink(theme, "dim", ELLIPSIS);
-  const tailRawStart = rawIndexAtVisibleIndex(line, tailStart);
+  const tailRawStart = rawIndexAtVisibleIndex(line, cuts.tailStart);
   const tailRaw = `${activeSgrAt(line, tailRawStart)}${line.slice(tailRawStart)}`;
 
-  const headEnd = budget - maxTail;
-  if (headEnd <= 0) return `${dimEllipsis}${tailRaw}`;
+  if (headCols <= 0) return `${dimEllipsis}${tailRaw}`;
 
-  const headRaw = line.slice(0, rawIndexAtVisibleIndex(line, headEnd));
+  const headRaw = line.slice(0, rawIndexAtVisibleIndex(line, cuts.headEnd));
   return `${headRaw}${RESET}${dimEllipsis}${tailRaw}`;
 }
 

--- a/tests/lib/style.test.ts
+++ b/tests/lib/style.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { GLYPH, SCALE, SEP, ink, middleTruncate, panelHeader, panelPips, sizeTone, SIZE_THRESHOLDS } from "../../extensions/_lib/style.ts";
 
 // A recording theme: proves ink() routes through Theme.fg with the right role.
@@ -64,6 +65,33 @@ test("middleTruncate replays active ink across the cut (design language §5)", (
   const reset = middleTruncate(`\x1b[1mB\x1b[0m${"b".repeat(120)}`, 40);
   const resetCut = reset.indexOf("…");
   assert.ok(!reset.slice(resetCut).includes("\x1b[1m"), `no stale bold after a reset: ${JSON.stringify(reset)}`);
+});
+
+test("middleTruncate never overflows the budget when wide graphemes sit at a cut", () => {
+  // Crash regression: the budget is terminal columns, but the cut used to count raw
+  // characters. A 2-column grapheme inside the tail made the "fitted" line one column
+  // wider than the terminal, and pi's render guard killed the session.
+  // Use BMP wide characters (\u2705, CJK): 1 UTF-16 code unit but 2 columns. Astral
+  // emoji are 2 code units for 2 columns, so they cannot expose a char/column mix-up.
+  const wide = "\u2705";
+  const head = "h".repeat(80);
+  const tail = `${"t".repeat(40)} ${wide} tail-end`;
+  const out = middleTruncate(`\x1b[38;5;245m${head} middle ${tail}\x1b[39m`, 100);
+  assert.ok(visibleWidth(out) <= 100, `overflowed: ${visibleWidth(out)} > 100`);
+  assert.ok(out.includes("tail-end"), `tail lost its end: ${JSON.stringify(out)}`);
+  assert.ok(out.includes("\u2026"), "ellipsis preserved");
+
+  // Wide grapheme straddling the head cut: dropped from the head, never half-kept.
+  const headWide = middleTruncate(`${"a".repeat(30)}\u4E2D${"b".repeat(120)}`, 60);
+  assert.ok(visibleWidth(headWide) <= 60, `head overflowed: ${visibleWidth(headWide)} > 60`);
+});
+
+test("middleTruncate fits the exact crashing thinking preview (159 cols in a 158 terminal)", () => {
+  // The pi-traceline Thinking preview that crashed: 158 chars but 159 columns because
+  // the tail carried an emoji.
+  const preview = `Thinking: The TTL docs issue - the CLI help says 30 days but the docs say 7. Let me just compile my findings now. The key items: Confirmed fixed in 0.1.7: 1. \u2705 API`;
+  const out = middleTruncate(` ${preview}`, 158);
+  assert.ok(visibleWidth(out) <= 158, `overflowed: ${visibleWidth(out)} > 158`);
 });
 
 test("sizeTone: dim below warning, warning at 10k ch, error at 50k ch", () => {


### PR DESCRIPTION
## The crash

Pi exited with `uncaughtException: Rendered line 291 exceeds terminal width (159 > 158)`. The offending line was a traceline `Thinking: …` preview whose tail ended in `· 1. ✅ API`.

## Root cause

`middleTruncate` (`extensions/_lib/style.ts`) computed its budget in terminal columns via `visibleWidth()`, but cut the string by character count (`stripAnsi(line).length` + `rawIndexAtVisibleIndex`, which counts UTF-16 units). A BMP wide grapheme in the kept text (1 char, 2 columns) made the "fitted" line one column too wide, and pi's render guard throws on over-wide lines, killing the session.

## Fix

Cuts now walk grapheme segments with their column widths: the head takes at most its column share, the tail at most `maxTail` columns, and a grapheme straddling a cut is dropped from that side. A row may end one column short, never one over (design language §9.8 updated to match).

## Tests

- New regression tests in `tests/lib/style.test.ts`: BMP wide grapheme (✅, CJK) at the tail and head cuts, plus the exact crashing preview shape. Both fail on the old implementation, pass on the new.
- `npm run check` green: 238 tests.
