### PR TITLE
Refine Cachemire branch lineage snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,14 @@
 
 ## 0.8.5 (2026-07-25)
 
-- **Cachemire: follow cache lineage through `/tree` navigation.** Rewinding or
-  switching branches now rebases the expected reusable prefix to the last
-  provider-billed prompt on the selected path. The intentional divergent tail no
-  longer produces a full-prefix break warning; provider usage remains authoritative
-  for the resolved cached and uncached split.
+- **Cachemire: follow cache lineage through `/tree` navigation.** Every live billed
+  request now records its session path, provider, model, fingerprint, cache window and
+  provider usage. Before each send, Cachemire resolves the selected path's last billed
+  prompt and accepts freshness only from compatible descendants. Intentional suffix
+  divergence is ordinary prefix growth rather than a suppressed warning; model, system,
+  tool, thinking and earlier-history changes still invalidate normally. Restored
+  sessions rebuild all-branch baselines from persisted provider usage while withholding
+  fingerprint-only freshness claims.
 - **Tests: keep Contextimate render goldens portable.** Golden prompt counts now use
   a fixed fixture home, so they remain stable across developer home-directory lengths.
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -190,7 +190,10 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   withhold the prior count and share rather than compare tokenizers
 - after tree navigation, the cache baseline follows the selected branch, not the
   abandoned leaf. Use the last provider-billed prompt on the selected path as the
-  expected reusable prefix. The intentional suffix divergence is not a full-prefix
+  expected reusable prefix. A later request refreshes that baseline only when session
+  ancestry and its provider, model, cache window and payload fingerprint prove
+  compatibility. The
+  intentional suffix divergence is therefore ordinary prefix growth, not a suppressed
   mutation; withhold a divergent-tail estimate until provider usage makes it exact
 - certainty ladder: contract-backed evidence gets definite words (`cache cold`);
   a documented band gets hedged words (`cache fading`); an unknown provider gets

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -121,25 +121,36 @@ first-touch. The matcher turns that hand analysis into the default diagnosis.
 
 ## Tree navigation and branch lineages
 
-Pi sessions are trees, so Cachemire's reusable-prefix baseline follows the active
-branch. After `/tree`, it rebuilds that baseline from the selected path's last billed
-assistant message. The provider-reported `input + cacheRead + cacheWrite` for that
-historical call is the exact prompt-side comparison baseline for the selected path.
+Pi sessions are trees, so Cachemire resolves cache lineage from the active path before
+every provider request, not only after `/tree`. Each live billed request records the
+session leaf it serialized, the assistant entry it produced, prompt usage, request time,
+provider, model, cache window and payload fingerprint. Restoring a session rebuilds the
+provider-usage subset from every branch; request-time fingerprints remain deliberately
+in-memory only.
 
-The abandoned and selected histories necessarily differ after their common prefix.
-That authenticated tree transition is not treated as an ordinary history mutation:
-pricing the abandoned leaf's full prompt would claim that the common prefix broke when
-it did not. Structural differences in model, system prompt, tools or thinking parameters
-still take precedence and are reported normally. The exact size of the new divergent
-tail remains unknown before provider usage, so Cachemire does not invent an in-flight
-suffix bill. The resolved call then uses the provider's exact cache read and uncached
-input.
+The nearest billed call anchored on the active path supplies the comparison baseline.
+This is normally an assistant response on the path; selecting a user/request leaf can
+also recover a prior call made from that exact leaf. Its provider-reported
+`input + cacheRead + cacheWrite` is the exact provider-known prompt size for that
+selected path. Cachemire then considers later requests whose session paths descend from
+that response. A candidate can refresh the baseline only when it uses the same provider,
+model and cache window and the baseline's system, tools, thinking parameters and message
+hashes remain a prefix of the candidate payload. A
+newer sibling with another model or prompt shape therefore cannot make the selected
+lineage look young.
 
-This also rebases the clock's at-risk prompt size and freshness anchor. Cachemire finds
-the latest billed descendant whose request contained the selected branch root. Calls on
-a sibling branch can refresh their common ancestor, but cannot make the selected
-branch's private suffix younger. If the provider reports otherwise, the normal resolved
-miss path corrects the prediction.
+The next outgoing payload is checked against that same selected baseline. Continuing or
+editing after the selected point is ordinary suffix growth, so no history exception or
+one-call suppression flag is needed. A change inside the baseline still reports a
+history mutation; model, system, tool and thinking changes still take precedence. The
+size of the selected response and new divergent tail is not provider-known before the
+next usage arrives, so Cachemire withholds that suffix estimate rather than pricing the
+abandoned leaf. Provider usage then supplies the exact cached and uncached split.
+
+Restored snapshots have provider, model, prompt size and response timestamps but no
+payload fingerprints. They can establish the selected denominator and their own
+response-time freshness approximation, but Cachemire does not claim that another
+restored descendant refreshed them without fingerprint proof.
 
 ## The cause ladder
 
@@ -187,13 +198,14 @@ past your idle gap.
 
 Working state is in-memory and dies with the process. What survives an exit is exactly
 what the provider billed (usage on assistant messages in the session transcript), from
