### PR TITLE
Fix Cachemire lineage tracking after /tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Cachemire: follow cache lineage through `/tree` navigation.** Rewinding or
+  switching branches now rebases the expected reusable prefix to the last
+  provider-billed prompt on the selected path. The intentional divergent tail no
+  longer produces a full-prefix break warning; provider usage remains authoritative
+  for the resolved cached and uncached split.
+
 ## 0.8.4 (2026-07-23)
 
 - **Cachemire: use the last pre-compaction prompt for cache-reuse shares.** The

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -188,6 +188,10 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   ordinary input plus explicit cache-write input: everything in the new prompt that was
   not a cache read. It therefore carries no share. If the model also changed,
   withhold the prior count and share rather than compare tokenizers
+- after tree navigation, the cache baseline follows the selected branch, not the
+  abandoned leaf. Use the last provider-billed prompt on the selected path as the
+  expected reusable prefix. The intentional suffix divergence is not a full-prefix
+  mutation; withhold a divergent-tail estimate until provider usage makes it exact
 - certainty ladder: contract-backed evidence gets definite words (`cache cold`);
   a documented band gets hedged words (`cache fading`); an unknown provider gets
   `likely`. Never write definite words on soft evidence

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -119,6 +119,28 @@ reads alternating 62,464 → 49,152 → 62,464 → 65,024, which a single cache 
 replica lineages were advancing independently, and each break was one replica's
 first-touch. The matcher turns that hand analysis into the default diagnosis.
 
