### PR TITLE
Fix Cachemire post-compaction cache reuse percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.4 (2026-07-23)
 
 - **Cachemire: use the last pre-compaction prompt for cache-reuse shares.** The
   post-compaction notice now reports the provider cache read as a share of the last

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **Cachemire: use the last pre-compaction prompt for cache-reuse shares.** The
+  post-compaction notice now reports the provider cache read as a share of the last
+  normal agent prompt before compaction, rather than dividing the new prompt's uncached
+  count by the new prompt total. It names that earlier cache lineage explicitly and
+  keeps the new prompt's uncached count separate: `reused 17.9k of the last
+  pre-compaction 173.9k prompt (10%) · processed 21.2k uncached`. Fixes #51.
+
 ## 0.8.3 (2026-07-22)
 
 - **Cachemire: isolate interactive-session state.** Nested headless Pi

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -179,11 +179,15 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
 - tense: in-flight statements are progressive with `~`
   (`cache breaking · re-writing ~138.2k`); resolved statements are past tense with
   exacts (`cache broke · re-wrote 138.2k`)
-- a resolved post-compaction notice shows both provider-exact sides:
-  `cache after compaction · preserved 34.9k of the prior 72.5k prefix · re-wrote
-  38.7k (52% of prompt)`. `preserved` means provider-reported cache reads from the
-  unchanged prompt prefix, not the number of conversation tokens the compactor retained.
-  If the model also changed, withhold the prior count rather than compare tokenizers
+- a resolved post-compaction notice compares provider-exact cache reads with the last
+  normal agent prompt before compaction: `cache after compaction · reused 34.9k of the
+  last pre-compaction 72.5k prompt (48%) · processed 39.1k uncached`. The share uses that
+  earlier prompt as its denominator. `reused` means the provider read an unchanged
+  prefix from that earlier cache lineage; it does not mean the compaction summary used
+  that prefix or retained that many semantic conversation tokens. The uncached count is
+  ordinary input plus explicit cache-write input: everything in the new prompt that was
+  not a cache read. It therefore carries no share. If the model also changed,
+  withhold the prior count and share rather than compare tokenizers
 - certainty ladder: contract-backed evidence gets definite words (`cache cold`);
   a documented band gets hedged words (`cache fading`); an unknown provider gets
   `likely`. Never write definite words on soft evidence

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -142,18 +142,24 @@ arrives; a send that aborts before usage resolves the notice to an explicit "out
 unknown".
 
 Compaction is deliberately unsized in flight: Pi's compact event does not provide an
-exact provider-token split for the new prefix. The first billed call afterwards does,
-so the resolved notice shows both sides: `preserved 34.9k of the prior 72.5k prefix ·
-re-wrote 38.7k (52% of prompt)`. `Preserved` is the response's exact `cacheRead`
-from the unchanged prompt prefix. It is not a claim about how many semantic
-conversation tokens Pi kept. If the model also changed, the old-model prefix count is
-withheld rather than compared with usage from a different tokenizer.
+exact provider-token split for the new prefix. The first billed agent call afterwards
+does, so the resolved notice compares its exact `cacheRead` with the last normal agent
+prompt before compaction: `reused 34.9k of the last pre-compaction 72.5k prompt (48%) ·
+processed 39.1k uncached`. Pi's summarizer request has a separate prompt shape and does not
+reuse that prefix. The first normal agent call after compaction can instead read the
+unchanged prefix from the earlier pre-compaction cache lineage. `Reused` is not a claim
+about how many semantic conversation tokens Pi kept. The uncached count is the
+provider-reported ordinary input plus explicit cache-write input: everything in the new
+prompt that was not a cache read. It therefore carries no share of the old prompt. If
+the model also changed, the
+old-model prompt count and share are withheld rather than compared with usage from a
+different tokenizer.
 
-The `(99%)` in a resolved notice is the share of the request's prompt-side tokens
-(input + cacheRead + cacheWrite) that had to be re-written. `cache held` (green)
-appears when a predicted break didn't happen, usually shared-prefix warmth: another
-session with the same harness prefix kept the early breakpoints alive past your idle
-gap.
+Percentages on ordinary resolved miss notices remain the share of that request's
+prompt-side tokens (input + cacheRead + cacheWrite) that had to be re-written. `cache
+held` (green) appears when a predicted break did not happen, usually shared-prefix
+warmth: another session with the same harness prefix kept the early breakpoints alive
+past your idle gap.
 
 ## State and lifecycle
 

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -43,17 +43,22 @@ default threshold is $0.05 or 20k re-written tokens.
 
 ```
 ◍ cache breaking · re-writing ~138.2k (~$2.59) · cause: idle 9h50m > 5m TTL   (in flight)