-which `--continue` rebuilds the ledger (and entry matching still works across a quick
-exit+resume, since prompt totals are recoverable). Request-time observations (payload
-fingerprints, request-start anchors, the observed `cache_control` TTL) exist only at
-the event boundary and are never persisted. Branch baselines are reconstructed from
-provider usage already stored on the active session path; restored rows say `cause unknown` rather
-than reconstruct a diagnosis from vibes, and cachemire writes nothing into session
-entries or exports (UI-only contract).
+which `--continue` rebuilds the active ledger and all-branch lineage baselines.
+Request-time observations (payload fingerprints, true request-start anchors and the
+observed `cache_control` TTL) exist only at the event boundary and are never persisted.
+After restore, Cachemire uses response timestamps as slightly optimistic anchor
+approximations, withholds compatibility claims that need a fingerprint, and restarts
+replica-entry matching from live calls. Restored rows say `cause unknown` rather than reconstruct a
+diagnosis from vibes. Cachemire writes nothing into session entries or exports (UI-only
+contract).
 
 Only the Pi extension instance with an interactive UI may own that process-global
 working state. A nested headless `AgentSession` still loads the extension, but its

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -49,11 +49,13 @@ default threshold is $0.05 or 20k re-written tokens.
 ◍ cache held · read 76.0k of 77.7k expected · prefix stayed warm              (prediction wrong, good news)
 ```
 
-Tree navigation follows the selected branch's cache lineage. Cachemire rebases its
-expected reusable prefix to the last provider-billed prompt on that path instead of
-pricing the abandoned leaf's whole prompt. The intentional divergent tail does not
-trigger a full-prefix warning; the next response supplies its exact cached and uncached
-split.
+Tree navigation follows the selected branch's cache lineage. Cachemire anchors each
+live billed request to its session path, then chooses the last provider-billed prompt on
+the active path instead of pricing the abandoned leaf. Only descendants with a
+compatible provider, model, cache window and payload fingerprint can refresh that
+baseline. Continuing
+with a divergent suffix is ordinary prefix growth, so it needs no warning suppression;
+the next response supplies the exact cached and uncached split.
 
 A compaction prediction stays unsized because the new prefix is not provider-known
 until the next response. The resolved line uses exact provider usage. `Reused` means
@@ -136,10 +138,11 @@ Cachemire follows these rules:
 - Freshness wording reflects how much is known. A contract TTL gets a definite
   countdown. A documented band gets fading or cap wording. When nothing is known,
   Cachemire says "likely". Under subscription auth, it marks savings as notional.
-- Sessions restored with `--continue` rebuild the ledger from session usage. Cachemire
-  marks restored rows and excludes them from savings because their pricing context is
-  unknown. `/tree` rebuilds the active cache baseline from the selected path while
-  retaining the full session ledger.
+- Sessions restored with `--continue` rebuild the active ledger and all-branch cache
+  baselines from session usage. Cachemire marks restored rows and excludes them from
+  savings because their pricing context is unknown. Payload fingerprints are not
+  persisted, so restored branches use their own response-time anchor approximation until
+  live requests provide compatibility evidence.
 
 ## Understand the model behind the wording
 

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -15,9 +15,44 @@ import {
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import { GLYPH, SCALE, SEP, ink, panelHeader, type Tone } from "../_lib/style.ts";
+import { restoreBranchRecords } from "./ledger.ts";
+import {
+  cacheStateForLineage,
+  findBranchBaseline,
+  hydrateLineageResponseIds,
+  resolveCacheLineage,
+  restoreLineageSnapshots,
+} from "./lineage.ts";
 import { settleDanglingSend } from "./lifecycle.ts";
-import { activeLineageCause, branchLineageBaseline, latestBranchRefreshAt, restoreBranchRecords } from "./lineage.ts";
-import { promptTokens, renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
+import { renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
+import type {
+  BreakPrediction,
+  CacheLineageSnapshot,
+  CacheWindow,
+  CachemireConfig,
+  CallCause,
+  CallClassification,
+  CallRecord,
+  ModelRates,
+  RequestFingerprint,
+  RunAggregate,
+  UsageLike,
+} from "./types.ts";
+
+export type {
+  BreakPrediction,
+  CacheWindow,
+  CachemireConfig,
+  CallCause,
+  CallClassification,
+  CallRecord,
+  CauseKind,
+  ModelRates,
+  RequestFingerprint,
+  RunAggregate,
+  UsageLike,
+} from "./types.ts";
+
 /**
  * pi-cachemire — explains the cache and loop economics of a pi session.
  *
@@ -38,85 +73,6 @@ import { promptTokens, renderBreakingLine, renderHeldLine, renderMissLine, rende
  * Anthropic gets the full treatment (explicit breakpoints, 5m/1h TTL, priced writes);
  * other providers degrade honestly to observed reads and soft "likely warm/cold" wording.
  */
-
-// --- shared shapes ---------------------------------------------------------------------
-
-export interface UsageLike {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
-}
-
-export interface ModelRates {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-} // USD per Mtok
-
-export interface RequestFingerprint {
-  kind: "anthropic" | "openai-responses" | "unknown";
-  model?: string;
-  systemHash?: string;
-  toolHashes: Array<{ name: string; hash: string }>;
-  messageHashes: string[];
-  ttlMs?: number; // from observed cache_control: 5m default, 1h when ttl:"1h"; undefined = implicit/unknown
-  /** Canonical description of the thinking/reasoning request params (e.g. "thinking budget
-   * 8192", "effort high"). Anthropic documents that changing these invalidates message
-   * cache breakpoints (system/tools stay cached); OpenAI's effort lives outside the
-   * prompt prefix, so there it is forensic context, not a predicted break. */
-  thinking?: string;
-}
-
-export type CauseKind =
-  | "cold" | "ttl" | "compaction" | "compaction-work" | "model" | "thinking" | "system"
-  | "tools" | "history" | "replica" | "restored" | "unknown";
-
-export interface CallCause { kind: CauseKind; detail: string }
-
-export interface CallClassification {
-  kind: "cold" | "hit" | "partial" | "miss";
-  cause?: CallCause;
-}
-
-export interface CallRecord {
-  index: number;
-  at: number;
-  /** Request-start anchor (when the provider wrote/refreshed this call's cache entry);
-   * `at` is response end. Absent on restored records, whose timestamps are response-ish. */
-  requestAt?: number;
-  gapMs?: number;
-  usage: UsageLike;
-  expectedRead: number;
-  classification: CallClassification;
-  rewroteTokens: number;
-  /** Context for the first billed provider call after session compaction. */
-  postCompaction?: { modelSwitched: boolean };
-  costUsd?: number;
-  uncachedUsd?: number; // counterfactual without caching, at this call's rates
-  restored?: boolean;
-}
-
-export interface RunAggregate {
-  startedAt: number;
-  calls: number;
-  input: number;
-  cacheRead: number;
-  cacheWrite: number;
-  output: number;
-  costUsd: number;
-}
-
-export interface CachemireConfig {
-  widget: boolean;
-  turnSummary: boolean;
-  turnSummaryMinCalls: number;
-  missWarnings: boolean;
-  missWarnUsd: number;
-  missWarnTokens: number;
-}
 
 const DEFAULT_CONFIG: CachemireConfig = {
   widget: true,
@@ -148,11 +104,6 @@ function inferAnthropicTtlMs(env: Record<string, string | undefined> = process.e
 //              "always removed within one hour of the cache's last use" (a hard cap, so
 //              past it "cold" is definite even without a TTL contract)
 //   unknown  — anything else: soft language only
-export type CacheWindow =
-  | { kind: "contract"; ttlMs: number; source: "observed" | "inferred" }
-  | { kind: "band"; softMs: number; hardMs: number }
-  | { kind: "unknown" };
-
 const OPENAI_WINDOW: CacheWindow = { kind: "band", softMs: TTL_SHORT_MS, hardMs: TTL_LONG_MS };
 const UNKNOWN_WINDOW: CacheWindow = { kind: "unknown" };
 
@@ -485,13 +436,6 @@ function classifyCall(args: ClassifyInput): CallClassification {
 // notice sit between the user's action and the response — where the causality lives —
 // and the resolved actuals replace it in place when usage arrives.
 
-export interface BreakPrediction {
-  cause: CallCause;
-  /** Expected re-write size (last call's prompt). undefined when unknowable (compaction). */
-  expectedRewriteTokens?: number;
-  expectedUsd?: number;
-}
-
 function predictBreak(args: {
   isFirst: boolean;
   inCompaction: boolean;
@@ -517,7 +461,7 @@ function predictBreak(args: {
     // Model switches break the cache for certain (caches are per-model on every provider)
     // but the stored size is denominated in the *old* model's tokenizer — withhold it
     // rather than show a number in the wrong currency.
-    if (args.fingerprintCause.kind === "model") return { cause: args.fingerprintCause };
+    if (args.fingerprintCause.kind === "model" || args.fingerprintCause.kind === "compaction") return { cause: args.fingerprintCause };
     if (args.fingerprintCause.kind === "thinking") {
       // Anthropic documents this break (messages invalidate; system/tools stay cached), so
       // a contract window earns an in-flight claim — unsized, because the surviving
@@ -759,8 +703,12 @@ interface CachemireState {
   config: CachemireConfig;
   notifyFallback?: (plainText: string) => void;
   records: CallRecord[];
-  prevFingerprint?: RequestFingerprint;
+  lineages: CacheLineageSnapshot[];
   pendingFingerprint?: RequestFingerprint;
+  pendingFingerprintCause?: CallCause;
+  pendingLineageCandidates?: CacheLineageSnapshot[];
+  pendingRequestLeafId?: string | null;
+  pendingRequestWindow?: CacheWindow;
   pendingRequestAt?: number;
   pendingPreviousCacheAt?: number;
   pendingCacheGapMs?: number;
@@ -782,16 +730,11 @@ interface CachemireState {
   providerLabel?: string;
   compacted: boolean;
   inCompaction: boolean;
-  treeRebased: boolean;
   /** Chat lines cachemire appended, with anchors for re-attachment after pi rebuilds. */
   anchored: AnchoredLine[];
   /** Cached chat container: rebuilds empty it of recognizable rows, but the instance
    * lives for the whole interactive session, so the first find stays valid. */
   chat?: ContainerLike;
-  /** Records before this index belong to a dead cache lineage (pre-compaction, or before
-   * a model/system/tools/history/thinking change): entries the current prefix cannot
-   * read, so entry matching never names them. */
-  lineageStart: number;
   /** In-flight break notice placed at request time; resolved in place when usage arrives. */
   pendingNotice?: Text;
   run?: RunAggregate;
@@ -814,15 +757,14 @@ function state(): CachemireState {
     g.__piCachemire = {
       config: DEFAULT_CONFIG,
       records: [],
+      lineages: [],
       window: UNKNOWN_WINDOW,
       modelSwitched: false,
       thinkingChanged: false,
       expectedRead: 0,
       compacted: false,
       inCompaction: false,
-      treeRebased: false,
       anchored: [],
-      lineageStart: 0,
     };
   }
   return g.__piCachemire;
@@ -892,45 +834,33 @@ export default function piCachemire(pi: ExtensionAPI): void {
     if (g.__piCachemireOwner !== undefined && !ownsState()) return;
     g.__piCachemireOwner = ownerToken;
     s.config = loadConfig(process.cwd());
-    s.treeRebased = false;
-    const { messages } = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId());
+    const entries = ctx.sessionManager.getEntries();
+    const { messages } = buildSessionContext(entries, ctx.sessionManager.getLeafId());
     s.records = restoreBranchRecords(messages as unknown as Array<Record<string, unknown>>, classifyCall);
-    let restoredModelId: string | undefined;
-    for (let i = messages.length - 1; i >= 0 && restoredModelId === undefined; i--) {
-      const message = messages[i]!;
-      if (message.role === "assistant") restoredModelId = message.model;
-    }
+    s.lineages = restoreLineageSnapshots(entries, windowForProvider);
+    const baseline = findBranchBaseline(entries, ctx.sessionManager.getLeafId(), s.lineages);
     const model = ctx.model;
     if (model) {
       s.rates = model.cost;
       s.currentModelId = model.id;
       s.modelLabel = `${model.provider}/${model.id}`;
     }
-    // Settings restore with the session, so the current level stands in for the level of
-    // the session's last billed call. Note: getThinkingLevel lives on the runtime API
-    // (`pi`), not the per-event ctx (contract-pinned in tests/contract).
+    Object.assign(s, cacheStateForLineage(
+      { baseline, refresh: baseline, compatible: [] },
+      model?.provider,
+      model?.id,
+      baseline?.window ?? windowForProvider(model?.provider) ?? UNKNOWN_WINDOW,
+    ));
+    s.prevCallRequestAt = s.records.at(-1)?.at || undefined;
     s.lastCallThinkingLevel = s.currentThinkingLevel = pi.getThinkingLevel();
-    // Restored sessions get the provider's real freshness window immediately (anthropic:
-    // inferred contract TTL; openai: documented band); the first live request's observed
-    // payload replaces the inference.
-    if (s.window.kind === "unknown") s.window = windowForProvider(model?.provider) ?? UNKNOWN_WINDOW;
-    if (s.records.length > 0) {
-      const last = s.records[s.records.length - 1]!;
-      s.expectedRead = last.usage.input + last.usage.cacheRead + last.usage.cacheWrite;
-      s.cachedTokens = s.expectedRead;
-      // Message timestamps are response-end-ish; the true TTL anchor (request processing
-      // start) is slightly earlier, so this is marginally optimistic — irrelevant at the
-      // hours-scale gaps where restore matters.
-      s.lastRequestAt = last.at || undefined;
-      s.prevCallRequestAt = last.at || undefined;
-      // Caches are per-model: a restored session resumed under a different model is cold,
-      // and cachedTokens is denominated in the old model's tokenizer.
-      s.lastCallModelId = restoredModelId ?? s.lastCallModelId;
-      s.modelSwitched = s.lastCallModelId !== undefined && model?.id !== undefined && s.lastCallModelId !== model.id;
-      // Restored under a different model: the restored entries are unreadable (caches are
-      // per-model), so they are out of lineage for entry matching from the start.
-      if (s.modelSwitched) s.lineageStart = s.records.length;
-    }
+    s.compacted = false;
+    s.inCompaction = false;
+    s.pendingFingerprint = undefined;
+    s.pendingFingerprintCause = undefined;
+    s.pendingLineageCandidates = undefined;
+    s.pendingRequestAt = s.pendingPreviousCacheAt = s.pendingCacheGapMs = undefined;
+    s.pendingRequestLeafId = undefined;
+    s.pendingRequestWindow = undefined;
     if (!ctx.hasUI) return;
     s.ui = ctx.ui;
     s.theme = ctx.ui.theme;
@@ -949,30 +879,48 @@ export default function piCachemire(pi: ExtensionAPI): void {
     g.__piCachemireOwner = undefined;
   });
 
-  pi.on("before_provider_request", async (event) => {
+  pi.on("before_provider_request", async (event, ctx) => {
     if (!ownsState()) return;
+    const firstAttempt = s.pendingRequestAt === undefined;
     s.pendingFingerprint = fingerprintPayload(event.payload);
     const requestAt = Date.now();
-    if (s.pendingRequestAt === undefined) {
-      s.pendingPreviousCacheAt = s.lastRequestAt;
-      s.pendingCacheGapMs = s.lastRequestAt !== undefined ? requestAt - s.lastRequestAt : undefined;
-    }
-    s.pendingRequestAt = requestAt;
-    // TTL anchor = request start: providers read/refresh/write cache entries while
-    // processing the request input (entries become available once the response *begins*),
-    // so the freshness window burns during generation — a long thinking block eats into it.
-    s.lastRequestAt = s.pendingRequestAt;
-    // Observation is authoritative per provider kind: anthropic payloads carry the real
-    // cache_control TTL; openai-responses requests get the documented eviction band.
+    const entries = ctx.sessionManager.getEntries();
+    hydrateLineageResponseIds(s.lineages, entries, windowForProvider);
+    const resolution = resolveCacheLineage({
+      entries,
+      activeLeafId: ctx.sessionManager.getLeafId(),
+      snapshots: s.lineages,
+      currentProvider: ctx.model?.provider,
+      currentModel: ctx.model?.id ?? s.pendingFingerprint.model,
+      currentFingerprint: s.pendingFingerprint,
+      compareFingerprints: diffFingerprints,
+    });
+    Object.assign(s, cacheStateForLineage(
+      resolution,
+      ctx.model?.provider,
+      ctx.model?.id ?? s.pendingFingerprint.model,
+      s.window,
+    ));
+    s.pendingFingerprintCause = resolution.cause;
+    s.pendingLineageCandidates = resolution.compatible;
+    s.pendingRequestLeafId = ctx.sessionManager.getLeafId();
+    if (firstAttempt) s.pendingPreviousCacheAt = s.lastRequestAt;
+    s.pendingCacheGapMs = s.lastRequestAt !== undefined ? requestAt - s.lastRequestAt : undefined;
     if (s.pendingFingerprint.kind === "anthropic") {
-      s.window = s.pendingFingerprint.ttlMs !== undefined
+      s.pendingRequestWindow = s.pendingFingerprint.ttlMs !== undefined
         ? { kind: "contract", ttlMs: s.pendingFingerprint.ttlMs, source: "observed" }
-        : UNKNOWN_WINDOW; // cacheRetention "none": no breakpoints were sent
+        : UNKNOWN_WINDOW;
       s.providerLabel = "anthropic";
     } else if (s.pendingFingerprint.kind === "openai-responses") {
-      s.window = OPENAI_WINDOW;
+      s.pendingRequestWindow = OPENAI_WINDOW;
       s.providerLabel = "openai";
+    } else {
+      s.pendingRequestWindow = UNKNOWN_WINDOW;
     }
+    s.window = s.pendingRequestWindow;
+    s.pendingRequestAt = requestAt;
+    // Optimistically anchor the in-flight request; agent_end rolls it back if no usage arrives.
+    s.lastRequestAt = requestAt;
 
     // Place the break notice where the causality lives: between the user's action and the
     // response. It shows the expectation now and is resolved in place when usage arrives.
@@ -984,7 +932,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
         gapMs: s.pendingCacheGapMs,
         window: s.window,
         expectedRead: s.expectedRead,
-        fingerprintCause: activeLineageCause(s.prevFingerprint, s.pendingFingerprint, s.treeRebased, diffFingerprints),
+        fingerprintCause: s.pendingFingerprintCause,
         rates: s.rates,
       });
       const material = prediction !== undefined && (
@@ -1040,14 +988,18 @@ export default function piCachemire(pi: ExtensionAPI): void {
   pi.on("session_tree", async (event, ctx) => {
     if (!ownsState()) return;
     const entries = ctx.sessionManager.getEntries();
-    const { messages } = buildSessionContext(entries, event.newLeafId);
-    const baseline = branchLineageBaseline(messages);
-    const branchRootId = event.summaryEntry?.parentId ?? event.newLeafId;
-    const refreshAt = latestBranchRefreshAt(entries, branchRootId) ?? baseline?.at;
-    s.expectedRead = baseline?.promptTokens ?? 0;
-    s.cachedTokens = baseline?.promptTokens;
-    s.lastRequestAt = refreshAt;
-    s.treeRebased = true;
+    hydrateLineageResponseIds(s.lineages, entries, windowForProvider);
+    const baseline = findBranchBaseline(entries, event.newLeafId, s.lineages);
+    const resolution = resolveCacheLineage({
+      entries,
+      activeLeafId: event.newLeafId,
+      snapshots: s.lineages,
+      currentProvider: ctx.model?.provider,
+      currentModel: ctx.model?.id,
+      currentFingerprint: baseline?.fingerprint,
+      compareFingerprints: diffFingerprints,
+    });
+    Object.assign(s, cacheStateForLineage(resolution, ctx.model?.provider, ctx.model?.id, s.window));
     updateWidget();
   });
 
@@ -1074,20 +1026,17 @@ export default function piCachemire(pi: ExtensionAPI): void {
     const gapMs = s.prevCallRequestAt !== undefined ? requestAt - s.prevCallRequestAt : undefined;
     const cacheGapMs = s.pendingCacheGapMs ?? gapMs;
 
-    const fingerprintCause = activeLineageCause(s.prevFingerprint, s.pendingFingerprint, s.treeRebased, diffFingerprints);
-    // Any invalidating change re-keys the cache: records before it are a dead lineage
-    // whose entries this prefix cannot read, and a 512-bucket collision with one would
-    // name an unreadable entry. Conservative on purpose — a mutation that happened to
-    // leave the cache warm still advances the boundary (false negatives degrade to the
-    // generic unknown hint; false positives would be dishonest).
-    if (s.compacted || fingerprintCause) s.lineageStart = s.records.length;
-    // Entry ages use the request-start anchor (entries are written/refreshed during
-    // request processing); restored records fall back to their response-ish message
-    // timestamp — marginally optimistic, same caveat as the restore-time TTL anchor.
+    const fingerprintCause = s.pendingFingerprintCause;
+    // Best-effort replica matching is restricted to path-compatible, fingerprint-proven
+    // snapshots. A sibling using another model or prompt shape cannot name this read.
     const entryMatch = s.window.kind === "band"
       ? matchPriorEntry(
           usage.cacheRead,
-          s.records.slice(s.lineageStart).map((record) => ({ index: record.index, at: record.requestAt ?? record.at, promptTokens: promptTokens(record.usage) })),
+          (s.pendingLineageCandidates ?? []).flatMap((snapshot) => snapshot.recordIndex === undefined ? [] : [{
+            index: snapshot.recordIndex,
+            at: snapshot.requestAt,
+            promptTokens: snapshot.promptTokens,
+          }]),
           requestAt,
           s.window.hardMs,
         )
@@ -1118,20 +1067,36 @@ export default function piCachemire(pi: ExtensionAPI): void {
       uncachedUsd: uncachedCostUsd(usage, s.rates),
     };
     s.records.push(record);
+    const promptSize = usage.input + usage.cacheRead + usage.cacheWrite;
+    s.lineages.push({
+      requestLeafId: s.pendingRequestLeafId ?? null,
+      responseAt: typeof message.timestamp === "number" ? message.timestamp : now,
+      requestAt,
+      promptTokens: promptSize,
+      cacheRead: usage.cacheRead,
+      cacheWrite: usage.cacheWrite,
+      provider: message.provider,
+      model: message.model,
+      fingerprint: s.pendingFingerprint,
+      window: s.pendingRequestWindow ?? s.window,
+      recordIndex: record.index,
+    });
     s.compacted = false;
-    s.treeRebased = false;
-    s.prevFingerprint = s.pendingFingerprint ?? s.prevFingerprint;
     s.prevCallRequestAt = requestAt;
     // Usage arrived: the anchor this request claimed at send time is provider-confirmed.
-    // Consume the pending pair — whatever is still pending at agent_end never got usage.
     s.pendingFingerprint = undefined;
+    s.pendingFingerprintCause = undefined;
+    s.pendingLineageCandidates = undefined;
     s.pendingRequestAt = undefined;
+    s.pendingRequestLeafId = undefined;
     s.pendingPreviousCacheAt = undefined;
     s.pendingCacheGapMs = undefined;
-    s.expectedRead = usage.input + usage.cacheRead + usage.cacheWrite;
-    s.cachedTokens = s.expectedRead;
+    s.expectedRead = promptSize;
+    s.cachedTokens = promptSize;
+    s.window = s.pendingRequestWindow ?? s.window;
+    s.pendingRequestWindow = undefined;
     // Fresh usage re-baselines the currency: counts are now denominated in this model.
-    s.lastCallModelId = s.currentModelId ?? s.lastCallModelId;
+    s.lastCallModelId = message.model ?? s.currentModelId ?? s.lastCallModelId;
     s.modelSwitched = false;
     s.lastCallThinkingLevel = s.currentThinkingLevel ?? s.lastCallThinkingLevel;
     s.thinkingChanged = false;
@@ -1167,6 +1132,11 @@ export default function piCachemire(pi: ExtensionAPI): void {
     updateWidget(now);
   });
 
+  pi.on("turn_end", async (_event, ctx) => {
+    if (!ownsState()) return;
+    hydrateLineageResponseIds(s.lineages, ctx.sessionManager.getEntries(), windowForProvider);
+  });
+
   pi.on("agent_end", async () => {
     if (!ownsState()) return;
     // A notice whose call never produced usage (abort/error) must not dangle as "breaking".
@@ -1178,8 +1148,12 @@ export default function piCachemire(pi: ExtensionAPI): void {
     if (settled.changed) {
       s.lastRequestAt = s.pendingPreviousCacheAt;
       s.pendingRequestAt = undefined;
+      s.pendingRequestLeafId = undefined;
       s.pendingPreviousCacheAt = undefined;
       s.pendingFingerprint = undefined;
+      s.pendingFingerprintCause = undefined;
+      s.pendingLineageCandidates = undefined;
+      s.pendingRequestWindow = undefined;
       s.pendingCacheGapMs = undefined;
       updateWidget();
     }
@@ -1221,9 +1195,10 @@ export const internals = {
   renderBreakingLine,
   renderHeldLine,
   diffFingerprints,
-  activeLineageCause,
-  branchLineageBaseline,
-  latestBranchRefreshAt,
+  findBranchBaseline,
+  hydrateLineageResponseIds,
+  resolveCacheLineage,
+  restoreLineageSnapshots,
   matchPriorEntry,
   classifyCall,
   settleDanglingSend,

--- a/extensions/pi-cachemire/ledger.ts
+++ b/extensions/pi-cachemire/ledger.ts
@@ -1,0 +1,47 @@
+import type { CallClassification, CallRecord, UsageLike } from "./types.ts";
+
+type RestoreClassifier = (args: {
+  isFirst: boolean;
+  gapMs?: number;
+  usage: UsageLike;
+  expectedRead: number;
+}) => CallClassification;
+
+/** Rebuild active-branch ledger rows without inventing request-time causes. */
+export function restoreBranchRecords(
+  messages: Array<Record<string, unknown>>,
+  classify: RestoreClassifier,
+): CallRecord[] {
+  const records: CallRecord[] = [];
+  let previousAt: number | undefined;
+  let expectedRead = 0;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    const usage = message.usage as UsageLike | undefined;
+    if (!usage || (usage.input === 0 && usage.output === 0 && usage.cacheRead === 0 && usage.cacheWrite === 0)) continue;
+    const at = typeof message.timestamp === "number" ? message.timestamp : 0;
+    const classification = classify({
+      isFirst: records.length === 0,
+      gapMs: previousAt !== undefined ? at - previousAt : undefined,
+      usage,
+      expectedRead,
+    });
+    if (classification.cause && classification.kind !== "cold" && classification.kind !== "hit") {
+      classification.cause = { kind: "restored", detail: "restored session (cause unknown)" };
+    }
+    records.push({
+      index: records.length + 1,
+      at,
+      gapMs: previousAt !== undefined ? at - previousAt : undefined,
+      usage,
+      expectedRead,
+      classification,
+      rewroteTokens: usage.cacheWrite > 0 ? usage.cacheWrite : usage.input,
+      costUsd: usage.cost?.total,
+      restored: true,
+    });
+    previousAt = at;
+    expectedRead = usage.input + usage.cacheRead + usage.cacheWrite;
+  }
+  return records;
+}

--- a/extensions/pi-cachemire/lineage.ts
+++ b/extensions/pi-cachemire/lineage.ts
@@ -1,136 +1,262 @@
 import { isJsonObject } from "../_lib/boundary.ts";
 import type {
+  CacheLineageSnapshot,
+  CacheWindow,
   CallCause,
-  CallClassification,
-  CallRecord,
   RequestFingerprint,
-  UsageLike,
-} from "./index.ts";
-
-export interface BranchLineageBaseline {
-  /** Provider-billed prompt tokens for the last call on the selected branch. */
-  promptTokens: number;
-  /** Response timestamp when the serialized message provides one. */
-  at?: number;
-}
+  ResolvedCacheLineage,
+} from "./types.ts";
 
 function nonNegativeNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
-/**
- * Recover the provider-exact prompt baseline for one resolved session branch.
- *
- * buildSessionContext() has already selected the active tree path and applied
- * compaction. This boundary parser deliberately ignores zero-usage assistant entries:
- * Pi can persist injected or aborted assistant messages that never reached a provider.
- */
-export function branchLineageBaseline(messages: readonly unknown[]): BranchLineageBaseline | undefined {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index];
-    if (!isJsonObject(message) || message.role !== "assistant" || !isJsonObject(message.usage)) continue;
-    const input = nonNegativeNumber(message.usage.input);
-    const cacheRead = nonNegativeNumber(message.usage.cacheRead);
-    const cacheWrite = nonNegativeNumber(message.usage.cacheWrite);
-    const output = nonNegativeNumber(message.usage.output);
-    if (input === undefined || cacheRead === undefined || cacheWrite === undefined || output === undefined) continue;
-    if (input === 0 && cacheRead === 0 && cacheWrite === 0 && output === 0) continue;
-    return {
-      promptTokens: input + cacheRead + cacheWrite,
-      at: nonNegativeNumber(message.timestamp),
-    };
-  }
-  return undefined;
+function billedSnapshotFromEntry(
+  entry: unknown,
+  windowForProvider: (provider: string | undefined) => CacheWindow | undefined,
+): CacheLineageSnapshot | undefined {
+  if (
+    !isJsonObject(entry) || entry.type !== "message" || typeof entry.id !== "string" ||
+    !isJsonObject(entry.message) || entry.message.role !== "assistant" || !isJsonObject(entry.message.usage)
+  ) return undefined;
+  const input = nonNegativeNumber(entry.message.usage.input);
+  const output = nonNegativeNumber(entry.message.usage.output);
+  const cacheRead = nonNegativeNumber(entry.message.usage.cacheRead);
+  const cacheWrite = nonNegativeNumber(entry.message.usage.cacheWrite);
+  if (input === undefined || output === undefined || cacheRead === undefined || cacheWrite === undefined) return undefined;
+  if (input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0) return undefined;
+  const messageAt = nonNegativeNumber(entry.message.timestamp);
+  const entryAt = typeof entry.timestamp === "string" ? Date.parse(entry.timestamp) : Number.NaN;
+  const responseAt = messageAt ?? (Number.isFinite(entryAt) ? entryAt : 0);
+  const provider = typeof entry.message.provider === "string" ? entry.message.provider : undefined;
+  return {
+    requestLeafId: typeof entry.parentId === "string" ? entry.parentId : null,
+    responseEntryId: entry.id,
+    responseAt,
+    requestAt: responseAt,
+    promptTokens: input + cacheRead + cacheWrite,
+    cacheRead,
+    cacheWrite,
+    provider,
+    model: typeof entry.message.model === "string" ? entry.message.model : undefined,
+    window: windowForProvider(provider),
+  };
 }
 
-function billedAssistantAt(entry: unknown): number | undefined {
-  if (!isJsonObject(entry) || entry.type !== "message" || !isJsonObject(entry.message)) return undefined;
-  const baseline = branchLineageBaseline([entry.message]);
-  return baseline?.at;
-}
-
-/** Latest provider call whose session path contains the selected branch root. */
-export function latestBranchRefreshAt(
+/** Restore every normal provider call in the session tree, not only the active branch. */
+export function restoreLineageSnapshots(
   entries: readonly unknown[],
-  branchRootId: string | null,
-): number | undefined {
-  if (branchRootId === null) return undefined;
+  windowForProvider: (provider: string | undefined) => CacheWindow | undefined,
+): CacheLineageSnapshot[] {
+  return entries
+    .map((entry) => billedSnapshotFromEntry(entry, windowForProvider))
+    .filter((snapshot): snapshot is CacheLineageSnapshot => snapshot !== undefined);
+}
+
+function responseLinkKey(snapshot: CacheLineageSnapshot): string {
+  return JSON.stringify([
+    snapshot.requestLeafId,
+    snapshot.responseAt,
+    snapshot.promptTokens,
+    snapshot.provider,
+    snapshot.model,
+  ]);
+}
+
+/** Link live snapshots after Pi persists their assistant response entries. */
+export function hydrateLineageResponseIds(
+  snapshots: CacheLineageSnapshot[],
+  entries: readonly unknown[],
+  windowForProvider: (provider: string | undefined) => CacheWindow | undefined,
+): void {
+  const unresolved = snapshots.filter((snapshot) => snapshot.responseEntryId === undefined);
+  if (unresolved.length === 0) return;
+  const persisted = new Map(
+    entries
+      .map((entry) => billedSnapshotFromEntry(entry, windowForProvider))
+      .filter((snapshot): snapshot is CacheLineageSnapshot => snapshot !== undefined)
+      .map((snapshot) => [responseLinkKey(snapshot), snapshot]),
+  );
+  for (const snapshot of unresolved) {
+    const match = persisted.get(responseLinkKey(snapshot));
+    if (match) snapshot.responseEntryId = match.responseEntryId;
+  }
+}
+
+function parentIndex(entries: readonly unknown[]): Map<string, string | null> {
   const parents = new Map<string, string | null>();
   for (const entry of entries) {
     if (!isJsonObject(entry) || typeof entry.id !== "string") continue;
     parents.set(entry.id, typeof entry.parentId === "string" ? entry.parentId : null);
   }
-  const descendsFromRoot = (entryId: string): boolean => {
-    let current: string | null | undefined = entryId;
-    const seen = new Set<string>();
-    while (current !== null && current !== undefined && !seen.has(current)) {
-      if (current === branchRootId) return true;
-      seen.add(current);
-      current = parents.get(current);
-    }
-    return false;
-  };
-  let latest: number | undefined;
+  return parents;
+}
+
+/** Nearest provider-billed request or response anchored on the active session path. */
+export function findBranchBaseline(
+  entries: readonly unknown[],
+  activeLeafId: string | null,
+  snapshots: readonly CacheLineageSnapshot[],
+): CacheLineageSnapshot | undefined {
+  if (activeLeafId === null) return undefined;
+  const parents = parentIndex(entries);
+  const reversePath: string[] = [];
+  let current: string | null | undefined = activeLeafId;
+  const seen = new Set<string>();
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    reversePath.push(current);
+    current = parents.get(current);
+  }
+  const depth = new Map(reversePath.reverse().map((id, index) => [id, index]));
+  let nearest: { snapshot: CacheLineageSnapshot; depth: number } | undefined;
+  for (const snapshot of snapshots) {
+    const responseDepth = snapshot.responseEntryId === undefined ? undefined : depth.get(snapshot.responseEntryId);
+    const requestDepth = snapshot.requestLeafId === null ? undefined : depth.get(snapshot.requestLeafId);
+    const anchorDepth = responseDepth ?? requestDepth;
+    if (anchorDepth === undefined) continue;
+    if (
+      !nearest || anchorDepth > nearest.depth ||
+      (anchorDepth === nearest.depth && snapshot.requestAt > nearest.snapshot.requestAt)
+    ) nearest = { snapshot, depth: anchorDepth };
+  }
+  return nearest?.snapshot;
+}
+
+function descendantsOf(entries: readonly unknown[], rootId: string): Set<string> {
+  const children = new Map<string, string[]>();
   for (const entry of entries) {
-    if (!isJsonObject(entry) || typeof entry.id !== "string" || !descendsFromRoot(entry.id)) continue;
-    const at = billedAssistantAt(entry);
-    if (at !== undefined && (latest === undefined || at > latest)) latest = at;
+    if (!isJsonObject(entry) || typeof entry.id !== "string" || typeof entry.parentId !== "string") continue;
+    children.set(entry.parentId, [...(children.get(entry.parentId) ?? []), entry.id]);
   }
-  return latest;
+  const descendants = new Set<string>();
+  const pending = [rootId];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (descendants.has(current)) continue;
+    descendants.add(current);
+    pending.push(...(children.get(current) ?? []));
+  }
+  return descendants;
 }
 
-export function activeLineageCause(
-  prev: RequestFingerprint | undefined,
-  cur: RequestFingerprint | undefined,
-  treeRebased: boolean,
-  diff: (a: RequestFingerprint, b: RequestFingerprint) => CallCause | undefined,
+function identityCause(
+  baseline: CacheLineageSnapshot,
+  provider: string | undefined,
+  model: string | undefined,
 ): CallCause | undefined {
-  const cause = prev && cur ? diff(prev, cur) : undefined;
-  return treeRebased && cause?.kind === "history" ? undefined : cause;
+  const providerChanged = baseline.provider !== undefined && provider !== undefined && baseline.provider !== provider;
+  const modelChanged = baseline.model !== undefined && model !== undefined && baseline.model !== model;
+  if (!providerChanged && !modelChanged) return undefined;
+  const before = [baseline.provider, baseline.model].filter(Boolean).join("/") || "previous model";
+  const after = [provider, model].filter(Boolean).join("/") || "current model";
+  return { kind: "model", detail: `model switched ${before} → ${after}` };
 }
 
-type RestoreClassifier = (args: {
-  isFirst: boolean;
-  gapMs?: number;
-  usage: UsageLike;
-  expectedRead: number;
-}) => CallClassification;
+function sameIdentity(a: CacheLineageSnapshot, b: CacheLineageSnapshot): boolean {
+  return (a.provider === undefined || b.provider === undefined || a.provider === b.provider) &&
+    (a.model === undefined || b.model === undefined || a.model === b.model);
+}
 
-/** Rebuild persisted ledger rows without inventing request-time causes. */
-export function restoreBranchRecords(
-  messages: Array<Record<string, unknown>>,
-  classify: RestoreClassifier,
-): CallRecord[] {
-  const records: CallRecord[] = [];
-  let previousAt: number | undefined;
-  let expectedRead = 0;
-  for (const message of messages) {
-    if (message.role !== "assistant") continue;
-    const usage = message.usage as UsageLike | undefined;
-    if (!usage || (usage.input === 0 && usage.output === 0 && usage.cacheRead === 0 && usage.cacheWrite === 0)) continue;
-    const at = typeof message.timestamp === "number" ? message.timestamp : 0;
-    const classification = classify({
-      isFirst: records.length === 0,
-      gapMs: previousAt !== undefined ? at - previousAt : undefined,
-      usage,
-      expectedRead,
-    });
-    if (classification.cause && classification.kind !== "cold" && classification.kind !== "hit") {
-      classification.cause = { kind: "restored", detail: "restored session (cause unknown)" };
-    }
-    records.push({
-      index: records.length + 1,
-      at,
-      gapMs: previousAt !== undefined ? at - previousAt : undefined,
-      usage,
-      expectedRead,
-      classification,
-      rewroteTokens: usage.cacheWrite > 0 ? usage.cacheWrite : usage.input,
-      costUsd: usage.cost?.total,
-      restored: true,
-    });
-    previousAt = at;
-    expectedRead = usage.input + usage.cacheRead + usage.cacheWrite;
+function sameWindow(a: CacheWindow | undefined, b: CacheWindow | undefined): boolean {
+  if (!a || !b || a.kind !== b.kind) return false;
+  if (a.kind === "contract" && b.kind === "contract") return a.ttlMs === b.ttlMs;
+  if (a.kind === "band" && b.kind === "band") return a.softMs === b.softMs && a.hardMs === b.hardMs;
+  return a.kind === "unknown" && b.kind === "unknown";
+}
+
+function pathContainsCompaction(
+  entries: readonly unknown[],
+  leafId: string | null,
+  baseline: CacheLineageSnapshot,
+): boolean {
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const entry of entries) {
+    if (isJsonObject(entry) && typeof entry.id === "string") byId.set(entry.id, entry);
   }
-  return records;
+  const stopIds = new Set(
+    [baseline.responseEntryId, baseline.requestLeafId].filter((id): id is string => id !== undefined && id !== null),
+  );
+  let current = leafId;
+  const seen = new Set<string>();
+  while (current !== null && !stopIds.has(current) && !seen.has(current)) {
+    seen.add(current);
+    const entry = byId.get(current);
+    if (!entry) return false;
+    if (entry.type === "compaction") return true;
+    current = typeof entry.parentId === "string" ? entry.parentId : null;
+  }
+  return false;
+}
+
+/** Project a lineage resolution onto the cache clock's baseline state. */
+export function cacheStateForLineage(
+  resolution: ResolvedCacheLineage,
+  currentProvider: string | undefined,
+  currentModel: string | undefined,
+  fallbackWindow: CacheWindow,
+): {
+  expectedRead: number;
+  cachedTokens: number | undefined;
+  lastRequestAt: number | undefined;
+  lastCallModelId: string | undefined;
+  modelSwitched: boolean;
+  window: CacheWindow;
+} {
+  const { baseline, refresh } = resolution;
+  return {
+    expectedRead: baseline?.promptTokens ?? 0,
+    cachedTokens: baseline?.promptTokens,
+    lastRequestAt: refresh?.requestAt,
+    lastCallModelId: baseline?.model,
+    modelSwitched:
+      (baseline?.provider !== undefined && currentProvider !== undefined && baseline.provider !== currentProvider) ||
+      (baseline?.model !== undefined && currentModel !== undefined && baseline.model !== currentModel),
+    window: refresh?.window ?? fallbackWindow,
+  };
+}
+
+/**
+ * Resolve the provider-known prefix for the active path and every compatible request
+ * that could have refreshed it. Conversation branching is handled by ancestry; payload
+ * compatibility is handled by the baseline fingerprint being a prefix of each request.
+ */
+export function resolveCacheLineage(args: {
+  entries: readonly unknown[];
+  activeLeafId: string | null;
+  snapshots: readonly CacheLineageSnapshot[];
+  currentProvider?: string;
+  currentModel?: string;
+  currentFingerprint?: RequestFingerprint;
+  compareFingerprints: (baseline: RequestFingerprint, current: RequestFingerprint) => CallCause | undefined;
+}): ResolvedCacheLineage {
+  const baseline = findBranchBaseline(args.entries, args.activeLeafId, args.snapshots);
+  if (!baseline) return { compatible: [] };
+  let cause = identityCause(baseline, args.currentProvider, args.currentModel) ??
+    (baseline.fingerprint && args.currentFingerprint
+      ? args.compareFingerprints(baseline.fingerprint, args.currentFingerprint)
+      : undefined);
+  if (
+    cause?.kind === "history" &&
+    pathContainsCompaction(args.entries, args.activeLeafId, baseline)
+  ) {
+    cause = { kind: "compaction", detail: "selected path contains a compaction checkpoint" };
+  }
+  if (cause) return { baseline, refresh: baseline, compatible: [], cause };
+
+  const descendants = baseline.responseEntryId
+    ? descendantsOf(args.entries, baseline.responseEntryId)
+    : new Set<string>();
+  const compatible = args.snapshots.filter((candidate) => {
+    if (candidate === baseline) return true;
+    if (candidate.requestLeafId === null || !descendants.has(candidate.requestLeafId)) return false;
+    if (!sameIdentity(baseline, candidate) || !sameWindow(baseline.window, candidate.window)) return false;
+    if (!baseline.fingerprint || !candidate.fingerprint) return false;
+    return args.compareFingerprints(baseline.fingerprint, candidate.fingerprint) === undefined;
+  });
+  const refresh = compatible.reduce<CacheLineageSnapshot | undefined>(
+    (latest, candidate) => !latest || candidate.requestAt > latest.requestAt ? candidate : latest,
+    undefined,
+  );
+  return { baseline, refresh, compatible };
 }

--- a/extensions/pi-cachemire/render.ts
+++ b/extensions/pi-cachemire/render.ts
@@ -1,6 +1,6 @@
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import { SEP } from "../_lib/style.ts";
-import type { BreakPrediction, CallRecord, RunAggregate, UsageLike } from "./index.ts";
+import type { BreakPrediction, CallRecord, RunAggregate, UsageLike } from "./types.ts";
 
 export function promptTokens(usage: UsageLike): number {
   return usage.input + usage.cacheRead + usage.cacheWrite;

--- a/extensions/pi-cachemire/types.ts
+++ b/extensions/pi-cachemire/types.ts
@@ -1,0 +1,109 @@
+export interface UsageLike {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+}
+
+export interface ModelRates {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+export interface RequestFingerprint {
+  kind: "anthropic" | "openai-responses" | "unknown";
+  model?: string;
+  systemHash?: string;
+  toolHashes: Array<{ name: string; hash: string }>;
+  messageHashes: string[];
+  ttlMs?: number;
+  /** Canonical thinking/reasoning wire parameters. */
+  thinking?: string;
+}
+
+export type CauseKind =
+  | "cold" | "ttl" | "compaction" | "compaction-work" | "model" | "thinking" | "system"
+  | "tools" | "history" | "replica" | "restored" | "unknown";
+
+export interface CallCause { kind: CauseKind; detail: string }
+
+export interface CallClassification {
+  kind: "cold" | "hit" | "partial" | "miss";
+  cause?: CallCause;
+}
+
+export interface CallRecord {
+  index: number;
+  at: number;
+  /** Request-start anchor; `at` is response end. Absent on restored records. */
+  requestAt?: number;
+  gapMs?: number;
+  usage: UsageLike;
+  expectedRead: number;
+  classification: CallClassification;
+  rewroteTokens: number;
+  postCompaction?: { modelSwitched: boolean };
+  costUsd?: number;
+  uncachedUsd?: number;
+  restored?: boolean;
+}
+
+export interface RunAggregate {
+  startedAt: number;
+  calls: number;
+  input: number;
+  cacheRead: number;
+  cacheWrite: number;
+  output: number;
+  costUsd: number;
+}
+
+export interface CachemireConfig {
+  widget: boolean;
+  turnSummary: boolean;
+  turnSummaryMinCalls: number;
+  missWarnings: boolean;
+  missWarnUsd: number;
+  missWarnTokens: number;
+}
+
+export type CacheWindow =
+  | { kind: "contract"; ttlMs: number; source: "observed" | "inferred" }
+  | { kind: "band"; softMs: number; hardMs: number }
+  | { kind: "unknown" };
+
+export interface BreakPrediction {
+  cause: CallCause;
+  /** Last provider-known prompt size; absent when token currency or the new prefix is unknown. */
+  expectedRewriteTokens?: number;
+  expectedUsd?: number;
+}
+
+/** One provider-billed request anchored to the session path it serialized. */
+export interface CacheLineageSnapshot {
+  /** Last persisted session entry included in this provider request. */
+  requestLeafId: string | null;
+  /** Assistant response entry created by the request, linked after message persistence. */
+  responseEntryId?: string;
+  responseAt: number;
+  requestAt: number;
+  promptTokens: number;
+  cacheRead: number;
+  cacheWrite: number;
+  provider?: string;
+  model?: string;
+  fingerprint?: RequestFingerprint;
+  window?: CacheWindow;
+  /** Chronological ledger row for live calls; restored all-branch snapshots omit it. */
+  recordIndex?: number;
+}
+
+export interface ResolvedCacheLineage {
+  baseline?: CacheLineageSnapshot;
+  refresh?: CacheLineageSnapshot;
+  compatible: CacheLineageSnapshot[];
+  cause?: CallCause;
+}

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -5,7 +5,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 1247,
+      "extensions/pi-cachemire/index.ts": 1222,
       "extensions/pi-contextimate/index.ts": 1959,
       "extensions/pi-traceline/index.ts": 1766,
       "tests/cachemire/economics-and-render.test.ts": 352,

--- a/tests/cachemire/tree-lineage.test.ts
+++ b/tests/cachemire/tree-lineage.test.ts
@@ -3,9 +3,19 @@ import assert from "node:assert/strict";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import piCachemire, { internals } from "../../extensions/pi-cachemire/index.ts";
+import type { CacheLineageSnapshot, CacheWindow } from "../../extensions/pi-cachemire/types.ts";
 
-const { activeLineageCause, branchLineageBaseline, diffFingerprints, fingerprintPayload, latestBranchRefreshAt } = internals;
+const {
+  diffFingerprints,
+  findBranchBaseline,
+  fingerprintPayload,
+  hydrateLineageResponseIds,
+  predictBreak,
+  resolveCacheLineage,
+  restoreLineageSnapshots,
+} = internals;
 
+const WINDOW: CacheWindow = { kind: "contract", ttlMs: 5 * 60_000, source: "observed" };
 type Handler = (...args: unknown[]) => unknown;
 
 function extensionProbe(): { handlers: Map<string, Handler[]>; commands: Map<string, Handler> } {
@@ -40,27 +50,71 @@ function usage(input: number, cacheRead: number, cacheWrite: number, output = 10
   };
 }
 
-function assistant(timestamp: number, prompt: number) {
+function assistant(timestamp: number, prompt: number, model = "claude-opus-4-8") {
   return {
     role: "assistant",
     content: [{ type: "text", text: "answer" }],
     provider: "anthropic",
-    model: "claude-opus-4-8",
+    model,
     stopReason: "stop",
     timestamp,
     usage: usage(2, prompt - 2, 0),
   };
 }
 
-function payload(messages: string[]) {
+function payload(
+  messages: string[],
+  options: { model?: string; system?: string; tools?: unknown[]; thinkingBudget?: number } = {},
+) {
   return {
-    model: "claude-opus-4-8",
-    system: [{ type: "text", text: "fixture", cache_control: { type: "ephemeral" } }],
+    model: options.model ?? "claude-opus-4-8",
+    system: [{ type: "text", text: options.system ?? "fixture", cache_control: { type: "ephemeral" } }],
     messages: messages.map((text) => ({ role: "user", content: [{ type: "text", text }] })),
+    ...(options.tools ? { tools: options.tools } : {}),
+    ...(options.thinkingBudget ? { thinking: { type: "enabled", budget_tokens: options.thinkingBudget } } : {}),
   };
 }
 
-function context(entries: unknown[], leafId: string, notifications: string[]) {
+function snapshotById(snapshots: CacheLineageSnapshot[], id: string): CacheLineageSnapshot {
+  return snapshots.find((snapshot) => snapshot.responseEntryId === id)!;
+}
+
+function branchedEntries(now = 30_000) {
+  return [
+    { type: "message", id: "root-user", parentId: null, message: { role: "user", content: "root", timestamp: 500 } },
+    { type: "message", id: "root", parentId: "root-user", message: assistant(1_000, 80_000) },
+    { type: "message", id: "left-user", parentId: "root", message: { role: "user", content: "left", timestamp: 2_000 } },
+    { type: "message", id: "left", parentId: "left-user", message: assistant(3_000, 100_000) },
+    { type: "message", id: "left-next-user", parentId: "left", message: { role: "user", content: "left next", timestamp: 4_000 } },
+    { type: "message", id: "left-next", parentId: "left-next-user", message: assistant(now, 110_000) },
+    { type: "message", id: "right-user", parentId: "root", message: { role: "user", content: "right", timestamp: 5_000 } },
+    { type: "message", id: "right", parentId: "right-user", message: assistant(20_000, 120_000) },
+  ];
+}
+
+function restored(entries: unknown[]): CacheLineageSnapshot[] {
+  return restoreLineageSnapshots(entries, () => WINDOW);
+}
+
+function resolve(
+  entries: unknown[],
+  snapshots: CacheLineageSnapshot[],
+  leaf: string,
+  current: ReturnType<typeof fingerprintPayload>,
+  model = "claude-opus-4-8",
+) {
+  return resolveCacheLineage({
+    entries,
+    activeLeafId: leaf,
+    snapshots,
+    currentProvider: "anthropic",
+    currentModel: model,
+    currentFingerprint: current,
+    compareFingerprints: diffFingerprints,
+  });
+}
+
+function context(entries: unknown[], leaf: { id: string }, notifications: string[]) {
   return {
     hasUI: true,
     ui: {
@@ -78,78 +132,179 @@ function context(entries: unknown[], leafId: string, notifications: string[]) {
     },
     sessionManager: {
       getEntries: () => entries,
-      getLeafId: () => leafId,
+      getLeafId: () => leaf.id,
     },
   };
 }
 
-test("branch baseline uses the selected path's last provider-billed prompt", () => {
-  const baseline = branchLineageBaseline([
-    assistant(1_000, 177_860),
-    { role: "assistant", timestamp: 2_000, usage: usage(0, 0, 0, 0) },
-  ])!;
-  assert.deepEqual(baseline, { promptTokens: 177_860, at: 1_000 });
-
-  // Observed rewind: the next request reused 177,858 and processed only 1,408
-  // uncached, rather than breaking the abandoned leaf's 179,294-token prompt.
-  assert.equal(177_858 / baseline.promptTokens > 0.99, true);
-  assert.equal(2 + 1_406, 1_408);
-  assert.equal(branchLineageBaseline([{ role: "user", content: "root" }]), undefined);
+test("restores every branch while selecting only the active path baseline", () => {
+  const entries = branchedEntries();
+  const snapshots = restored(entries);
+  assert.deepEqual(snapshots.map((snapshot) => snapshot.responseEntryId), ["root", "left", "left-next", "right"]);
+  assert.equal(findBranchBaseline(entries, "left", snapshots)?.promptTokens, 100_000);
+  assert.equal(findBranchBaseline(entries, "right", snapshots)?.promptTokens, 120_000);
+  assert.equal(
+    findBranchBaseline(entries, "left-user", snapshots)?.promptTokens,
+    100_000,
+    "a replay can reuse the prior provider call made from that exact request leaf",
+  );
+  assert.equal(findBranchBaseline(entries, null, snapshots), undefined);
+  const restoredResolution = resolve(entries, snapshots, "left", fingerprintPayload(payload(["root", "left"])));
+  assert.equal(restoredResolution.refresh?.responseEntryId, "left", "restored descendants lack compatibility proof");
 });
 
-test("branch freshness follows calls that actually contain the selected prefix", () => {
-  const entries = [
-    { type: "message", id: "root", parentId: null, message: assistant(1_000, 80_000) },
-    { type: "message", id: "left-user", parentId: "root", message: { role: "user", content: "left" } },
-    { type: "message", id: "left", parentId: "left-user", message: assistant(10_000, 100_000) },
-    { type: "message", id: "right-user", parentId: "root", message: { role: "user", content: "right" } },
-    { type: "message", id: "right", parentId: "right-user", message: assistant(20_000, 120_000) },
+test("links a live request snapshot after Pi persists its assistant response", () => {
+  const entries = branchedEntries();
+  const persisted = restored(entries)[0]!;
+  const live = { ...persisted, responseEntryId: undefined, fingerprint: fingerprintPayload(payload(["root"])) };
+  hydrateLineageResponseIds([live], entries, () => WINDOW);
+  assert.equal(live.responseEntryId, "root");
+  assert.ok(live.fingerprint);
+});
+
+test("returning to a warm branch uses its compatible descendants, not a sibling", () => {
+  const entries = branchedEntries(30_000);
+  const snapshots = restored(entries);
+  const root = snapshotById(snapshots, "root");
+  const left = snapshotById(snapshots, "left");
+  const leftNext = snapshotById(snapshots, "left-next");
+  const right = snapshotById(snapshots, "right");
+  root.fingerprint = fingerprintPayload(payload(["root"]));
+  left.fingerprint = fingerprintPayload(payload(["root", "left"]));
+  leftNext.fingerprint = fingerprintPayload(payload(["root", "left", "left next"]));
+  right.fingerprint = fingerprintPayload(payload(["root", "right"]));
+
+  const resolution = resolve(entries, snapshots, "left", fingerprintPayload(payload(["root", "left", "continued"])));
+  assert.equal(resolution.baseline, left);
+  assert.equal(resolution.refresh, leftNext);
+  assert.deepEqual(resolution.compatible, [left, leftNext]);
+  assert.equal(resolution.cause, undefined);
+});
+
+test("incompatible descendants cannot refresh the selected lineage", () => {
+  const entries = branchedEntries(40_000);
+  const tool = { name: "read", input_schema: { type: "object" } };
+  const baseOptions = { tools: [tool], thinkingBudget: 8_192 };
+  const variants = [
+    { ...baseOptions, system: "changed" },
+    { ...baseOptions, tools: [{ ...tool, description: "changed" }] },
+    { ...baseOptions, thinkingBudget: 16_384 },
+    { ...baseOptions, model: "claude-fable-5" },
   ];
-  assert.equal(latestBranchRefreshAt(entries, "left-user"), 10_000, "a sibling call cannot refresh this branch");
-  assert.equal(latestBranchRefreshAt(entries, "root"), 20_000, "both siblings refresh their common prefix");
-  assert.equal(latestBranchRefreshAt(entries, null), undefined);
+  for (const options of variants) {
+    const snapshots = restored(entries);
+    const left = snapshotById(snapshots, "left");
+    const leftNext = snapshotById(snapshots, "left-next");
+    left.fingerprint = fingerprintPayload(payload(["root", "left"], baseOptions));
+    leftNext.fingerprint = fingerprintPayload(payload(["root", "left", "left next"], options));
+    const current = fingerprintPayload(payload(["root", "left", "continued"], baseOptions));
+    const resolution = resolve(entries, snapshots, "left", current);
+    assert.equal(resolution.refresh, left);
+    assert.deepEqual(resolution.compatible, [left]);
+  }
+  for (const mutate of [
+    (snapshot: CacheLineageSnapshot) => { snapshot.provider = "openai"; },
+    (snapshot: CacheLineageSnapshot) => { snapshot.window = { kind: "contract", ttlMs: 60 * 60_000, source: "observed" }; },
+  ]) {
+    const snapshots = restored(entries);
+    const left = snapshotById(snapshots, "left");
+    const leftNext = snapshotById(snapshots, "left-next");
+    left.fingerprint = fingerprintPayload(payload(["root", "left"], baseOptions));
+    leftNext.fingerprint = fingerprintPayload(payload(["root", "left", "left next"], baseOptions));
+    mutate(leftNext);
+    const resolution = resolve(entries, snapshots, "left", fingerprintPayload(payload(["root", "left"], baseOptions)));
+    assert.deepEqual(resolution.compatible, [left]);
+  }
 });
 
-test("tree navigation suppresses only the intentional history divergence", () => {
-  const oldBranch = fingerprintPayload(payload(["base", "old branch"]));
-  const newBranch = fingerprintPayload(payload(["base", "new branch"]));
-  assert.equal(activeLineageCause(oldBranch, newBranch, true, diffFingerprints), undefined);
-  assert.equal(activeLineageCause(oldBranch, newBranch, false, diffFingerprints)?.kind, "history");
+test("suffix divergence is natural, while edited history and model changes still break", () => {
+  const entries = branchedEntries();
+  const snapshots = restored(entries);
+  const left = snapshotById(snapshots, "left");
+  left.fingerprint = fingerprintPayload(payload(["root", "left"]));
 
-  const changedSystem = fingerprintPayload({ ...payload(["base", "new branch"]), system: "changed" });
-  assert.equal(activeLineageCause(oldBranch, changedSystem, true, diffFingerprints)?.kind, "system");
+  const suffix = resolve(entries, snapshots, "left", fingerprintPayload(payload(["root", "left", "new suffix"])));
+  assert.equal(suffix.cause, undefined);
+  const edited = resolve(entries, snapshots, "left", fingerprintPayload(payload(["root", "edited"])));
+  assert.equal(edited.cause?.kind, "history");
+  const switched = resolve(
+    entries,
+    snapshots,
+    "left",
+    fingerprintPayload(payload(["root", "left"], { model: "claude-fable-5" })),
+    "claude-fable-5",
+  );
+  assert.equal(switched.cause?.kind, "model");
 });
 
-test("session_tree rebases classification to the selected branch", async () => {
+test("a selected compaction checkpoint stays unsized before provider usage", () => {
+  const entries = [
+    ...branchedEntries(),
+    { type: "compaction", id: "compact", parentId: "left", summary: "short summary", timestamp: new Date().toISOString() },
+  ];
+  const snapshots = restored(entries);
+  const left = snapshotById(snapshots, "left");
+  left.fingerprint = fingerprintPayload(payload(["root", "left"]));
+  const resolution = resolve(entries, snapshots, "compact", fingerprintPayload(payload(["summary"])));
+  assert.equal(resolution.cause?.kind, "compaction");
+  const prediction = predictBreak({
+    isFirst: false,
+    inCompaction: false,
+    compacted: false,
+    expectedRead: resolution.baseline!.promptTokens,
+    fingerprintCause: resolution.cause,
+  });
+  assert.equal(prediction?.expectedRewriteTokens, undefined);
+});
+
+test("lineage-local freshness drives TTL prediction", () => {
+  const now = 10 * 60_000;
+  const entries = branchedEntries(now - 6 * 60_000);
+  const snapshots = restored(entries);
+  const left = snapshotById(snapshots, "left");
+  const leftNext = snapshotById(snapshots, "left-next");
+  left.fingerprint = fingerprintPayload(payload(["root", "left"]));
+  leftNext.fingerprint = fingerprintPayload(payload(["root", "left", "left next"]));
+  const resolution = resolve(entries, snapshots, "left", fingerprintPayload(payload(["root", "left", "continued"])));
+  const prediction = predictBreak({
+    isFirst: false,
+    inCompaction: false,
+    compacted: false,
+    gapMs: now - resolution.refresh!.requestAt,
+    window: resolution.refresh!.window,
+    expectedRead: resolution.baseline!.promptTokens,
+  });
+  assert.equal(prediction?.cause.kind, "ttl");
+  assert.equal(prediction?.expectedRewriteTokens, 100_000);
+});
+
+test("session_tree rebases classification to the selected provider-known prompt", async () => {
   const now = Date.now();
-  const baseAssistant = assistant(now - 3_000, 100_000);
-  const oldAssistant = assistant(now - 1_000, 200_000);
   const entries = [
     { type: "message", id: "user-base", parentId: null, timestamp: new Date(now - 4_000).toISOString(), message: { role: "user", content: "base", timestamp: now - 4_000 } },
-    { type: "message", id: "assistant-base", parentId: "user-base", timestamp: new Date(now - 3_000).toISOString(), message: baseAssistant },
+    { type: "message", id: "assistant-base", parentId: "user-base", timestamp: new Date(now - 3_000).toISOString(), message: assistant(now - 3_000, 100_000) },
     { type: "message", id: "user-old", parentId: "assistant-base", timestamp: new Date(now - 2_000).toISOString(), message: { role: "user", content: "old branch", timestamp: now - 2_000 } },
-    { type: "message", id: "assistant-old", parentId: "user-old", timestamp: new Date(now - 1_000).toISOString(), message: oldAssistant },
+    { type: "message", id: "assistant-old", parentId: "user-old", timestamp: new Date(now - 1_000).toISOString(), message: assistant(now - 1_000, 200_000) },
   ];
   const notifications: string[] = [];
+  const leaf = { id: "assistant-old" };
   const probe = extensionProbe();
-  const ctx = context(entries, "assistant-old", notifications);
+  const ctx = context(entries, leaf, notifications);
 
   await fire(probe, "session_start", {}, ctx);
   try {
-    // Establish a live fingerprint and the abandoned leaf's 200k prompt baseline.
-    await fire(probe, "before_provider_request", { payload: payload(["base", "old branch"]) });
-    await fire(probe, "message_end", { message: { ...oldAssistant, usage: usage(0, 200_000, 0) } });
+    leaf.id = "assistant-base";
+    await fire(probe, "session_tree", { newLeafId: leaf.id, oldLeafId: "assistant-old" }, ctx);
+    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch"]) }, ctx);
+    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch"]) }, ctx);
+    assert.equal(notifications.length, 0, "branching must not price the abandoned 200k leaf");
+    await fire(probe, "message_end", { message: { ...assistant(now, 100_000), usage: usage(0, 90_000, 10_000) } });
 
-    // Rewind to the 100k selected-branch baseline. A 90k read is a hit against this
-    // branch, but would be misclassified as a 45% partial against the abandoned 200k leaf.
-    await fire(probe, "session_tree", { newLeafId: "assistant-base", oldLeafId: "assistant-old" }, ctx);
-    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch"]) });
-    assert.equal(notifications.length, 0, "intentional branch divergence must not emit a full-prefix warning");
-    await fire(probe, "message_end", { message: { ...baseAssistant, usage: usage(0, 90_000, 10_000) } });
-
+    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch", "aborted suffix"]) }, ctx);
+    await fire(probe, "agent_end");
     await probe.commands.get("cache")?.("", ctx);
     assert.equal(notifications.length, 1);
-    assert.match(notifications[0]!, /\s4\s+.*● hit/);
+    assert.match(notifications[0]!, /\s3\s+.*● hit/);
   } finally {
     await fire(probe, "session_shutdown", {});
   }


### PR DESCRIPTION
## What this changes

Cachemire now follows the branch you select in `/tree` when it estimates cache reuse.

Previously, Cachemire remembered one recent request. After switching branches, it could compare the next request with the branch you had left. It could also treat activity on an incompatible branch as if it had kept the selected branch warm.

Cachemire now:

- records which session branch each provider request used
- uses the last billed request on the selected branch as the comparison point
- remembers warm branches when you switch away and return during the same session
- accepts a later request as a cache refresh only when its provider, model, cache window and prompt structure match
- treats new content after a shared prefix as normal growth, so it does not warn that the whole prefix changed
- rebuilds branch baselines from saved provider usage when you continue a session
- avoids claiming that a restored branch stayed warm when the saved session does not contain enough evidence

The provider's usage report remains the final source of truth after each response.

## Why this matters

In the session that exposed the bug, Cachemire used the abandoned branch's 179,294-token prompt. The selected branch's correct baseline was 177,860 tokens. The next request reused 177,858 tokens and processed only 1,408 uncached tokens.

This change makes the estimate follow that selected branch while keeping uncertain preflight costs unsized.

This is a follow-up to #53.

## Checks

- `npm run check` passed with 263 tests
- the real Pi smoke suite passed in an isolated tmux session
- `npm pack --dry-run` passed
- replaying the 666-entry example session restored 304 billed requests and found the correct 177,860-token baseline
- `git diff --check` passed