+## Tree navigation and branch lineages
+
+Pi sessions are trees, so Cachemire's reusable-prefix baseline follows the active
+branch. After `/tree`, it rebuilds that baseline from the selected path's last billed
+assistant message. The provider-reported `input + cacheRead + cacheWrite` for that
+historical call is the exact prompt-side comparison baseline for the selected path.
+
+The abandoned and selected histories necessarily differ after their common prefix.
+That authenticated tree transition is not treated as an ordinary history mutation:
+pricing the abandoned leaf's full prompt would claim that the common prefix broke when
+it did not. Structural differences in model, system prompt, tools or thinking parameters
+still take precedence and are reported normally. The exact size of the new divergent
+tail remains unknown before provider usage, so Cachemire does not invent an in-flight
+suffix bill. The resolved call then uses the provider's exact cache read and uncached
+input.
+
+This also rebases the clock's at-risk prompt size and freshness anchor. Cachemire finds
+the latest billed descendant whose request contained the selected branch root. Calls on
+a sibling branch can refresh their common ancestor, but cannot make the selected
+branch's private suffix younger. If the provider reports otherwise, the normal resolved
+miss path corrects the prediction.
+
 ## The cause ladder
 
 Every provider request is fingerprinted (system prompt, each tool, each history
@@ -168,7 +190,8 @@ what the provider billed (usage on assistant messages in the session transcript)
 which `--continue` rebuilds the ledger (and entry matching still works across a quick
 exit+resume, since prompt totals are recoverable). Request-time observations (payload
 fingerprints, request-start anchors, the observed `cache_control` TTL) exist only at
-the event boundary and are never persisted: restored rows say `cause unknown` rather
+the event boundary and are never persisted. Branch baselines are reconstructed from
+provider usage already stored on the active session path; restored rows say `cause unknown` rather
 than reconstruct a diagnosis from vibes, and cachemire writes nothing into session
 entries or exports (UI-only contract).
 

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -49,6 +49,12 @@ default threshold is $0.05 or 20k re-written tokens.
 ◍ cache held · read 76.0k of 77.7k expected · prefix stayed warm              (prediction wrong, good news)
 ```
 
+Tree navigation follows the selected branch's cache lineage. Cachemire rebases its
+expected reusable prefix to the last provider-billed prompt on that path instead of
+pricing the abandoned leaf's whole prompt. The intentional divergent tail does not
+trigger a full-prefix warning; the next response supplies its exact cached and uncached
+split.
+
 A compaction prediction stays unsized because the new prefix is not provider-known
 until the next response. The resolved line uses exact provider usage. `Reused` means
 the first normal agent call after compaction read an unchanged prefix from the last
@@ -132,7 +138,8 @@ Cachemire follows these rules:
   Cachemire says "likely". Under subscription auth, it marks savings as notional.
 - Sessions restored with `--continue` rebuild the ledger from session usage. Cachemire
   marks restored rows and excludes them from savings because their pricing context is
-  unknown.
+  unknown. `/tree` rebuilds the active cache baseline from the selected path while
+  retaining the full session ledger.
 
 ## Understand the model behind the wording
 

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -16,8 +16,8 @@ import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import { GLYPH, SCALE, SEP, ink, panelHeader, type Tone } from "../_lib/style.ts";
 import { settleDanglingSend } from "./lifecycle.ts";
+import { activeLineageCause, branchLineageBaseline, latestBranchRefreshAt, restoreBranchRecords } from "./lineage.ts";
 import { promptTokens, renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
-
 /**
  * pi-cachemire — explains the cache and loop economics of a pi session.
  *
@@ -719,44 +719,6 @@ function renderLedger(
   return lines;
 }
 
-// --- ledger restore (so --continue sessions keep their totals) --------------------------
-
-function restoreFromMessages(messages: Array<Record<string, unknown>>): CallRecord[] {
-  const records: CallRecord[] = [];
-  let previousAt: number | undefined;
-  let expectedRead = 0;
-  for (const message of messages) {
-    if (message.role !== "assistant") continue;
-    const usage = message.usage as UsageLike | undefined;
-    if (!usage || (usage.input === 0 && usage.output === 0 && usage.cacheRead === 0 && usage.cacheWrite === 0)) continue;
-    const at = typeof message.timestamp === "number" ? message.timestamp : 0;
-    const isFirst = records.length === 0;
-    const classification = classifyCall({
-      isFirst,
-      gapMs: previousAt !== undefined ? at - previousAt : undefined,
-      usage,
-      expectedRead,
-    });
-    if (classification.cause && classification.kind !== "cold" && classification.kind !== "hit") {
-      classification.cause = { kind: "restored", detail: "restored session (cause unknown)" };
-    }
-    records.push({
-      index: records.length + 1,
-      at,
-      gapMs: previousAt !== undefined ? at - previousAt : undefined,
-      usage,
-      expectedRead,
-      classification,
-      rewroteTokens: usage.cacheWrite > 0 ? usage.cacheWrite : usage.input,
-      costUsd: usage.cost?.total,
-      restored: true,
-    });
-    previousAt = at;
-    expectedRead = usage.input + usage.cacheRead + usage.cacheWrite;
-  }
-  return records;
-}
-
 // --- config ----------------------------------------------------------------------------
 
 function parseCachemireConfig(value: unknown): Partial<CachemireConfig> {
@@ -800,6 +762,8 @@ interface CachemireState {
   prevFingerprint?: RequestFingerprint;
   pendingFingerprint?: RequestFingerprint;
   pendingRequestAt?: number;
+  pendingPreviousCacheAt?: number;
+  pendingCacheGapMs?: number;
   prevCallRequestAt?: number;
   lastRequestAt?: number;
   window: CacheWindow;
@@ -818,6 +782,7 @@ interface CachemireState {
   providerLabel?: string;
   compacted: boolean;
   inCompaction: boolean;
+  treeRebased: boolean;
   /** Chat lines cachemire appended, with anchors for re-attachment after pi rebuilds. */
   anchored: AnchoredLine[];
   /** Cached chat container: rebuilds empty it of recognizable rows, but the instance
@@ -855,6 +820,7 @@ function state(): CachemireState {
       expectedRead: 0,
       compacted: false,
       inCompaction: false,
+      treeRebased: false,
       anchored: [],
       lineageStart: 0,
     };
@@ -926,8 +892,9 @@ export default function piCachemire(pi: ExtensionAPI): void {
     if (g.__piCachemireOwner !== undefined && !ownsState()) return;
     g.__piCachemireOwner = ownerToken;
     s.config = loadConfig(process.cwd());
+    s.treeRebased = false;
     const { messages } = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId());
-    s.records = restoreFromMessages(messages as unknown as Array<Record<string, unknown>>);
+    s.records = restoreBranchRecords(messages as unknown as Array<Record<string, unknown>>, classifyCall);
     let restoredModelId: string | undefined;
     for (let i = messages.length - 1; i >= 0 && restoredModelId === undefined; i--) {
       const message = messages[i]!;
@@ -985,7 +952,12 @@ export default function piCachemire(pi: ExtensionAPI): void {
   pi.on("before_provider_request", async (event) => {
     if (!ownsState()) return;
     s.pendingFingerprint = fingerprintPayload(event.payload);
-    s.pendingRequestAt = Date.now();
+    const requestAt = Date.now();
+    if (s.pendingRequestAt === undefined) {
+      s.pendingPreviousCacheAt = s.lastRequestAt;
+      s.pendingCacheGapMs = s.lastRequestAt !== undefined ? requestAt - s.lastRequestAt : undefined;
+    }
+    s.pendingRequestAt = requestAt;
     // TTL anchor = request start: providers read/refresh/write cache entries while
     // processing the request input (entries become available once the response *begins*),
     // so the freshness window burns during generation — a long thinking block eats into it.
@@ -1009,10 +981,10 @@ export default function piCachemire(pi: ExtensionAPI): void {
         isFirst: s.records.length === 0,
         inCompaction: s.inCompaction,
         compacted: s.compacted,
-        gapMs: s.prevCallRequestAt !== undefined ? s.pendingRequestAt - s.prevCallRequestAt : undefined,
+        gapMs: s.pendingCacheGapMs,
         window: s.window,
         expectedRead: s.expectedRead,
-        fingerprintCause: s.prevFingerprint ? diffFingerprints(s.prevFingerprint, s.pendingFingerprint) : undefined,
+        fingerprintCause: activeLineageCause(s.prevFingerprint, s.pendingFingerprint, s.treeRebased, diffFingerprints),
         rates: s.rates,
       });
       const material = prediction !== undefined && (
@@ -1065,6 +1037,20 @@ export default function piCachemire(pi: ExtensionAPI): void {
     s.run = { startedAt: Date.now(), calls: 0, input: 0, cacheRead: 0, cacheWrite: 0, output: 0, costUsd: 0 };
   });
 
+  pi.on("session_tree", async (event, ctx) => {
+    if (!ownsState()) return;
+    const entries = ctx.sessionManager.getEntries();
+    const { messages } = buildSessionContext(entries, event.newLeafId);
+    const baseline = branchLineageBaseline(messages);
+    const branchRootId = event.summaryEntry?.parentId ?? event.newLeafId;
+    const refreshAt = latestBranchRefreshAt(entries, branchRootId) ?? baseline?.at;
+    s.expectedRead = baseline?.promptTokens ?? 0;
+    s.cachedTokens = baseline?.promptTokens;
+    s.lastRequestAt = refreshAt;
+    s.treeRebased = true;
+    updateWidget();
+  });
+
   pi.on("session_before_compact", async () => {
     if (!ownsState()) return;
     s.inCompaction = true;
@@ -1086,10 +1072,9 @@ export default function piCachemire(pi: ExtensionAPI): void {
     // Idle gap between the previous request (which refreshed the TTL) and this one.
     const requestAt = s.pendingRequestAt ?? now;
     const gapMs = s.prevCallRequestAt !== undefined ? requestAt - s.prevCallRequestAt : undefined;
+    const cacheGapMs = s.pendingCacheGapMs ?? gapMs;
 
-    const fingerprintCause = s.prevFingerprint && s.pendingFingerprint
-      ? diffFingerprints(s.prevFingerprint, s.pendingFingerprint)
-      : undefined;
+    const fingerprintCause = activeLineageCause(s.prevFingerprint, s.pendingFingerprint, s.treeRebased, diffFingerprints);
     // Any invalidating change re-keys the cache: records before it are a dead lineage
     // whose entries this prefix cannot read, and a 512-bucket collision with one would
     // name an unreadable entry. Conservative on purpose — a mutation that happened to
@@ -1109,7 +1094,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
       : undefined;
     const classification = classifyCall({
       isFirst: s.records.length === 0,
-      gapMs,
+      gapMs: cacheGapMs,
       window: s.window,
       usage,
       expectedRead: s.expectedRead,
@@ -1134,12 +1119,15 @@ export default function piCachemire(pi: ExtensionAPI): void {
     };
     s.records.push(record);
     s.compacted = false;
+    s.treeRebased = false;
     s.prevFingerprint = s.pendingFingerprint ?? s.prevFingerprint;
     s.prevCallRequestAt = requestAt;
     // Usage arrived: the anchor this request claimed at send time is provider-confirmed.
     // Consume the pending pair — whatever is still pending at agent_end never got usage.
     s.pendingFingerprint = undefined;
     s.pendingRequestAt = undefined;
+    s.pendingPreviousCacheAt = undefined;
+    s.pendingCacheGapMs = undefined;
     s.expectedRead = usage.input + usage.cacheRead + usage.cacheWrite;
     s.cachedTokens = s.expectedRead;
     // Fresh usage re-baselines the currency: counts are now denominated in this model.
@@ -1188,9 +1176,11 @@ export default function piCachemire(pi: ExtensionAPI): void {
     // the provider ever touched the cache, and the countdown would then be fiction.
     const settled = settleDanglingSend(s);
     if (settled.changed) {
-      s.lastRequestAt = settled.lastRequestAt;
+      s.lastRequestAt = s.pendingPreviousCacheAt;
       s.pendingRequestAt = undefined;
+      s.pendingPreviousCacheAt = undefined;
       s.pendingFingerprint = undefined;
+      s.pendingCacheGapMs = undefined;
       updateWidget();
     }
     const run = s.run;
@@ -1231,6 +1221,9 @@ export const internals = {
   renderBreakingLine,
   renderHeldLine,
   diffFingerprints,
+  activeLineageCause,
+  branchLineageBaseline,
+  latestBranchRefreshAt,
   matchPriorEntry,
   classifyCall,
   settleDanglingSend,
@@ -1247,7 +1240,7 @@ export const internals = {
   renderRunSummary,
   renderMissLine,
   renderLedger,
-  restoreFromMessages,
+  restoreFromMessages: (messages: Array<Record<string, unknown>>) => restoreBranchRecords(messages, classifyCall),
   loadConfig,
   DEFAULT_CONFIG,
 };

--- a/extensions/pi-cachemire/lineage.ts
+++ b/extensions/pi-cachemire/lineage.ts
@@ -1,0 +1,136 @@
+import { isJsonObject } from "../_lib/boundary.ts";
+import type {
+  CallCause,
+  CallClassification,
+  CallRecord,
+  RequestFingerprint,
+  UsageLike,
+} from "./index.ts";
+
+export interface BranchLineageBaseline {
+  /** Provider-billed prompt tokens for the last call on the selected branch. */
+  promptTokens: number;
+  /** Response timestamp when the serialized message provides one. */
+  at?: number;
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/**
+ * Recover the provider-exact prompt baseline for one resolved session branch.
+ *
+ * buildSessionContext() has already selected the active tree path and applied
+ * compaction. This boundary parser deliberately ignores zero-usage assistant entries:
+ * Pi can persist injected or aborted assistant messages that never reached a provider.
+ */
+export function branchLineageBaseline(messages: readonly unknown[]): BranchLineageBaseline | undefined {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (!isJsonObject(message) || message.role !== "assistant" || !isJsonObject(message.usage)) continue;
+    const input = nonNegativeNumber(message.usage.input);
+    const cacheRead = nonNegativeNumber(message.usage.cacheRead);
+    const cacheWrite = nonNegativeNumber(message.usage.cacheWrite);
+    const output = nonNegativeNumber(message.usage.output);
+    if (input === undefined || cacheRead === undefined || cacheWrite === undefined || output === undefined) continue;
+    if (input === 0 && cacheRead === 0 && cacheWrite === 0 && output === 0) continue;
+    return {
+      promptTokens: input + cacheRead + cacheWrite,
+      at: nonNegativeNumber(message.timestamp),
+    };
+  }
+  return undefined;
+}
+
+function billedAssistantAt(entry: unknown): number | undefined {
+  if (!isJsonObject(entry) || entry.type !== "message" || !isJsonObject(entry.message)) return undefined;
+  const baseline = branchLineageBaseline([entry.message]);
+  return baseline?.at;
+}
+
+/** Latest provider call whose session path contains the selected branch root. */
+export function latestBranchRefreshAt(
+  entries: readonly unknown[],
+  branchRootId: string | null,
+): number | undefined {
+  if (branchRootId === null) return undefined;
+  const parents = new Map<string, string | null>();
+  for (const entry of entries) {
+    if (!isJsonObject(entry) || typeof entry.id !== "string") continue;
+    parents.set(entry.id, typeof entry.parentId === "string" ? entry.parentId : null);
+  }
+  const descendsFromRoot = (entryId: string): boolean => {
+    let current: string | null | undefined = entryId;
+    const seen = new Set<string>();
+    while (current !== null && current !== undefined && !seen.has(current)) {
+      if (current === branchRootId) return true;
+      seen.add(current);
+      current = parents.get(current);
+    }
+    return false;
+  };
+  let latest: number | undefined;
+  for (const entry of entries) {
+    if (!isJsonObject(entry) || typeof entry.id !== "string" || !descendsFromRoot(entry.id)) continue;
+    const at = billedAssistantAt(entry);
+    if (at !== undefined && (latest === undefined || at > latest)) latest = at;
+  }
+  return latest;
+}
+
+export function activeLineageCause(
+  prev: RequestFingerprint | undefined,
+  cur: RequestFingerprint | undefined,
+  treeRebased: boolean,
+  diff: (a: RequestFingerprint, b: RequestFingerprint) => CallCause | undefined,
+): CallCause | undefined {
+  const cause = prev && cur ? diff(prev, cur) : undefined;
+  return treeRebased && cause?.kind === "history" ? undefined : cause;
+}
+
+type RestoreClassifier = (args: {
+  isFirst: boolean;
+  gapMs?: number;
+  usage: UsageLike;
+  expectedRead: number;
+}) => CallClassification;
+
+/** Rebuild persisted ledger rows without inventing request-time causes. */
+export function restoreBranchRecords(
+  messages: Array<Record<string, unknown>>,
+  classify: RestoreClassifier,
+): CallRecord[] {
+  const records: CallRecord[] = [];
+  let previousAt: number | undefined;
+  let expectedRead = 0;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    const usage = message.usage as UsageLike | undefined;
+    if (!usage || (usage.input === 0 && usage.output === 0 && usage.cacheRead === 0 && usage.cacheWrite === 0)) continue;
+    const at = typeof message.timestamp === "number" ? message.timestamp : 0;
+    const classification = classify({
+      isFirst: records.length === 0,
+      gapMs: previousAt !== undefined ? at - previousAt : undefined,
+      usage,
+      expectedRead,
+    });
+    if (classification.cause && classification.kind !== "cold" && classification.kind !== "hit") {
+      classification.cause = { kind: "restored", detail: "restored session (cause unknown)" };
+    }
+    records.push({
+      index: records.length + 1,
+      at,
+      gapMs: previousAt !== undefined ? at - previousAt : undefined,
+      usage,
+      expectedRead,
+      classification,
+      rewroteTokens: usage.cacheWrite > 0 ? usage.cacheWrite : usage.input,
+      costUsd: usage.cost?.total,
+      restored: true,
+    });
+    previousAt = at;
+    expectedRead = usage.input + usage.cacheRead + usage.cacheWrite;
+  }
+  return records;
+}

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -5,7 +5,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 1254,
+      "extensions/pi-cachemire/index.ts": 1247,
       "extensions/pi-contextimate/index.ts": 1959,
       "extensions/pi-traceline/index.ts": 1771,
       "tests/cachemire/economics-and-render.test.ts": 352,

--- a/tests/cachemire/tree-lineage.test.ts
+++ b/tests/cachemire/tree-lineage.test.ts
@@ -1,0 +1,156 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+import piCachemire, { internals } from "../../extensions/pi-cachemire/index.ts";
+
+const { activeLineageCause, branchLineageBaseline, diffFingerprints, fingerprintPayload, latestBranchRefreshAt } = internals;
+
+type Handler = (...args: unknown[]) => unknown;
+
+function extensionProbe(): { handlers: Map<string, Handler[]>; commands: Map<string, Handler> } {
+  const handlers = new Map<string, Handler[]>();
+  const commands = new Map<string, Handler>();
+  const pi = {
+    on(event: string, handler: Handler): void {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+    },
+    registerCommand(name: string, options: { handler: Handler }): void {
+      commands.set(name, options.handler);
+    },
+    getThinkingLevel(): string {
+      return "off";
+    },
+  } as unknown as ExtensionAPI;
+  piCachemire(pi);
+  return { handlers, commands };
+}
+
+async function fire(probe: ReturnType<typeof extensionProbe>, event: string, ...args: unknown[]): Promise<void> {
+  for (const handler of probe.handlers.get(event) ?? []) await handler(...args);
+}
+
+function usage(input: number, cacheRead: number, cacheWrite: number, output = 10) {
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function assistant(timestamp: number, prompt: number) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "answer" }],
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    stopReason: "stop",
+    timestamp,
+    usage: usage(2, prompt - 2, 0),
+  };
+}
+
+function payload(messages: string[]) {
+  return {
+    model: "claude-opus-4-8",
+    system: [{ type: "text", text: "fixture", cache_control: { type: "ephemeral" } }],
+    messages: messages.map((text) => ({ role: "user", content: [{ type: "text", text }] })),
+  };
+}
+
+function context(entries: unknown[], leafId: string, notifications: string[]) {
+  return {
+    hasUI: true,
+    ui: {
+      theme: undefined,
+      setWidget(): void {},
+      notify(text: string): void {
+        notifications.push(text);
+      },
+    },
+    model: {
+      id: "claude-opus-4-8",
+      provider: "anthropic",
+      reasoning: false,
+      cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+    },
+    sessionManager: {
+      getEntries: () => entries,
+      getLeafId: () => leafId,
+    },
+  };
+}
+
+test("branch baseline uses the selected path's last provider-billed prompt", () => {
+  const baseline = branchLineageBaseline([
+    assistant(1_000, 177_860),
+    { role: "assistant", timestamp: 2_000, usage: usage(0, 0, 0, 0) },
+  ])!;
+  assert.deepEqual(baseline, { promptTokens: 177_860, at: 1_000 });
+
+  // Observed rewind: the next request reused 177,858 and processed only 1,408
+  // uncached, rather than breaking the abandoned leaf's 179,294-token prompt.
+  assert.equal(177_858 / baseline.promptTokens > 0.99, true);
+  assert.equal(2 + 1_406, 1_408);
+  assert.equal(branchLineageBaseline([{ role: "user", content: "root" }]), undefined);
+});
+
+test("branch freshness follows calls that actually contain the selected prefix", () => {
+  const entries = [
+    { type: "message", id: "root", parentId: null, message: assistant(1_000, 80_000) },
+    { type: "message", id: "left-user", parentId: "root", message: { role: "user", content: "left" } },
+    { type: "message", id: "left", parentId: "left-user", message: assistant(10_000, 100_000) },
+    { type: "message", id: "right-user", parentId: "root", message: { role: "user", content: "right" } },
+    { type: "message", id: "right", parentId: "right-user", message: assistant(20_000, 120_000) },
+  ];
+  assert.equal(latestBranchRefreshAt(entries, "left-user"), 10_000, "a sibling call cannot refresh this branch");
+  assert.equal(latestBranchRefreshAt(entries, "root"), 20_000, "both siblings refresh their common prefix");
+  assert.equal(latestBranchRefreshAt(entries, null), undefined);
+});
+
+test("tree navigation suppresses only the intentional history divergence", () => {
+  const oldBranch = fingerprintPayload(payload(["base", "old branch"]));
+  const newBranch = fingerprintPayload(payload(["base", "new branch"]));
+  assert.equal(activeLineageCause(oldBranch, newBranch, true, diffFingerprints), undefined);
+  assert.equal(activeLineageCause(oldBranch, newBranch, false, diffFingerprints)?.kind, "history");
+
+  const changedSystem = fingerprintPayload({ ...payload(["base", "new branch"]), system: "changed" });
+  assert.equal(activeLineageCause(oldBranch, changedSystem, true, diffFingerprints)?.kind, "system");
+});
+
+test("session_tree rebases classification to the selected branch", async () => {
+  const now = Date.now();
+  const baseAssistant = assistant(now - 3_000, 100_000);
+  const oldAssistant = assistant(now - 1_000, 200_000);
+  const entries = [
+    { type: "message", id: "user-base", parentId: null, timestamp: new Date(now - 4_000).toISOString(), message: { role: "user", content: "base", timestamp: now - 4_000 } },
+    { type: "message", id: "assistant-base", parentId: "user-base", timestamp: new Date(now - 3_000).toISOString(), message: baseAssistant },
+    { type: "message", id: "user-old", parentId: "assistant-base", timestamp: new Date(now - 2_000).toISOString(), message: { role: "user", content: "old branch", timestamp: now - 2_000 } },
+    { type: "message", id: "assistant-old", parentId: "user-old", timestamp: new Date(now - 1_000).toISOString(), message: oldAssistant },
+  ];
+  const notifications: string[] = [];
+  const probe = extensionProbe();
+  const ctx = context(entries, "assistant-old", notifications);
+
+  await fire(probe, "session_start", {}, ctx);
+  try {
+    // Establish a live fingerprint and the abandoned leaf's 200k prompt baseline.
+    await fire(probe, "before_provider_request", { payload: payload(["base", "old branch"]) });
+    await fire(probe, "message_end", { message: { ...oldAssistant, usage: usage(0, 200_000, 0) } });
+
+    // Rewind to the 100k selected-branch baseline. A 90k read is a hit against this
+    // branch, but would be misclassified as a 45% partial against the abandoned 200k leaf.
+    await fire(probe, "session_tree", { newLeafId: "assistant-base", oldLeafId: "assistant-old" }, ctx);
+    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch"]) });
+    assert.equal(notifications.length, 0, "intentional branch divergence must not emit a full-prefix warning");
+    await fire(probe, "message_end", { message: { ...baseAssistant, usage: usage(0, 90_000, 10_000) } });
+
+    await probe.commands.get("cache")?.("", ctx);
+    assert.equal(notifications.length, 1);
+    assert.match(notifications[0]!, /\s4\s+.*● hit/);
+  } finally {
+    await fire(probe, "session_shutdown", {});
+  }
+});


### PR DESCRIPTION
## Summary

- rebase Cachemire's expected reusable prompt to the selected `/tree` branch
- track freshness from the latest billed descendant that actually contains that branch prefix
- treat the authenticated tree suffix divergence as normal branching, while preserving model, system, tool, and thinking invalidation checks
- keep chronological call gaps separate from branch-lineage cache age

## Evidence

The observed rewind had a 179,294-token abandoned leaf, a 177,860-token selected-branch baseline, and the next provider response reused 177,858 tokens while processing only 1,408 uncached. Regression coverage includes that shape plus sibling-branch freshness and an extension lifecycle test where a 90k read must be a hit against a selected 100k branch, not a partial miss against the abandoned 200k leaf.

## Validation

- `npm run check`
- 246 tests passed
- `git diff --check`