-◍ cache after compaction · preserved 34.9k of the prior 72.5k prefix · re-wrote 38.7k (52% of prompt)
+◍ cache after compaction · reused 34.9k of the last pre-compaction 72.5k prompt (48%) · processed 39.1k uncached
 ◍ cache broke · re-wrote 138.2k of 139.6k prompt (99%) · $0.52 · cause: idle 9h50m > 5m TTL
 ◍ cache partial · read 41.2k of 138.2k expected · re-wrote 138.2k (76% of prompt) · cause: system prompt changed
 ◍ cache held · read 76.0k of 77.7k expected · prefix stayed warm              (prediction wrong, good news)
 ```
 
 A compaction prediction stays unsized because the new prefix is not provider-known
-until the next response. The resolved line uses exact provider usage. `Preserved`
-means cache reads from the unchanged prompt prefix, not semantic conversation tokens
-retained by the compactor. If the model also changed, Cachemire withholds the prior
-count rather than compare values from different tokenizers.
+until the next response. The resolved line uses exact provider usage. `Reused` means
+the first normal agent call after compaction read an unchanged prefix from the last
+normal pre-compaction prompt. The separate summarizer request does not reuse that
+prefix, and this is not a count of semantic conversation tokens retained by the
+compactor. The percentage therefore uses the last pre-compaction prompt as its
+denominator. The processed count is ordinary input plus explicit cache-write input:
+everything in the new prompt that was not a cache read. It carries no percentage. If the
+model also changed, Cachemire withholds the prior count and share rather than
+compare values from different tokenizers.
 
 ## See the cost of each turn
 

--- a/extensions/pi-cachemire/render.ts
+++ b/extensions/pi-cachemire/render.ts
@@ -44,13 +44,14 @@ function isPostCompaction(record: CallRecord): boolean {
 }
 
 function renderCompactionLine(record: CallRecord): string {
-  const prior = record.expectedRead > 0 && record.postCompaction?.modelSwitched !== true
-    ? ` of the prior ${compactCount(record.expectedRead)} prefix`
-    : " from the prior prefix";
-  const prompt = promptTokens(record.usage);
-  const rewriteShare = prompt > 0 ? ` (${Math.round((record.rewroteTokens / prompt) * 100)}% of prompt)` : "";
-  return `cache after compaction \u00b7 preserved ${compactCount(record.usage.cacheRead)}${prior}` +
-    ` \u00b7 re-wrote ${compactCount(record.rewroteTokens)}${rewriteShare}`;
+  const canCompare = record.expectedRead > 0 && record.postCompaction?.modelSwitched !== true;
+  const prior = canCompare
+    ? ` of the last pre-compaction ${compactCount(record.expectedRead)} prompt` +
+      ` (${Math.round((record.usage.cacheRead / record.expectedRead) * 100)}%)`
+    : " from the last pre-compaction prompt";
+  const uncached = record.usage.input + record.usage.cacheWrite;
+  return `cache after compaction \u00b7 reused ${compactCount(record.usage.cacheRead)}${prior}` +
+    ` \u00b7 processed ${compactCount(uncached)} uncached`;
 }
 
 export function renderMissLine(record: CallRecord): string {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-of-glass",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Observability extensions for the Pi coding agent",
   "license": "MIT",
   "type": "module",

--- a/tests/cachemire/compaction-render.test.ts
+++ b/tests/cachemire/compaction-render.test.ts
@@ -16,14 +16,27 @@ const COMPACTED: CallRecord = {
   postCompaction: { modelSwitched: false },
 };
 
-test("resolved compaction notice reports the exact preserved and re-written split", () => {
+test("resolved compaction notice reports reuse against the last pre-compaction prompt", () => {
   assert.equal(
     renderMissLine(COMPACTED),
-    "cache after compaction \u00b7 preserved 34.9k of the prior 72.5k prefix \u00b7 re-wrote 38.7k (52% of prompt)",
+    "cache after compaction \u00b7 reused 34.9k of the last pre-compaction 72.5k prompt (48%) \u00b7 processed 39.1k uncached",
   );
 });
 
-test("a post-compaction hit keeps the split instead of falling back to generic held wording", () => {
+test("the reported session uses the pre-compaction denominator", () => {
+  const observed: CallRecord = {
+    ...COMPACTED,
+    usage: { input: 21_163, output: 299, cacheRead: 17_920, cacheWrite: 0 },
+    expectedRead: 173_864,
+    rewroteTokens: 21_163,
+  };
+  assert.equal(
+    renderMissLine(observed),
+    "cache after compaction \u00b7 reused 17.9k of the last pre-compaction 173.9k prompt (10%) \u00b7 processed 21.2k uncached",
+  );
+});
+
+test("a post-compaction hit keeps the reuse comparison instead of generic held wording", () => {
   const held: CallRecord = {
     ...COMPACTED,
     usage: { ...COMPACTED.usage, cacheRead: 68_000, cacheWrite: 4_100 },
@@ -32,13 +45,13 @@ test("a post-compaction hit keeps the split instead of falling back to generic h
   };
   assert.equal(
     renderHeldLine(held),
-    "cache after compaction \u00b7 preserved 68.0k of the prior 72.5k prefix \u00b7 re-wrote 4.1k (6% of prompt)",
+    "cache after compaction \u00b7 reused 68.0k of the last pre-compaction 72.5k prompt (94%) \u00b7 processed 4.5k uncached",
   );
 });
 
-test("a model switch withholds the prior count because its tokenizer differs", () => {
+test("a model switch withholds the prior count and share because its tokenizer differs", () => {
   assert.equal(
     renderMissLine({ ...COMPACTED, postCompaction: { modelSwitched: true } }),
-    "cache after compaction \u00b7 preserved 34.9k from the prior prefix \u00b7 re-wrote 38.7k (52% of prompt)",
+    "cache after compaction \u00b7 reused 34.9k from the last pre-compaction prompt \u00b7 processed 39.1k uncached",
   );
 });

--- a/tests/fixtures/goldens/cachemire-lines.txt
+++ b/tests/fixtures/goldens/cachemire-lines.txt
@@ -21,7 +21,7 @@
 === notices (chat lines) ===
 ◍ cache breaking · re-writing ~150.3k (~$2.82) · cause: idle 7m00s > 5m TTL
 ◍ cache breaking · re-writing the new prefix · cause: history compacted
-◍ cache after compaction · preserved 34.9k of the prior 72.5k prefix · re-wrote 38.7k (52% of prompt)
+◍ cache after compaction · reused 34.9k of the last pre-compaction 72.5k prompt (48%) · processed 39.1k uncached
 ◍ cache broke · re-wrote 153.0k of 153.2k prompt (100%) · $2.97 · cause: idle 7m00s > 5m TTL
 ◍ cache partial · read 90.0k of 152.1k expected · re-wrote 62.1k (41% of prompt) · cause: unknown (provider-side eviction?)
 ◍ cache held · read 150.3k of 150.3k expected · prefix stayed warm


### PR DESCRIPTION
## Summary
- compare post-compaction cache reads with the last normal pre-compaction prompt
- label the provider-grounded remainder as uncached input processed
- document the cache lineage and add regression coverage for #51
- release as v0.8.4

## Verification
- `npm run check` (242 tests)
- `npm pack --dry-run`
- real Pi compaction path exercised in tmux

Fixes #51