### PR TITLE
traceline: peek pager fidelity — full args, inline images, code grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pi-contextimate-*/
 *.payloads.jsonl
 *.summary.json
 pi-contextimate-*-results.json
+.worktrees/

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -611,6 +611,16 @@ The peek pager:
   conversions already made by pi's row are reused rather than redone. Any
   other block type renders its type and what metadata it carries, never a
   bare bracket
+- a text result that is provably code renders as code, ink-only: the text is
+  untouched. A read whose path names a code language gets pi's own syntax
+  highlighter (theme-derived), a dim right-aligned line-number gutter counting
+  from the call's offset, and a language cell on the result label. A wrapped
+  code line's continuations keep a blank gutter cell and hang under the code's
+  own indentation, so wrapping never destroys the shape of the code. A bash
+  result earns the same ink, without the gutter, only when its command is one
+  plain `cat`/`sed`/`head`/`tail` of a single code file with no pipes, chains
+  or redirects: highlighting is a claim about what the text is (§7), and
+  anything less certain stays plain
 - an inline image is atomic under scrolling. The pager scrolls by line
   windowing, but a terminal image escape sequence cannot be sliced: an image
   renders its pixels only when its full cell block lies inside the viewport;

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -386,6 +386,13 @@ The right-aligned suffix carries facts in columns that align down the block:
   size cell as noise unless the output reaches warning severity (§6): its result
   is porcelain about the event, not pulled context, but an output that balloons
   is a story of its own and re-earns the cell
+- a row whose result carries an image block shows an image fact in the size
+  cell's berth instead of a char count: `png 1044×646`, dim. The text note
+  beside an image read is near-noise; counting only its chars claims the
+  result was tiny when the model actually received the pixels. The image fact
+  names what was pulled without pretending to know its token cost. It occupies
+  the size cell for column alignment but does not light the block's size
+  column: it is a what-fact, not a how-big-fact
 
 ### 9.8 Truncation
 
@@ -584,9 +591,35 @@ The peek pager:
   transcript beneath is untouched, and esc returns to identical pixels
 - the pager is a §8 panel: a `[Traceline] peek · row 3 of 37` brand line, one
   dim hint line, then the row's own trace lines as the anchor, the full
-  invocation from pi's call renderer with its real newlines, and the complete
-  result text, each section under a dim label. A folded read run renders one
-  invocation and result section per call
+  invocation, and the complete result, each section under a dim label. A
+  folded read run renders one invocation and result section per call
+- the pager is the fidelity surface: everything the model saw, the reader can
+  see here. The trace line may truncate and the transcript may fold, but the
+  pager never shows less than the call and result the model exchanged
+- the invocation section uses pi's call renderer with its real newlines when
+  the tool has one. A tool without a call renderer (papercut, MCP tools, most
+  extension tools) renders its complete arguments instead: the tool name, then
+  one aligned `key  value` row per argument (keys dim in one left-aligned
+  column, string values verbatim with wrapped continuations hanging at the
+  value column, nested objects as indented JSON). The arguments are the
+  invocation; a bare tool name is not
+- every result block is accounted for. Text blocks render complete. An image
+  block always renders its fact line, `image · png · 1044×646 · 65.6k bytes`
+  (§4 grammar: what, then how big), and on a terminal whose capabilities
+  support inline images it renders the pixels too, mirroring pi's own native
+  tool row: the row's `showImages` setting is honoured, and kitty PNG
+  conversions already made by pi's row are reused rather than redone. Any
+  other block type renders its type and what metadata it carries, never a
+  bare bracket
+- an inline image is atomic under scrolling. The pager scrolls by line
+  windowing, but a terminal image escape sequence cannot be sliced: an image
+  renders its pixels only when its full cell block lies inside the viewport;
+  a partially scrolled image shows its dim fact line in place (`scroll to
+  view`), never a clipped or overdrawn image. Images are sized to fit the
+  viewport so full visibility is always reachable
+- kitty image ids allocated by the pager are deleted when it closes, the same
+  bounded lifecycle as drill-mode mouse reporting: the mode cleans up every
+  terminal-state side effect it created, on exit and on shutdown
 - `j`/`k`, the arrows, page keys and `g`/`G` scroll; `h`/`l` and left/right
   move to the neighbouring numbered target without closing; `p` toggles
   expansion; digits jump; esc, enter or `q` closes back to drill mode

--- a/extensions/_lib/chat.ts
+++ b/extensions/_lib/chat.ts
@@ -41,6 +41,10 @@ export interface ToolRowDataLike {
   args?: ToolArgsLike;
   result?: ToolResultLike;
   isPartial?: unknown;
+  /** pi's inline-image setting for this row (tool-execution.ts); undefined means on. */
+  showImages?: unknown;
+  /** pi's kitty PNG conversions, a Map keyed by image-block index (tool-execution.ts). */
+  convertedImages?: unknown;
   /** pi's per-row expansion flag: written by setExpanded(), read for the zoom ladder (design language §9.12). */
   expanded?: unknown;
   cwd?: unknown;
@@ -89,6 +93,18 @@ export interface TracelineTuiLike {
   requestRender: (force?: boolean) => unknown;
   __tracelineRRWrapVersion?: number;
   __tracelineOriginalRequestRender?: (force?: boolean) => unknown;
+}
+
+/** Total text chars across a result's text blocks; undefined before a result exists. */
+export function resultTextCharCount(comp: ToolRowDataLike | undefined): number | undefined {
+  const content = comp?.result?.content;
+  if (!Array.isArray(content)) return undefined;
+  return content.reduce((sum: number, block: unknown) => {
+    if (!block || typeof block !== "object") return sum;
+    const textBlock = block as { type?: unknown; text?: unknown };
+    if (textBlock.type === "text" && typeof textBlock.text === "string") return sum + textBlock.text.length;
+    return sum;
+  }, 0);
 }
 
 /** A tool execution row: has setExpanded() and a toolName property. */

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -74,6 +74,7 @@ A modifier chord drill mode does not own (`Option+Up`, `Ctrl+C`, …) leaves the
 The pager shows the row's trace line, then the complete invocation and the complete result. It never shows less than the model saw:
 
 - a tool with no call renderer of its own (papercut, MCP tools, most extension tools) shows its complete arguments as aligned `key  value` rows instead of a bare tool name
+- a result that provably is code renders as code: a read whose path names a code language gets pi's own syntax highlighting, a dim line-number gutter counting from the call's offset, and wrapped lines that hang under the code's indentation instead of snapping back to the margin. A bash `cat`/`sed`/`head`/`tail` of a single code file earns the same ink (without the gutter)
 - an image result always shows a fact line (`image · png · 1044×646 · 65.6k bytes`), and on a terminal with inline-image support (kitty, iTerm2, Ghostty) the pixels render right in the pager, mirroring pi's own inline images. A partially scrolled image shows a dim `scroll to view` hint instead of a torn image
 
 Scroll with `j`/`k`, the arrow keys, the page keys or `g`/`G`. Press `h`/`l` to move to the neighbouring row without closing. Press `esc` to return to the numbered transcript, exactly as you left it.

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -71,7 +71,12 @@ Press `Alt+T` (or run `/drill`) to number the tool rows in place. The transcript
 
 A modifier chord drill mode does not own (`Option+Up`, `Ctrl+C`, …) leaves the mode and still does its normal job: the editor is restored first, then the same keystroke lands in it. Drill mode never silently eats a shortcut that means something outside it.
 
-The pager shows the row's trace line, then the complete invocation and the complete result. Scroll with `j`/`k`, the arrow keys, the page keys or `g`/`G`. Press `h`/`l` to move to the neighbouring row without closing. Press `esc` to return to the numbered transcript, exactly as you left it.
+The pager shows the row's trace line, then the complete invocation and the complete result. It never shows less than the model saw:
+
+- a tool with no call renderer of its own (papercut, MCP tools, most extension tools) shows its complete arguments as aligned `key  value` rows instead of a bare tool name
+- an image result always shows a fact line (`image · png · 1044×646 · 65.6k bytes`), and on a terminal with inline-image support (kitty, iTerm2, Ghostty) the pixels render right in the pager, mirroring pi's own inline images. A partially scrolled image shows a dim `scroll to view` hint instead of a torn image
+
+Scroll with `j`/`k`, the arrow keys, the page keys or `g`/`G`. Press `h`/`l` to move to the neighbouring row without closing. Press `esc` to return to the numbered transcript, exactly as you left it.
 
 The most common case takes two keys: `Alt+T`, then `1` for the latest call.
 
@@ -97,7 +102,7 @@ Results use these colours by default:
 - warning colour from 10k characters
 - error colour from 50k characters
 
-Results under 100 characters stay hidden unless another row in the same block has a visible size. File changes show diff counts instead of result size.
+Results under 100 characters stay hidden unless another row in the same block has a visible size. File changes show diff counts instead of result size. A result that carries an image shows what was pulled instead of a misleading text-only count: `png 1044×646`, dim.
 
 Set different thresholds in `~/.pi/agent/pi-traceline.json` or `<project>/.pi/pi-traceline.json`:
 

--- a/extensions/pi-traceline/drill-pager-content.ts
+++ b/extensions/pi-traceline/drill-pager-content.ts
@@ -5,8 +5,9 @@
 // and the foreign-block line. Windowing, caching, and image-component lifecycle stay
 // in drill-pager.ts.
 
-import type { Theme } from "@earendil-works/pi-coding-agent";
+import { getLanguageFromPath, highlightCode, type Theme } from "@earendil-works/pi-coding-agent";
 import { getCapabilities, getImageDimensions, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { stripAnsi } from "../_lib/ansi.ts";
 import { resultTextCharCount, type ToolRowLike } from "../_lib/chat.ts";
 import { compactCount } from "../_lib/fmt.ts";
 import { SEP, ink, type Tone } from "../_lib/style.ts";
@@ -69,11 +70,99 @@ function argumentText(value: unknown): string {
   }
 }
 
-export function resultLabel(theme: Theme | undefined, tone: Tone, call: ToolRowLike): string {
+export function resultLabel(theme: Theme | undefined, tone: Tone, call: ToolRowLike, language?: string): string {
   const word = tone === "error" ? "failed" : tone === "success" ? "success" : "running";
   const chars = resultTextCharCount(call);
   const size = chars !== undefined ? ink(theme, "dim", `${SEP}${compactCount(chars)} ch`) : "";
-  return `${ink(theme, "dim", `result${SEP}`)}${ink(theme, tone, word)}${size}`;
+  const lang = language ? ink(theme, "dim", `${SEP}${language}`) : "";
+  return `${ink(theme, "dim", `result${SEP}`)}${ink(theme, tone, word)}${size}${lang}`;
+}
+
+export type CodeContext = { language: string; nextLine: number | undefined };
+
+const CODE_PRINTERS = new Set(["cat", "sed", "head", "tail", "bat"]);
+
+/** A result renders as code only when it provably is code (§9.13): a read whose path
+ * names a language (numbered from the call's offset), or a bash command that is one
+ * plain printer of a single code file (no gutter; the true start line is unknown). */
+export function codeContextFor(call: ToolRowLike): CodeContext | undefined {
+  const args = call.args as { path?: unknown; offset?: unknown; command?: unknown } | undefined;
+  if (call.toolName === "read" && typeof args?.path === "string") {
+    const language = languageOf(args.path);
+    if (!language) return undefined;
+    const offset = typeof args.offset === "number" && args.offset >= 1 ? Math.floor(args.offset) : 1;
+    return { language, nextLine: offset };
+  }
+  if (call.toolName === "bash" && typeof args?.command === "string") {
+    const language = printedCodeLanguage(args.command);
+    if (language) return { language, nextLine: undefined };
+  }
+  return undefined;
+}
+
+function languageOf(path: string): string | undefined {
+  try {
+    return getLanguageFromPath(path.replace(/^["']|["']$/g, ""));
+  } catch {
+    return undefined; // Pi seam: no language means no code claim; the text stays plain.
+  }
+}
+
+function printedCodeLanguage(command: string): string | undefined {
+  if (/[|&;<>`$(){}\n\\]/.test(command)) return undefined; // one plain command, provable
+  const words = command.trim().split(/\s+/);
+  if (!CODE_PRINTERS.has(words[0] ?? "")) return undefined;
+  const operands = words.slice(1).filter((word) => !word.startsWith("-"));
+  const target = operands[operands.length - 1]; // sed's script operand precedes the file
+  return target ? languageOf(target) : undefined;
+}
+
+/** One text block's content lines, unindented. Plain text wraps at the content width;
+ * a code block (§9.13) gets syntax ink (content untouched), a dim right-aligned line
+ * number gutter when the start line is known, and wrapped continuations that keep a
+ * blank gutter cell and hang under the code's own indentation. */
+export function textBlockLines(theme: Theme | undefined, text: string, width: number, code: CodeContext | undefined): string[] {
+  const clean = text.replace(/\r\n?/g, "\n").replace(/\t/g, "    ");
+  if (!code) {
+    const out: string[] = [];
+    for (const raw of clean.split("\n")) {
+      if (raw.length === 0) out.push("");
+      else out.push(...wrapTextWithAnsi(raw, width));
+    }
+    return out;
+  }
+  const source = highlightedLines(clean, code.language);
+  const gutterWidth = code.nextLine === undefined ? 0 : String(code.nextLine + source.length - 1).length;
+  const pad = gutterWidth === 0 ? "" : " ".repeat(gutterWidth + 2);
+  const bodyWidth = Math.max(20, width - pad.length);
+  const out: string[] = [];
+  for (const line of source) {
+    const number = code.nextLine;
+    if (number !== undefined) code.nextLine = number + 1;
+    const gutter = gutterWidth === 0 ? "" : `${ink(theme, "dim", String(number).padStart(gutterWidth))}  `;
+    const plain = stripAnsi(line);
+    if (plain.length === 0) {
+      out.push(gutterWidth === 0 ? "" : gutter.trimEnd());
+      continue;
+    }
+    const hang = Math.min((/^ */.exec(plain)?.[0]?.length ?? 0) + 2, Math.max(0, bodyWidth - 30));
+    let first = true;
+    for (const piece of wrapTextWithAnsi(line, Math.max(20, bodyWidth - hang))) {
+      out.push(first ? `${gutter}${piece}` : `${pad}${" ".repeat(hang)}${piece}`);
+      first = false;
+    }
+  }
+  return out;
+}
+
+function highlightedLines(text: string, language: string): string[] {
+  try {
+    const lines = highlightCode(text, language);
+    if (Array.isArray(lines)) return lines.map((line) => String(line));
+  } catch {
+    // Pi seam: highlighting is ink only, never content; fall through to plain lines.
+  }
+  return text.split("\n");
 }
 
 /** The image fact line (§9.13, §4 grammar: what, then how big): always rendered,

--- a/extensions/pi-traceline/drill-pager-content.ts
+++ b/extensions/pi-traceline/drill-pager-content.ts
@@ -1,0 +1,143 @@
+// Peek-pager content grammar (design language §9.13): the pager is the fidelity
+// surface, so everything the model saw must be renderable here. This module builds the
+// text of each section: the invocation (pi's call renderer when the tool has one, the
+// complete argument grammar when it does not), the result label, the image fact line,
+// and the foreign-block line. Windowing, caching, and image-component lifecycle stay
+// in drill-pager.ts.
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { getCapabilities, getImageDimensions, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { resultTextCharCount, type ToolRowLike } from "../_lib/chat.ts";
+import { compactCount } from "../_lib/fmt.ts";
+import { SEP, ink, type Tone } from "../_lib/style.ts";
+import { imageMimeShort } from "./image-fact.ts";
+
+export type ImageBlockLike = { type?: unknown; data?: unknown; mimeType?: unknown };
+
+// Pi's call renderer with its real newlines when the tool has one; a tool without one
+// (papercut, MCP tools, most extension tools) shows its complete arguments instead
+// (§9.13): the arguments are the invocation, a bare tool name is not.
+export function invocationLines(theme: Theme | undefined, call: ToolRowLike, width: number): string[] {
+  try {
+    const out = call.callRendererComponent?.render?.(width);
+    if (Array.isArray(out) && out.length > 0) return out.map((line) => String(line));
+  } catch {
+    // Pi seam: a call renderer may throw mid-stream; fall through to the argument grammar.
+  }
+  const name = typeof call.toolName === "string" ? call.toolName : "tool";
+  return [name, ...argumentLines(theme, call.args, width)];
+}
+
+const ARG_KEY_WIDTH_CAP = 24;
+
+/** Aligned `key  value` rows (§9.13): keys dim in one column, string values verbatim,
+ * wrapped continuations hanging at the value column, nested objects as indented JSON. */
+export function argumentLines(theme: Theme | undefined, args: unknown, width: number): string[] {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return [];
+  const entries = Object.entries(args as Record<string, unknown>);
+  if (entries.length === 0) return [];
+  const keyWidth = Math.min(Math.max(...entries.map(([key]) => key.length)), ARG_KEY_WIDTH_CAP);
+  const continuation = " ".repeat(keyWidth + 2);
+  const bodyWidth = Math.max(10, width - keyWidth - 2);
+  const out: string[] = [];
+  for (const [key, value] of entries) {
+    const text = argumentText(value).replace(/\r\n?/g, "\n").replace(/\t/g, "    ");
+    // An overlong key takes its own line; its value rows all hang at the value column,
+    // so the column stays one straight edge (vertical alignment is load-bearing).
+    let first = true;
+    if (key.length > keyWidth) {
+      out.push(ink(theme, "dim", key));
+      first = false;
+    }
+    for (const row of text.split("\n")) {
+      const wrapped = row.length === 0 ? [""] : wrapTextWithAnsi(row, bodyWidth);
+      for (const piece of wrapped) {
+        out.push(first ? `${ink(theme, "dim", key.padEnd(keyWidth))}  ${piece}` : `${continuation}${piece}`);
+        first = false;
+      }
+    }
+  }
+  return out;
+}
+
+function argumentText(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function resultLabel(theme: Theme | undefined, tone: Tone, call: ToolRowLike): string {
+  const word = tone === "error" ? "failed" : tone === "success" ? "success" : "running";
+  const chars = resultTextCharCount(call);
+  const size = chars !== undefined ? ink(theme, "dim", `${SEP}${compactCount(chars)} ch`) : "";
+  return `${ink(theme, "dim", `result${SEP}`)}${ink(theme, tone, word)}${size}`;
+}
+
+/** The image fact line (§9.13, §4 grammar: what, then how big): always rendered,
+ * whether or not the terminal can also show the pixels. */
+export function imageFactLine(theme: Theme | undefined, block: ImageBlockLike): string {
+  const mimeType = typeof block.mimeType === "string" ? block.mimeType : undefined;
+  const cells = ["image"];
+  const short = imageMimeShort(mimeType);
+  if (short !== "image") cells.push(short);
+  const data = typeof block.data === "string" ? block.data : undefined;
+  if (data && mimeType) {
+    const dims = getImageDimensions(data, mimeType);
+    if (dims) cells.push(`${dims.widthPx}×${dims.heightPx}`);
+  }
+  if (data) cells.push(`${compactCount(Math.floor((data.length * 3) / 4))} bytes`);
+  return ink(theme, "dim", cells.join(SEP));
+}
+
+/** A block the pager has no richer rendering for shows its type and metadata (§9.13),
+ * never a bare bracket. Bulky payload fields stay out; they are not readable anyway. */
+export function foreignBlockLine(theme: Theme | undefined, block: object): string {
+  const typed = block as { type?: unknown };
+  const kind = typeof typed.type === "string" ? typed.type : "block";
+  const meta: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(block)) {
+    if (key === "type" || key === "data") continue;
+    meta[key] = value;
+  }
+  let json = "";
+  try {
+    json = Object.keys(meta).length > 0 ? (JSON.stringify(meta) ?? "") : "";
+  } catch {
+    json = "";
+  }
+  return ink(theme, "dim", json ? `${kind}${SEP}${json}` : kind);
+}
+
+// Pixels mirror pi's own native tool row (§9.13): the row's showImages setting is
+// honoured, terminal capabilities decide, and pi's async kitty PNG conversions
+// (tool-execution.ts convertedImages) are reused rather than redone. Kitty draws PNG
+// only; an unconverted block keeps its fact line, exactly as pi's row does.
+export function imagePixelSource(
+  call: ToolRowLike,
+  imageIndex: number,
+  block: ImageBlockLike,
+): { data: string; mimeType: string } | undefined {
+  if (call.showImages === false) return undefined;
+  const caps = getCapabilities();
+  if (!caps.images) return undefined;
+  const converted = convertedImage(call, imageIndex);
+  const data = converted?.data ?? (typeof block.data === "string" ? block.data : undefined);
+  const mimeType = converted?.mimeType ?? (typeof block.mimeType === "string" ? block.mimeType : undefined);
+  if (!data || !mimeType) return undefined;
+  if (caps.images === "kitty" && mimeType !== "image/png") return undefined;
+  return { data, mimeType };
+}
+
+function convertedImage(call: ToolRowLike, imageIndex: number): { data: string; mimeType: string } | undefined {
+  const map = call.convertedImages;
+  if (!(map instanceof Map)) return undefined;
+  const value: unknown = map.get(imageIndex);
+  if (!value || typeof value !== "object") return undefined;
+  const typed = value as { data?: unknown; mimeType?: unknown };
+  return typeof typed.data === "string" && typeof typed.mimeType === "string"
+    ? { data: typed.data, mimeType: typed.mimeType }
+    : undefined;
+}

--- a/extensions/pi-traceline/drill-pager.ts
+++ b/extensions/pi-traceline/drill-pager.ts
@@ -1,17 +1,39 @@
 // The peek pager (design language §9.13): a full-screen overlay opened from drill mode.
 // The transcript beneath stays untouched, so esc returns to identical pixels. The panel
 // speaks the §8 header form, then anchors on the row's own trace line and shows the
-// full invocation (pi's call renderer, real newlines) and the complete result text,
-// each section under a dim label. A folded read run renders one invocation and result
-// section per call. Scrolling is offset-based line windowing; h/l switch to the
-// neighbouring numbered target without closing.
+// full invocation and the complete result, each section under a dim label. The pager is
+// the fidelity surface: everything the model saw, the reader can see here; the section
+// grammar (argument rows, image fact lines, foreign blocks) lives in
+// drill-pager-content.ts. Inline images mirror pi's own native tool row and are atomic
+// under the pager's offset-based line windowing: pixels render only when the whole cell
+// block is inside the viewport, a partially scrolled image shows its dim hint line
+// instead, and kitty image ids the pager allocated are deleted when it closes. A folded
+// read run renders one invocation and result section per call. Scrolling is offset-based
+// line windowing; h/l switch to the neighbouring numbered target without closing.
 
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { matchesKey, truncateToWidth, wrapTextWithAnsi, type Component, type KeyId, type TUI } from "@earendil-works/pi-tui";
+import {
+  Image,
+  deleteKittyImage,
+  getCapabilities,
+  matchesKey,
+  truncateToWidth,
+  wrapTextWithAnsi,
+  type Component,
+  type KeyId,
+  type TUI,
+} from "@earendil-works/pi-tui";
 import type { ToolRowLike } from "../_lib/chat.ts";
-import { compactCount } from "../_lib/fmt.ts";
-import { ELLIPSIS, SEP, ink, type Tone } from "../_lib/style.ts";
+import { ELLIPSIS, SEP, ink } from "../_lib/style.ts";
 import { applyDigit, setSelected, togglePin, type DrillState } from "./drill.ts";
+import {
+  foreignBlockLine,
+  imageFactLine,
+  imagePixelSource,
+  invocationLines,
+  resultLabel,
+  type ImageBlockLike,
+} from "./drill-pager-content.ts";
 
 const BOLD = "\x1b[1m";
 const BOLD_OFF = "\x1b[22m";
@@ -21,12 +43,39 @@ const SECTION_INDENT = "    ";
 
 type TerminalSizeLike = { terminal?: { rows?: number } };
 
+type PagerImage = { start: number; lines: string[] };
+type PagerBody = { lines: string[]; images: PagerImage[] };
+type CachedImage = { data: string; comp: Image };
+
+// A crash mid-peek must not leave transmitted kitty images behind in the terminal:
+// the same bounded lifecycle as drill-mode mouse reporting (§9.13).
+const livePagers = new Set<DrillPager>();
+let exitGuardInstalled = false;
+
+function ensureExitGuard(): void {
+  if (exitGuardInstalled) return;
+  exitGuardInstalled = true;
+  process.on("exit", () => {
+    for (const pager of livePagers) pager.dispose();
+  });
+}
+
+function writeIgnoringErrors(sequence: string): void {
+  try {
+    process.stdout.write(sequence);
+  } catch {
+    // terminal already gone; nothing to clean up
+  }
+}
+
 export class DrillPager implements Component {
   private readonly st: DrillState;
   private scroll = 0;
   private tui: TerminalSizeLike | undefined;
   private lastRowIndex: number;
-  private cache: { row: unknown; result: unknown; width: number; lines: string[] } | undefined;
+  private cache: { row: unknown; result: unknown; width: number; viewport: number; body: PagerBody } | undefined;
+  private imageComps = new Map<string, CachedImage>();
+  private imageCompsViewport = 0;
 
   constructor(st: DrillState) {
     this.st = st;
@@ -78,6 +127,7 @@ export class DrillPager implements Component {
       this.lastRowIndex = st.selected;
       this.scroll = 0;
       this.cache = undefined;
+      this.disposeImages(); // the next row's blocks get fresh, correctly sized components
     }
     const fit = (line: string) => truncateToWidth(line, Math.max(1, width), ELLIPSIS);
     const row = st.rows[st.selected];
@@ -87,97 +137,177 @@ export class DrillPager implements Component {
     const hint = `  ${ink(theme, "dim", `esc close${SEP}j/k scroll${SEP}h/l switch row${SEP}p expand${SEP}g/G ends`)}`;
     if (!row) return [fit(head), fit(hint), fit(`  ${ink(theme, "dim", "row no longer available")}`)];
 
-    const body = this.bodyLines(row, width);
     const viewport = this.viewport();
-    this.scroll = Math.min(this.scroll, Math.max(0, body.length - viewport));
-    const view = body.slice(this.scroll, this.scroll + viewport);
+    const body = this.body(row, width, viewport);
+    this.scroll = Math.min(this.scroll, Math.max(0, body.lines.length - viewport));
+    const view = body.lines.slice(this.scroll, this.scroll + viewport);
+    // An inline image is atomic (§9.13): its escape-sequence block substitutes over its
+    // placeholder lines only when the whole block sits inside the window. A partial
+    // block keeps the placeholder hint; a sliced image sequence would overdraw chrome.
+    for (const image of body.images) {
+      if (image.start < this.scroll || image.start + image.lines.length > this.scroll + viewport) continue;
+      for (let i = 0; i < image.lines.length; i++) view[image.start - this.scroll + i] = image.lines[i]!;
+    }
     while (view.length < viewport) view.push(""); // cover the transcript to the full height
-    const from = body.length === 0 ? 0 : this.scroll + 1;
-    const to = Math.min(body.length, this.scroll + viewport);
-    const footer = `  ${ink(theme, "dim", `lines ${from}-${to} of ${body.length}`)}`;
-    return [head, hint, ...view, footer].map(fit);
+    const from = body.lines.length === 0 ? 0 : this.scroll + 1;
+    const to = Math.min(body.lines.length, this.scroll + viewport);
+    const footer = `  ${ink(theme, "dim", `lines ${from}-${to} of ${body.lines.length}`)}`;
+    return [fit(head), fit(hint), ...view, fit(footer)];
   }
 
-  private bodyLines(row: ToolRowLike, width: number): string[] {
+  private body(row: ToolRowLike, width: number, viewport: number): PagerBody {
     const streaming = (this.st.host.runRows(row) ?? [row]).some((call) => call.isPartial === true);
     const c = this.cache;
-    if (!streaming && c && c.row === row && c.result === row.result && c.width === width) return c.lines;
-    const lines = buildPagerBody(this.st, row, width);
-    this.cache = streaming ? undefined : { row, result: row.result, width, lines };
-    return lines;
+    if (!streaming && c && c.row === row && c.result === row.result && c.width === width && c.viewport === viewport) {
+      return c.body;
+    }
+    if (this.imageCompsViewport !== viewport) this.disposeImages(); // height caps are constructor-fixed
+    this.imageCompsViewport = viewport;
+    const body = this.buildBody(row, width, viewport);
+    this.cache = streaming ? undefined : { row, result: row.result, width, viewport, body };
+    return body;
   }
 
   invalidate(): void {
     this.cache = undefined;
   }
-}
 
-// --- body construction ------------------------------------------------------------------
-
-function buildPagerBody(st: DrillState, row: ToolRowLike, width: number): string[] {
-  const theme = st.host.theme();
-  const contentWidth = Math.max(20, width - SECTION_INDENT.length);
-  const lines: string[] = [...st.host.traceLines(row, width)];
-  const calls = st.host.runRows(row) ?? [row];
-  calls.forEach((call, index) => {
-    const callLabel = calls.length > 1 ? `${SEP}call ${index + 1} of ${calls.length}` : "";
-    lines.push("", `  ${ink(theme, "dim", `invocation${callLabel}`)}`);
-    for (const line of invocationLines(call, contentWidth)) lines.push(`${SECTION_INDENT}${line}`);
-    lines.push("", `  ${resultLabel(theme, st.host.statusTone(call), call)}`);
-    for (const line of resultLines(theme, call, contentWidth)) lines.push(`${SECTION_INDENT}${line}`);
-  });
-  return lines;
-}
-
-function invocationLines(call: ToolRowLike, width: number): string[] {
-  try {
-    const out = call.callRendererComponent?.render?.(width);
-    if (Array.isArray(out)) return out.map((line) => String(line));
-  } catch {
-    // Pi seam: a call renderer may throw mid-stream; fall through to the tool name.
+  /** Delete every kitty image id this pager allocated; idempotent, safe at exit. */
+  dispose(): void {
+    this.disposeImages();
+    livePagers.delete(this);
   }
-  return [typeof call.toolName === "string" ? call.toolName : "tool"];
-}
 
-function resultChars(call: ToolRowLike): number | undefined {
-  const content = call.result?.content;
-  if (!Array.isArray(content)) return undefined;
-  let sum = 0;
-  for (const block of content) {
-    if (!block || typeof block !== "object") continue;
-    const textBlock = block as { type?: unknown; text?: unknown };
-    if (textBlock.type === "text" && typeof textBlock.text === "string") sum += textBlock.text.length;
+  // --- body construction ----------------------------------------------------------------
+
+  private buildBody(row: ToolRowLike, width: number, viewport: number): PagerBody {
+    const st = this.st;
+    const theme = st.host.theme();
+    const contentWidth = Math.max(20, width - SECTION_INDENT.length);
+    const fit = (line: string) => truncateToWidth(line, Math.max(1, width), ELLIPSIS);
+    const lines: string[] = [...st.host.traceLines(row, width)];
+    const images: PagerImage[] = [];
+    const calls = st.host.runRows(row) ?? [row];
+    calls.forEach((call, callIndex) => {
+      const callLabel = calls.length > 1 ? `${SEP}call ${callIndex + 1} of ${calls.length}` : "";
+      lines.push("", `  ${ink(theme, "dim", `invocation${callLabel}`)}`);
+      for (const line of invocationLines(theme, call, contentWidth)) lines.push(fit(`${SECTION_INDENT}${line}`));
+      lines.push("", `  ${resultLabel(theme, st.host.statusTone(call), call)}`);
+      this.pushResult(call, callIndex, theme, width, contentWidth, viewport, lines, images);
+    });
+    return { lines, images };
   }
-  return sum;
-}
 
-function resultLabel(theme: Theme | undefined, tone: Tone, call: ToolRowLike): string {
-  const word = tone === "error" ? "failed" : tone === "success" ? "success" : "running";
-  const chars = resultChars(call);
-  const size = chars !== undefined ? ink(theme, "dim", `${SEP}${compactCount(chars)} ch`) : "";
-  return `${ink(theme, "dim", `result${SEP}`)}${ink(theme, tone, word)}${size}`;
-}
-
-function resultLines(theme: Theme | undefined, call: ToolRowLike, width: number): string[] {
-  const content = call.result?.content;
-  if (!Array.isArray(content)) return [ink(theme, "dim", "no output yet")];
-  const out: string[] = [];
-  for (const block of content) {
-    if (!block || typeof block !== "object") continue;
-    const textBlock = block as { type?: unknown; text?: unknown };
-    if (textBlock.type === "text" && typeof textBlock.text === "string") {
-      const text = textBlock.text.replace(/\r\n?/g, "\n").replace(/\t/g, "    ");
-      for (const raw of text.split("\n")) {
-        if (raw.length === 0) {
-          out.push("");
-          continue;
-        }
-        for (const wrapped of wrapTextWithAnsi(raw, width)) out.push(wrapped);
-      }
-    } else {
-      out.push(ink(theme, "dim", `[${typeof textBlock.type === "string" ? textBlock.type : "block"}]`));
+  private pushResult(
+    call: ToolRowLike,
+    callIndex: number,
+    theme: Theme | undefined,
+    width: number,
+    contentWidth: number,
+    viewport: number,
+    lines: string[],
+    images: PagerImage[],
+  ): void {
+    const fit = (line: string) => truncateToWidth(line, Math.max(1, width), ELLIPSIS);
+    const content = call.result?.content;
+    if (!Array.isArray(content)) {
+      lines.push(fit(`${SECTION_INDENT}${ink(theme, "dim", "no output yet")}`));
+      return;
     }
+    const before = lines.length;
+    let imageIndex = 0;
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const typed = block as { type?: unknown; text?: unknown };
+      if (typed.type === "text" && typeof typed.text === "string") {
+        const text = typed.text.replace(/\r\n?/g, "\n").replace(/\t/g, "    ");
+        for (const raw of text.split("\n")) {
+          if (raw.length === 0) {
+            lines.push("");
+            continue;
+          }
+          for (const wrapped of wrapTextWithAnsi(raw, contentWidth)) lines.push(fit(`${SECTION_INDENT}${wrapped}`));
+        }
+      } else if (typed.type === "image") {
+        this.pushImage(call, callIndex, imageIndex++, block as ImageBlockLike, theme, width, contentWidth, viewport, lines, images);
+      } else {
+        lines.push(fit(`${SECTION_INDENT}${foreignBlockLine(theme, block)}`));
+      }
+    }
+    if (lines.length === before) lines.push(fit(`${SECTION_INDENT}${ink(theme, "dim", "(empty result)")}`));
   }
-  if (out.length === 0) out.push(ink(theme, "dim", "(empty result)"));
-  return out;
+
+  private pushImage(
+    call: ToolRowLike,
+    callIndex: number,
+    imageIndex: number,
+    block: ImageBlockLike,
+    theme: Theme | undefined,
+    width: number,
+    contentWidth: number,
+    viewport: number,
+    lines: string[],
+    images: PagerImage[],
+  ): void {
+    lines.push(truncateToWidth(`${SECTION_INDENT}${imageFactLine(theme, block)}`, Math.max(1, width), ELLIPSIS));
+    const source = imagePixelSource(call, imageIndex, block);
+    if (!source) return;
+    const comp = this.imageComponent(`${callIndex}:${imageIndex}`, source, theme, contentWidth, viewport);
+    let rendered: string[];
+    try {
+      rendered = comp.render(contentWidth).map((line) => (line.length > 0 ? `${SECTION_INDENT}${line}` : line));
+    } catch {
+      return; // Pi seam: a malformed payload keeps its fact line; pixels are best-effort.
+    }
+    if (rendered.length === 0) return;
+    // Placeholder lines hold the block's height in the scroll geometry; the hint sits on
+    // the first and last line so a partial block explains itself from either direction.
+    const hint = ink(theme, "dim", `${SECTION_INDENT}(image${SEP}scroll to view)`);
+    const start = lines.length;
+    for (let i = 0; i < rendered.length; i++) {
+      lines.push(i === 0 || i === rendered.length - 1 ? hint : "");
+    }
+    images.push({ start, lines: rendered });
+    livePagers.add(this);
+    ensureExitGuard();
+  }
+
+  // One Image component per result block, keyed by call and block index so kitty image
+  // ids survive re-renders; recreated when pi's async PNG conversion swaps the data in.
+  private imageComponent(
+    key: string,
+    source: { data: string; mimeType: string },
+    theme: Theme | undefined,
+    contentWidth: number,
+    viewport: number,
+  ): Image {
+    const cached = this.imageComps.get(key);
+    if (cached && cached.data === source.data) return cached.comp;
+    if (cached) deleteCompImage(cached.comp);
+    const comp = new Image(
+      source.data,
+      source.mimeType,
+      { fallbackColor: (s: string) => ink(theme, "dim", s) },
+      {
+        maxWidthCells: Math.max(10, contentWidth - 2),
+        // Fit inside the viewport (§9.13): full visibility must always be reachable,
+        // leaving room for the fact line above and one line of breathing space.
+        maxHeightCells: Math.max(4, viewport - 2),
+      },
+    );
+    this.imageComps.set(key, { data: source.data, comp });
+    return comp;
+  }
+
+  private disposeImages(): void {
+    if (this.imageComps.size === 0) return;
+    for (const cached of this.imageComps.values()) deleteCompImage(cached.comp);
+    this.imageComps.clear();
+  }
+}
+
+function deleteCompImage(comp: Image): void {
+  if (getCapabilities().images !== "kitty") return; // only kitty stores images by id
+  const id = comp.getImageId();
+  if (typeof id === "number") writeIgnoringErrors(deleteKittyImage(id));
 }

--- a/extensions/pi-traceline/drill-pager.ts
+++ b/extensions/pi-traceline/drill-pager.ts
@@ -18,7 +18,6 @@ import {
   getCapabilities,
   matchesKey,
   truncateToWidth,
-  wrapTextWithAnsi,
   type Component,
   type KeyId,
   type TUI,
@@ -27,11 +26,14 @@ import type { ToolRowLike } from "../_lib/chat.ts";
 import { ELLIPSIS, SEP, ink } from "../_lib/style.ts";
 import { applyDigit, setSelected, togglePin, type DrillState } from "./drill.ts";
 import {
+  codeContextFor,
   foreignBlockLine,
   imageFactLine,
   imagePixelSource,
   invocationLines,
   resultLabel,
+  textBlockLines,
+  type CodeContext,
   type ImageBlockLike,
 } from "./drill-pager-content.ts";
 
@@ -192,8 +194,9 @@ export class DrillPager implements Component {
       const callLabel = calls.length > 1 ? `${SEP}call ${callIndex + 1} of ${calls.length}` : "";
       lines.push("", `  ${ink(theme, "dim", `invocation${callLabel}`)}`);
       for (const line of invocationLines(theme, call, contentWidth)) lines.push(fit(`${SECTION_INDENT}${line}`));
-      lines.push("", `  ${resultLabel(theme, st.host.statusTone(call), call)}`);
-      this.pushResult(call, callIndex, theme, width, contentWidth, viewport, lines, images);
+      const code = codeContextFor(call);
+      lines.push("", `  ${resultLabel(theme, st.host.statusTone(call), call, code?.language)}`);
+      this.pushResult(call, callIndex, code, theme, width, contentWidth, viewport, lines, images);
     });
     return { lines, images };
   }
@@ -201,6 +204,7 @@ export class DrillPager implements Component {
   private pushResult(
     call: ToolRowLike,
     callIndex: number,
+    code: CodeContext | undefined,
     theme: Theme | undefined,
     width: number,
     contentWidth: number,
@@ -220,13 +224,8 @@ export class DrillPager implements Component {
       if (!block || typeof block !== "object") continue;
       const typed = block as { type?: unknown; text?: unknown };
       if (typed.type === "text" && typeof typed.text === "string") {
-        const text = typed.text.replace(/\r\n?/g, "\n").replace(/\t/g, "    ");
-        for (const raw of text.split("\n")) {
-          if (raw.length === 0) {
-            lines.push("");
-            continue;
-          }
-          for (const wrapped of wrapTextWithAnsi(raw, contentWidth)) lines.push(fit(`${SECTION_INDENT}${wrapped}`));
+        for (const line of textBlockLines(theme, typed.text, contentWidth, code)) {
+          lines.push(line.length === 0 ? "" : fit(`${SECTION_INDENT}${line}`));
         }
       } else if (typed.type === "image") {
         this.pushImage(call, callIndex, imageIndex++, block as ImageBlockLike, theme, width, contentWidth, viewport, lines, images);

--- a/extensions/pi-traceline/drill.ts
+++ b/extensions/pi-traceline/drill.ts
@@ -224,6 +224,7 @@ export function openPager(st: DrillState): void {
     )
     .catch(() => undefined)
     .finally(() => {
+      pager.dispose(); // kitty image ids are pager-scoped terminal state (§9.13)
       if (st.pager === pager) {
         st.pager = undefined;
         st.closePager = undefined;

--- a/extensions/pi-traceline/image-fact.ts
+++ b/extensions/pi-traceline/image-fact.ts
@@ -1,0 +1,40 @@
+// The image what-fact for trace rows (design language §9.7): an image-bearing result
+// wears `png 1044×646` in the size cell's berth instead of a char count, because
+// counting only the text note beside an image claims the result was tiny when the
+// model actually received the pixels. It is a what-fact, not a how-big-fact: ink and
+// column policy stay in index.ts.
+import { getImageDimensions } from "@earendil-works/pi-tui";
+import type { ToolRowDataLike } from "../_lib/chat.ts";
+
+// Dimension parsing decodes the payload, so facts cache per result identity like
+// record facts do (results never change once settled).
+const imageFactCache = new WeakMap<object, string>();
+
+export function resultImageFact(comp: ToolRowDataLike | undefined): string {
+  const result = comp?.result;
+  if (!result || typeof result !== "object" || !Array.isArray(result.content)) return "";
+  const cached = imageFactCache.get(result);
+  if (cached !== undefined) return cached;
+  const blocks = result.content.filter(
+    (block): block is { type: "image"; data?: unknown; mimeType?: unknown } =>
+      !!block && typeof block === "object" && (block as { type?: unknown }).type === "image",
+  );
+  let fact = "";
+  if (blocks.length > 1) fact = `${blocks.length} images`;
+  else if (blocks.length === 1) {
+    const block = blocks[0]!;
+    const mimeType = typeof block.mimeType === "string" ? block.mimeType : undefined;
+    const data = typeof block.data === "string" ? block.data : undefined;
+    const short = imageMimeShort(mimeType);
+    const dims = data && mimeType ? getImageDimensions(data, mimeType) : null;
+    fact = dims ? `${short} ${dims.widthPx}×${dims.heightPx}` : short;
+  }
+  imageFactCache.set(result, fact);
+  return fact;
+}
+
+export function imageMimeShort(mimeType: string | undefined): string {
+  if (!mimeType) return "image";
+  const slash = mimeType.indexOf("/");
+  return slash >= 0 && slash < mimeType.length - 1 ? mimeType.slice(slash + 1) : mimeType;
+}

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -11,6 +11,7 @@ import {
   type AssistantRowLike,
   type AssistantRowPrototypeLike,
   type ContainerLike,
+  resultTextCharCount,
   type ToolArgsLike,
   type ToolRowDataLike,
   type ToolRowLike,
@@ -41,6 +42,7 @@ import {
   type DrillHost,
 } from "./drill.ts";
 import { handleDrillTerminalInput } from "./drill-input.ts";
+import { resultImageFact } from "./image-fact.ts";
 import { commonDirSegments, compactReadDisplay, cwdRelativePath, lineRange, readDirKey } from "./path-rows.ts";
 import { recordFacts, type RecordTone } from "./records.ts";
 import {
@@ -342,19 +344,14 @@ function charSuffix(chars: number | undefined, columnLive = false): string {
   return ink(currentTheme(), sizeTone(chars, sizeThresholds), `${formatCharCount(chars)} ch`);
 }
 
-function resultTextCharCount(comp: ToolRowDataLike | undefined): number | undefined {
-  const content = comp?.result?.content;
-  if (!Array.isArray(content)) return undefined;
-  return content.reduce((sum: number, block: unknown) => {
-    if (!block || typeof block !== "object") return sum;
-    const textBlock = block as { type?: unknown; text?: unknown };
-    if (textBlock.type === "text" && typeof textBlock.text === "string") return sum + textBlock.text.length;
-    return sum;
-  }, 0);
-}
-
 function resultCharSuffix(comp: ToolRowDataLike | undefined, facts: BlockFacts): string {
   return charSuffix(resultTextCharCount(comp), facts.sizeColumnLive);
+}
+
+// The image what-fact (§9.7, image-fact.ts): dim, never lighting the size column.
+function imageFactCell(comp: ToolRowDataLike | undefined): string {
+  const fact = resultImageFact(comp);
+  return fact ? dim(fact) : "";
 }
 
 const MUTATION_VERBS = new Set(["edit", "write"]);
@@ -427,10 +424,8 @@ function blockFacts(rows: ToolRowLike[]): BlockFacts {
       if (stats.added > 0) plus = Math.max(plus, 1 + String(stats.added).length);
       if (stats.removed > 0) minus = Math.max(minus, 1 + String(stats.removed).length);
     }
-    size = Math.max(
-      size,
-      visibleWidth(recordRow(row) ? recordCharSuffix(row) : charSuffix(resultTextCharCount(row), sizeColumnLive)),
-    );
+    const cell = recordRow(row) ? recordCharSuffix(row) : imageFactCell(row) || charSuffix(resultTextCharCount(row), sizeColumnLive);
+    size = Math.max(size, visibleWidth(cell));
   }
   return { sizeColumnLive, diffColumns: { plus, minus, size } };
 }
@@ -583,7 +578,7 @@ function toolFactSuffix(comp: ToolRowLike, available = Number.POSITIVE_INFINITY,
   // below warning severity.
   const inline = inlineMutationRow(comp);
   const diff = inline ? undefined : mutationDiffStats(comp);
-  const chars = inline ? "" : recordRow(comp) ? recordCharSuffix(comp) : resultCharSuffix(comp, facts);
+  const chars = inline ? "" : recordRow(comp) ? recordCharSuffix(comp) : imageFactCell(comp) || resultCharSuffix(comp, facts);
   if (diff) {
     // The diff cell right-aligns within the block's sign columns, and the size cell
     // pads left to the block's widest, so each diff column's right edge and the `·`

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "check": "npm run lint && npm run typecheck && npm test",
     "test:smoke:traceline": "node tests/smoke/traceline-empty-thinking-smoke.mjs",
     "test:smoke:drill": "node tests/smoke/traceline-drill-smoke.mjs",
-    "test:smoke": "npm run test:smoke:traceline && npm run test:smoke:drill && node tests/smoke/startup-smoke.mjs"
+    "test:smoke:pager": "node tests/smoke/traceline-pager-fidelity-smoke.mjs",
+    "test:smoke": "npm run test:smoke:traceline && npm run test:smoke:drill && npm run test:smoke:pager && node tests/smoke/startup-smoke.mjs"
   },
   "pi": {
     "extensions": [

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,7 +7,7 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 1247,
       "extensions/pi-contextimate/index.ts": 1959,
-      "extensions/pi-traceline/index.ts": 1771,
+      "extensions/pi-traceline/index.ts": 1766,
       "tests/cachemire/economics-and-render.test.ts": 352,
       "tests/contract/pi-internals.test.ts": 432,
       "tests/traceline/one-line.test.ts": 775

--- a/tests/contract/pi-image-seams.test.ts
+++ b/tests/contract/pi-image-seams.test.ts
@@ -1,0 +1,79 @@
+// Pins for the pi seams behind the peek pager's image fidelity (design language
+// §9.13) and the trace row's image what-fact (§9.7): the result image blocks pi's
+// read tool emits, the ToolExecutionComponent fields the pager piggybacks on
+// (showImages, convertedImages, the kitty PNG-only guard), the bare-name call
+// fallback that justifies the pager's argument grammar, and the pi-tui image API
+// (Image component line accounting, kitty id deletion). After `pi update`, a failure
+// here names exactly which seam drifted.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as piTui from "@earendil-works/pi-tui";
+
+const piRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"))), "..");
+
+function pngBase64(widthPx: number, heightPx: number): string {
+  const buffer = Buffer.alloc(96);
+  buffer.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  buffer.writeUInt32BE(13, 8);
+  buffer.write("IHDR", 12);
+  buffer.writeUInt32BE(widthPx, 16);
+  buffer.writeUInt32BE(heightPx, 20);
+  return buffer.toString("base64");
+}
+
+test("read tool emits image result blocks the pager and image fact consume", () => {
+  const source = readFileSync(join(piRoot, "dist/core/tools/read.js"), "utf8");
+  assert.ok(
+    source.includes('{ type: "image", data: processed.data, mimeType: processed.mimeType }'),
+    "read no longer emits { type: 'image', data, mimeType } blocks — image fidelity seam drifted",
+  );
+});
+
+test("ToolExecutionComponent seams the pager piggybacks on", () => {
+  const source = readFileSync(join(piRoot, "dist/modes/interactive/components/tool-execution.js"), "utf8");
+  assert.ok(
+    source.includes("this.showImages = options.showImages ?? true;"),
+    "showImages default drifted — the pager mirrors this row setting",
+  );
+  assert.ok(
+    source.includes('this.result.content.filter((c) => c.type === "image")'),
+    "image blocks no longer filtered by type — convertedImages indexing drifted",
+  );
+  assert.ok(
+    source.includes("this.convertedImages.set(index, converted)"),
+    "convertedImages no longer keyed by image-block index — the pager's kitty reuse drifted",
+  );
+  assert.ok(
+    /caps\.images === "kitty" && imageMimeType !== "image\/png"/.test(source),
+    "kitty PNG-only guard gone — re-verify the pager's mirrored guard",
+  );
+  // A tool without renderCall renders only its bold name; that bareness is why the
+  // pager renders the complete arguments itself (§9.13).
+  assert.ok(
+    source.includes("createCallFallback() {") &&
+      source.includes("return new Text(theme.fg(\"toolTitle\", theme.bold(this.toolName)), 0, 0);"),
+    "call fallback no longer a bare tool name — revisit whether the argument grammar still owns this gap",
+  );
+});
+
+test("pi-tui image API: Image line accounting, capability override, kitty deletion", () => {
+  const original = piTui.getCapabilities();
+  try {
+    piTui.setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: false });
+    const image = new piTui.Image(pngBase64(100, 800), "image/png", { fallbackColor: (s: string) => s }, { maxWidthCells: 20, maxHeightCells: 10 });
+    const lines = image.render(60);
+    assert.ok(lines.length >= 1 && lines.length <= 10, "Image.render must account its height in lines, capped by maxHeightCells");
+    assert.ok(lines.some((line) => line.includes("\x1b]1337")), "iterm2 sequence gone from rendered lines");
+
+    piTui.setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+    const fallback = new piTui.Image(pngBase64(4, 4), "image/png", { fallbackColor: (s: string) => s });
+    assert.match(fallback.render(60).join("\n"), /\[Image: \[image\/png\] 4x4\]/, "capability-less fallback text drifted");
+  } finally {
+    piTui.setCapabilities(original);
+  }
+  assert.deepEqual(piTui.getImageDimensions(pngBase64(1044, 646), "image/png"), { widthPx: 1044, heightPx: 646 });
+  assert.ok(piTui.deleteKittyImage(7).includes("a=d"), "kitty delete sequence drifted — pager dispose would leak images");
+});

--- a/tests/contract/pi-pager-seams.test.ts
+++ b/tests/contract/pi-pager-seams.test.ts
@@ -1,16 +1,18 @@
-// Pins for the pi seams behind the peek pager's image fidelity (design language
+// Pins for the pi seams behind the peek pager's fidelity surface (design language
 // §9.13) and the trace row's image what-fact (§9.7): the result image blocks pi's
 // read tool emits, the ToolExecutionComponent fields the pager piggybacks on
 // (showImages, convertedImages, the kitty PNG-only guard), the bare-name call
-// fallback that justifies the pager's argument grammar, and the pi-tui image API
-// (Image component line accounting, kitty id deletion). After `pi update`, a failure
-// here names exactly which seam drifted.
+// fallback that justifies the pager's argument grammar, the syntax-highlight exports
+// behind the pager's code grammar, and the pi-tui image API (Image component line
+// accounting, kitty id deletion). After `pi update`, a failure here names exactly
+// which seam drifted.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as piTui from "@earendil-works/pi-tui";
+import { getLanguageFromPath, highlightCode } from "@earendil-works/pi-coding-agent";
 
 const piRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"))), "..");
 
@@ -56,6 +58,22 @@ test("ToolExecutionComponent seams the pager piggybacks on", () => {
     source.includes("createCallFallback() {") &&
       source.includes("return new Text(theme.fg(\"toolTitle\", theme.bold(this.toolName)), 0, 0);"),
     "call fallback no longer a bare tool name — revisit whether the argument grammar still owns this gap",
+  );
+});
+
+test("syntax-highlight exports behind the pager's code grammar", () => {
+  // The pager claims code only through pi's own path-to-language mapping, and inks it
+  // through pi's own highlighter; both must stay exported and line-preserving.
+  assert.equal(getLanguageFromPath("a/b.ts"), "typescript");
+  assert.equal(getLanguageFromPath("dist/x.mjs"), "javascript");
+  assert.equal(getLanguageFromPath("notes.txt"), undefined, "prose must never earn a code claim");
+  const code = "const x = 1;\n\nconst y = 2;";
+  const lines = highlightCode(code, "typescript");
+  assert.equal(lines.length, 3, "highlightCode must preserve line structure");
+  assert.equal(
+    lines.map((line) => line.replaceAll(/\x1b\[[0-9;]*m/g, "")).join("\n"),
+    code,
+    "highlighting must be ink only, never content",
   );
 });
 

--- a/tests/smoke/traceline-pager-fidelity-smoke.mjs
+++ b/tests/smoke/traceline-pager-fidelity-smoke.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// Resume a real Pi session holding the two fidelity gaps the peek pager closes
-// (design language §9.13): a custom tool with no call renderer (papercut-shaped) and a
-// read whose result is an image block. Prove end to end that Alt+T → digit shows the
-// complete arguments (the note text a bare tool name would hide) and the image fact
-// line, and that the image read's trace row wears the `png W×H` what-fact (§9.7).
+// Resume a real Pi session holding the fidelity gaps the peek pager closes (design
+// language §9.13): a custom tool with no call renderer (papercut-shaped), a read whose
+// result is an image block, and a code read. Prove end to end that Alt+T → digit shows
+// the complete arguments (the note text a bare tool name would hide), the image fact
+// line, and the code grammar (offset-numbered gutter plus real syntax ink), and that
+// the image read's trace row wears the `png W×H` what-fact (§9.7).
 // tmux reports no image capability, so the pixel path stays unit/contract-tested;
 // this smoke pins the always-on text tier against the real Pi component stack.
 import { spawnSync } from "node:child_process";
@@ -46,8 +47,8 @@ function hasTmuxSession() {
   return run(["tmux", "has-session", "-t", tmuxSession], { timeoutMs: 2_000 }).status === 0;
 }
 
-function capturePane() {
-  return run(["tmux", "capture-pane", "-p", "-t", tmuxSession, "-S", "-500"], { timeoutMs: 2_000 }).stdout ?? "";
+function capturePane(...extra) {
+  return run(["tmux", "capture-pane", "-p", ...extra, "-t", tmuxSession, "-S", "-500"], { timeoutMs: 2_000 }).stdout ?? "";
 }
 
 function sendKeys(...keys) {
@@ -101,10 +102,40 @@ function sessionEntries(cwd) {
       timestamp: iso,
       message: { role: "user", content: [{ type: "text", text: "Resume the pager fidelity fixture." }], timestamp },
     },
+    // Order matters: the papercut call sits between the two reads so consecutive
+    // sibling reads do not fold into one run row (§9.9); each fidelity case keeps its
+    // own numbered trace row. Newest first: 1 image read, 2 papercut, 3 code read.
     {
       type: "message",
       id: "00000003",
       parentId: "00000002",
+      timestamp: iso,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-code", name: "read", arguments: { path: join(cwd, "answer.ts"), offset: 7 } }],
+        ...assistantShell,
+        stopReason: "toolUse",
+        timestamp: timestamp + 1,
+      },
+    },
+    {
+      type: "message",
+      id: "00000004",
+      parentId: "00000003",
+      timestamp: iso,
+      message: {
+        role: "toolResult",
+        toolCallId: "call-code",
+        toolName: "read",
+        content: [{ type: "text", text: 'const answer = 42;\nexport function speak() {\n  return "lynx";\n}' }],
+        isError: false,
+        timestamp: timestamp + 2,
+      },
+    },
+    {
+      type: "message",
+      id: "00000005",
+      parentId: "00000004",
       timestamp: iso,
       message: {
         role: "assistant",
@@ -118,33 +149,6 @@ function sessionEntries(cwd) {
         ],
         ...assistantShell,
         stopReason: "toolUse",
-        timestamp: timestamp + 1,
-      },
-    },
-    {
-      type: "message",
-      id: "00000004",
-      parentId: "00000003",
-      timestamp: iso,
-      message: {
-        role: "toolResult",
-        toolCallId: "call-papercut",
-        toolName: "papercut",
-        content: [{ type: "text", text: "Recorded locally" }],
-        isError: false,
-        timestamp: timestamp + 2,
-      },
-    },
-    {
-      type: "message",
-      id: "00000005",
-      parentId: "00000004",
-      timestamp: iso,
-      message: {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call-image", name: "read", arguments: { path: join(cwd, "shot.png") } }],
-        ...assistantShell,
-        stopReason: "toolUse",
         timestamp: timestamp + 3,
       },
     },
@@ -155,12 +159,9 @@ function sessionEntries(cwd) {
       timestamp: iso,
       message: {
         role: "toolResult",
-        toolCallId: "call-image",
-        toolName: "read",
-        content: [
-          { type: "text", text: "Read image file [image/png]" },
-          { type: "image", data: pngBase64(1044, 646), mimeType: "image/png" },
-        ],
+        toolCallId: "call-papercut",
+        toolName: "papercut",
+        content: [{ type: "text", text: "Recorded locally" }],
         isError: false,
         timestamp: timestamp + 4,
       },
@@ -172,10 +173,40 @@ function sessionEntries(cwd) {
       timestamp: iso,
       message: {
         role: "assistant",
+        content: [{ type: "toolCall", id: "call-image", name: "read", arguments: { path: join(cwd, "shot.png") } }],
+        ...assistantShell,
+        stopReason: "toolUse",
+        timestamp: timestamp + 5,
+      },
+    },
+    {
+      type: "message",
+      id: "00000008",
+      parentId: "00000007",
+      timestamp: iso,
+      message: {
+        role: "toolResult",
+        toolCallId: "call-image",
+        toolName: "read",
+        content: [
+          { type: "text", text: "Read image file [image/png]" },
+          { type: "image", data: pngBase64(1044, 646), mimeType: "image/png" },
+        ],
+        isError: false,
+        timestamp: timestamp + 6,
+      },
+    },
+    {
+      type: "message",
+      id: "00000009",
+      parentId: "00000008",
+      timestamp: iso,
+      message: {
+        role: "assistant",
         content: [{ type: "text", text: readySentinel }],
         ...assistantShell,
         stopReason: "stop",
-        timestamp: timestamp + 5,
+        timestamp: timestamp + 7,
       },
     },
   ];
@@ -245,19 +276,36 @@ try {
   if (!resumed.includes(readySentinel)) throw new Error(`resumed session did not render\n${resumed}`);
   if (!resumed.includes("png 1044×646")) throw new Error(`image read trace row missing the png W×H fact\n${resumed}`);
 
-  // 2. Alt+T, then row 2 (the papercut call): the pager shows the complete arguments.
+  // 2. Alt+T, then the papercut row: the pager shows the complete arguments.
   sendKeys("M-t");
-  const drilling = waitForPane((pane) => pane.includes("drill · row 1 of 2"));
-  if (!drilling.includes("drill · row 1 of 2")) throw new Error(`hint bar did not appear\n${drilling}`);
+  const drilling = waitForPane((pane) => pane.includes("drill · row 1 of 3"));
+  if (!drilling.includes("drill · row 1 of 3")) throw new Error(`hint bar did not appear\n${drilling}`);
   sendKeys("2");
-  const papercutPeek = waitForPane((pane) => pane.includes("peek · row 2 of 2"));
+  const papercutPeek = waitForPane((pane) => pane.includes("peek · row 2 of 3"));
   if (!papercutPeek.includes(noteText)) throw new Error(`pager hides the papercut note (bare tool name?)\n${papercutPeek}`);
   if (!papercutPeek.includes("pine-of-glass")) throw new Error(`pager missing the context argument\n${papercutPeek}`);
 
-  // 3. l switches to the image read: the fact line accounts for the image block.
-  sendKeys("l");
-  const imagePeek = waitForPane((pane) => pane.includes("peek · row 1 of 2"));
+  // 3. Digit 1 switches to the image read: the fact line accounts for the image block.
+  sendKeys("1");
+  const imagePeek = waitForPane((pane) => pane.includes("peek · row 1 of 3"));
   if (!imagePeek.includes("image · png · 1044×646")) throw new Error(`pager missing the image fact line\n${imagePeek}`);
+
+  // 4. Digit 3: the code read renders as code, gutter counting from the offset, with
+  // real syntax ink (capture with escapes: the code line must carry SGR beyond the
+  // dim gutter, proving pi's highlighter ran through the live theme).
+  sendKeys("3");
+  const codePeek = waitForPane((pane) => pane.includes("peek · row 3 of 3"));
+  if (!/result · success · [\d.]+k? ?ch · typescript/.test(codePeek)) {
+    throw new Error(`result label missing the language cell\n${codePeek}`);
+  }
+  if (!/7 {2}const answer = 42;/.test(codePeek)) throw new Error(`code gutter missing or misnumbered\n${codePeek}`);
+  if (!/8 {2}export function speak/.test(codePeek)) throw new Error(`gutter did not count on\n${codePeek}`);
+  const inkPane = capturePane("-e");
+  const codeLine = inkPane
+    .split("\n")
+    .find((line) => line.replaceAll(/\x1b\[[0-9;]*m/g, "").includes("const answer"));
+  const sgrCount = (codeLine?.match(/\x1b\[[0-9;]*m/g) ?? []).length;
+  if (sgrCount < 3) throw new Error(`code line lacks syntax ink (${sgrCount} SGR runs)\n${codeLine}`);
 
   sendKeys("Escape");
   sendKeys("Escape");

--- a/tests/smoke/traceline-pager-fidelity-smoke.mjs
+++ b/tests/smoke/traceline-pager-fidelity-smoke.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+// Resume a real Pi session holding the two fidelity gaps the peek pager closes
+// (design language §9.13): a custom tool with no call renderer (papercut-shaped) and a
+// read whose result is an image block. Prove end to end that Alt+T → digit shows the
+// complete arguments (the note text a bare tool name would hide) and the image fact
+// line, and that the image read's trace row wears the `png W×H` what-fact (§9.7).
+// tmux reports no image capability, so the pixel path stays unit/contract-tested;
+// this smoke pins the always-on text tier against the real Pi component stack.
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const extensionPath = join(repoRoot, "extensions", "pi-traceline", "index.ts");
+const tmuxSession = `pog-pager-${process.pid}`;
+const readySentinel = "PAGER_SMOKE_READY";
+const noteText = "Renaming a session mid-run drops the sidebar selection.";
+const hardDeadline = Date.now() + 60_000;
+let launchedPid;
+let fixtureHome;
+let fixtureDir;
+
+function remainingMs(cap = 5_000) {
+  return Math.max(1, Math.min(cap, hardDeadline - Date.now()));
+}
+
+function run(args, options = {}) {
+  return spawnSync(args[0], args.slice(1), {
+    encoding: "utf8",
+    timeout: remainingMs(options.timeoutMs),
+    ...options.spawn,
+  });
+}
+
+function cleanupRun(args) {
+  return spawnSync(args[0], args.slice(1), { encoding: "utf8", timeout: 2_000 });
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function hasTmuxSession() {
+  return run(["tmux", "has-session", "-t", tmuxSession], { timeoutMs: 2_000 }).status === 0;
+}
+
+function capturePane() {
+  return run(["tmux", "capture-pane", "-p", "-t", tmuxSession, "-S", "-500"], { timeoutMs: 2_000 }).stdout ?? "";
+}
+
+function sendKeys(...keys) {
+  return run(["tmux", "send-keys", "-t", tmuxSession, ...keys], { timeoutMs: 2_000 });
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitForPane(predicate) {
+  let pane = "";
+  while (Date.now() < hardDeadline && hasTmuxSession()) {
+    pane = capturePane();
+    if (predicate(pane)) return pane;
+    sleep(200);
+  }
+  return pane;
+}
+
+// A syntactically valid PNG header claiming 1044×646; Pi renders dimensions from the
+// header and treats the payload as opaque, so padding bytes suffice for the fixture.
+function pngBase64(widthPx, heightPx) {
+  const buffer = Buffer.alloc(96);
+  buffer.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  buffer.writeUInt32BE(13, 8);
+  buffer.write("IHDR", 12);
+  buffer.writeUInt32BE(widthPx, 16);
+  buffer.writeUInt32BE(heightPx, 20);
+  return buffer.toString("base64");
+}
+
+function sessionEntries(cwd) {
+  const iso = "2026-07-16T09:00:00.000Z";
+  const timestamp = Date.parse(iso);
+  const usage = {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+  const assistantShell = { api: "anthropic-messages", provider: "anthropic", model: "claude-opus-4-8", usage };
+  return [
+    { type: "session", version: 3, id: "00000001", parentId: null, timestamp: iso, cwd },
+    {
+      type: "message",
+      id: "00000002",
+      parentId: "00000001",
+      timestamp: iso,
+      message: { role: "user", content: [{ type: "text", text: "Resume the pager fidelity fixture." }], timestamp },
+    },
+    {
+      type: "message",
+      id: "00000003",
+      parentId: "00000002",
+      timestamp: iso,
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-papercut",
+            name: "papercut",
+            arguments: { note: noteText, context: "pine-of-glass", surface: "alt+t" },
+          },
+        ],
+        ...assistantShell,
+        stopReason: "toolUse",
+        timestamp: timestamp + 1,
+      },
+    },
+    {
+      type: "message",
+      id: "00000004",
+      parentId: "00000003",
+      timestamp: iso,
+      message: {
+        role: "toolResult",
+        toolCallId: "call-papercut",
+        toolName: "papercut",
+        content: [{ type: "text", text: "Recorded locally" }],
+        isError: false,
+        timestamp: timestamp + 2,
+      },
+    },
+    {
+      type: "message",
+      id: "00000005",
+      parentId: "00000004",
+      timestamp: iso,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-image", name: "read", arguments: { path: join(cwd, "shot.png") } }],
+        ...assistantShell,
+        stopReason: "toolUse",
+        timestamp: timestamp + 3,
+      },
+    },
+    {
+      type: "message",
+      id: "00000006",
+      parentId: "00000005",
+      timestamp: iso,
+      message: {
+        role: "toolResult",
+        toolCallId: "call-image",
+        toolName: "read",
+        content: [
+          { type: "text", text: "Read image file [image/png]" },
+          { type: "image", data: pngBase64(1044, 646), mimeType: "image/png" },
+        ],
+        isError: false,
+        timestamp: timestamp + 4,
+      },
+    },
+    {
+      type: "message",
+      id: "00000007",
+      parentId: "00000006",
+      timestamp: iso,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: readySentinel }],
+        ...assistantShell,
+        stopReason: "stop",
+        timestamp: timestamp + 5,
+      },
+    },
+  ];
+}
+
+function cleanupLaunchedPi() {
+  if (Number.isInteger(launchedPid)) {
+    const panePid = Number.parseInt(
+      cleanupRun(["tmux", "display-message", "-p", "-t", tmuxSession, "#{pane_pid}"]).stdout?.trim() ?? "",
+      10,
+    );
+    const command = cleanupRun(["ps", "-p", String(launchedPid), "-o", "command="]).stdout ?? "";
+    const fixtureOwned = command.includes(tmuxSession) || (fixtureDir && command.includes(fixtureDir));
+    if (panePid === launchedPid || fixtureOwned) {
+      try {
+        process.kill(launchedPid, "SIGKILL");
+      } catch (error) {
+        if (error?.code !== "ESRCH") throw error;
+      }
+    }
+  }
+  cleanupRun(["tmux", "kill-session", "-t", tmuxSession]);
+}
+
+if (run(["tmux", "-V"]).status !== 0) {
+  console.error("tmux not available: real-Pi pager fidelity smoke requires tmux");
+  process.exit(2);
+}
+if (run(["pi", "--version"]).status !== 0) {
+  console.error("pi not on PATH: real-Pi pager fidelity smoke requires an installed Pi");
+  process.exit(2);
+}
+
+fixtureHome = mkdtempSync(join(tmpdir(), "pog-pager-home-"));
+fixtureDir = mkdtempSync(join(tmpdir(), `${tmuxSession}-`));
+const agentDir = join(fixtureHome, ".pi", "agent");
+mkdirSync(agentDir, { recursive: true });
+writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ hideThinkingBlock: true }, null, 2));
+writeFileSync(join(agentDir, "trust.json"), JSON.stringify({ [fixtureDir]: true, [repoRoot]: true }, null, 2));
+writeFileSync(join(fixtureDir, "AGENTS.md"), "# Pager fidelity smoke\nFixture only.\n");
+const sessionFile = join(fixtureDir, "session.jsonl");
+writeFileSync(sessionFile, `${sessionEntries(fixtureDir).map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+
+try {
+  const command = [
+    "exec env",
+    `HOME=${shellQuote(fixtureHome)}`,
+    "pi",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "-e",
+    shellQuote(extensionPath),
+    "--session",
+    shellQuote(sessionFile),
+  ].join(" ");
+  const launch = run(["tmux", "new-session", "-d", "-s", tmuxSession, "-x", "110", "-y", "32", command]);
+  if (launch.status !== 0) throw new Error(`tmux launch failed: ${launch.stderr?.trim()}`);
+
+  const pidResult = run(["tmux", "display-message", "-p", "-t", tmuxSession, "#{pane_pid}"], { timeoutMs: 2_000 });
+  launchedPid = Number.parseInt(pidResult.stdout?.trim() ?? "", 10);
+  if (!Number.isInteger(launchedPid)) throw new Error("could not identify the isolated Pi pane PID");
+
+  // 1. Resume renders both rows; the image read wears the §9.7 what-fact in the trace.
+  const resumed = waitForPane((pane) => pane.includes(readySentinel) && pane.includes("shot.png"));
+  if (!resumed.includes(readySentinel)) throw new Error(`resumed session did not render\n${resumed}`);
+  if (!resumed.includes("png 1044×646")) throw new Error(`image read trace row missing the png W×H fact\n${resumed}`);
+
+  // 2. Alt+T, then row 2 (the papercut call): the pager shows the complete arguments.
+  sendKeys("M-t");
+  const drilling = waitForPane((pane) => pane.includes("drill · row 1 of 2"));
+  if (!drilling.includes("drill · row 1 of 2")) throw new Error(`hint bar did not appear\n${drilling}`);
+  sendKeys("2");
+  const papercutPeek = waitForPane((pane) => pane.includes("peek · row 2 of 2"));
+  if (!papercutPeek.includes(noteText)) throw new Error(`pager hides the papercut note (bare tool name?)\n${papercutPeek}`);
+  if (!papercutPeek.includes("pine-of-glass")) throw new Error(`pager missing the context argument\n${papercutPeek}`);
+
+  // 3. l switches to the image read: the fact line accounts for the image block.
+  sendKeys("l");
+  const imagePeek = waitForPane((pane) => pane.includes("peek · row 1 of 2"));
+  if (!imagePeek.includes("image · png · 1044×646")) throw new Error(`pager missing the image fact line\n${imagePeek}`);
+
+  sendKeys("Escape");
+  sendKeys("Escape");
+  sendKeys("C-c");
+  sendKeys("/quit", "Enter");
+  const exitDeadline = Math.min(hardDeadline, Date.now() + 5_000);
+  while (Date.now() < exitDeadline && hasTmuxSession()) sleep(100);
+  if (hasTmuxSession()) throw new Error("pager fidelity smoke rendered but Pi did not respond to /quit");
+
+  console.log("real-Pi pager fidelity smoke passed");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  cleanupLaunchedPi();
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+  if (fixtureHome) rmSync(fixtureHome, { recursive: true, force: true });
+}

--- a/tests/traceline/drill-pager.test.ts
+++ b/tests/traceline/drill-pager.test.ts
@@ -1,0 +1,186 @@
+// The peek pager's fidelity surface (design language §9.13): a tool without a call
+// renderer shows its complete arguments in the aligned key/value grammar; an image
+// result block always shows its fact line and, on a capable terminal, atomic inline
+// pixels that never render as a sliced escape sequence; kitty image ids are deleted on
+// dispose. Rows are the same synthetic duck types the other suites use; the contract
+// suite pins the real pi shapes (convertedImages, showImages, image result blocks).
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { getCapabilities, setCapabilities, type TUI } from "@earendil-works/pi-tui";
+
+import { DrillPager } from "../../extensions/pi-traceline/drill-pager.ts";
+import { argumentLines, imageFactLine } from "../../extensions/pi-traceline/drill-pager-content.ts";
+import { internals } from "../../extensions/pi-traceline/index.ts";
+import type { DrillHost, DrillState } from "../../extensions/pi-traceline/drill.ts";
+import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
+
+const { setTracelineChat, stripAnsi, toolFactSuffix } = internals;
+
+// A syntactically valid PNG header claiming the given dimensions; pi-tui reads only the
+// header for dimensions and embeds the payload opaquely, so the body can be padding.
+function pngBase64(widthPx: number, heightPx: number, padBytes = 64): string {
+  const buffer = Buffer.alloc(24 + padBytes);
+  buffer.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  buffer.writeUInt32BE(13, 8);
+  buffer.write("IHDR", 12);
+  buffer.writeUInt32BE(widthPx, 16);
+  buffer.writeUInt32BE(heightPx, 20);
+  return buffer.toString("base64");
+}
+
+function imageRow(overrides: Partial<ToolRowLike> = {}): ToolRowLike {
+  return {
+    toolName: "read",
+    args: { path: "/tmp/shot.png" },
+    result: {
+      content: [
+        { type: "text", text: "Read image file [image/png]" },
+        { type: "image", data: pngBase64(100, 4000), mimeType: "image/png" },
+      ],
+      isError: false,
+    },
+    isPartial: false,
+    render: () => [],
+    setExpanded: () => {},
+    ...overrides,
+  } as ToolRowLike;
+}
+
+function pagerFor(rows: ToolRowLike[], terminalRows = 16): DrillPager {
+  const host: DrillHost = {
+    ui: {} as DrillHost["ui"],
+    theme: () => undefined,
+    chatChildren: () => rows,
+    requestRender: () => {},
+    traceLines: () => ["trace line"],
+    runRows: () => undefined,
+    hiddenByFold: () => false,
+    statusTone: () => "success",
+    mouse: false,
+  };
+  const st: DrillState = { host, rows, numbers: new Map(), selected: 0, digits: "", mouseOn: false };
+  const pager = new DrillPager(st);
+  pager.attach({ terminal: { rows: terminalRows } } as unknown as TUI);
+  return pager;
+}
+
+const originalCaps = getCapabilities();
+beforeEach(() => setTracelineChat(undefined));
+afterEach(() => {
+  setCapabilities(originalCaps);
+  setTracelineChat(undefined);
+});
+
+// --- invocation fidelity (§9.13: the arguments are the invocation) ----------------------
+
+test("a tool without a call renderer shows its complete arguments, not a bare name", () => {
+  setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+  const note = "Renaming a session mid-run drops the sidebar selection.";
+  const row = imageRow({
+    toolName: "papercut",
+    args: { note, context: "pine-of-glass", surface: "alt+t" },
+    result: { content: [{ type: "text", text: "Recorded locally" }], isError: false },
+  });
+  delete (row as { callRendererComponent?: unknown }).callRendererComponent;
+  const text = pagerFor([row])
+    .render(80)
+    .map((line) => stripAnsi(line))
+    .join("\n");
+  assert.match(text, /papercut/, "tool name still anchors the invocation");
+  assert.ok(text.includes(`note     ${note}`), "argument keys pad to one aligned column");
+  assert.ok(text.includes("context  pine-of-glass"), "every argument renders");
+  assert.ok(text.includes("surface  alt+t"), "every argument renders");
+});
+
+test("argumentLines: wraps at the value column, JSON for nested values, [] for non-objects", () => {
+  const lines = argumentLines(undefined, { key: "aaaa bbbb cccc dddd", nested: { a: 1 } }, 18).map((l) => stripAnsi(l));
+  assert.equal(lines[0], "key     aaaa bbbb");
+  assert.equal(lines[1], "        cccc dddd", "continuations hang at the value column");
+  assert.equal(lines[2], 'nested  {');
+  assert.match(lines[3]!, /"a": 1/, "nested objects render as indented JSON");
+  assert.deepEqual(argumentLines(undefined, undefined, 80), []);
+  assert.deepEqual(argumentLines(undefined, ["array"], 80), []);
+  assert.deepEqual(argumentLines(undefined, {}, 80), []);
+});
+
+// --- image result blocks (§9.13: every block accounted for) -----------------------------
+
+test("an image block always renders its fact line, even with no image capability", () => {
+  setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+  const fact = stripAnsi(imageFactLine(undefined, { type: "image", data: pngBase64(1044, 646), mimeType: "image/png" }));
+  assert.match(fact, /^image · png · 1044×646 · 0\.1k bytes$/);
+  const lines = pagerFor([imageRow()]).render(80).map((line) => stripAnsi(line));
+  assert.ok(lines.some((line) => /image · png · 100×4000/.test(line)), "fact line present");
+  assert.ok(!lines.some((line) => line.includes("scroll to view")), "no pixel block without capability");
+});
+
+test("inline pixels are atomic: partial visibility shows the hint, full visibility the image", () => {
+  setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: false });
+  const pager = pagerFor([imageRow()]); // 16 terminal rows → 13-line viewport, tall image clamps below it
+  const first = pager.render(80);
+  const firstText = first.map((line) => stripAnsi(line)).join("\n");
+  assert.match(firstText, /image · png · 100×4000/, "fact line above the block");
+  assert.match(firstText, /\(image · scroll to view\)/, "partially visible block shows its hint");
+  assert.ok(!first.some((line) => line.includes("\x1b]1337")), "no sliced escape sequence in a partial window");
+
+  pager.scrollBy(Number.MAX_SAFE_INTEGER); // bottom: the clamped block now fits the window
+  const settled = pager.render(80);
+  assert.ok(settled.some((line) => line.includes("\x1b]1337")), "fully visible block renders the pixels");
+  assert.ok(!settled.map((line) => stripAnsi(line)).join("\n").includes("scroll to view"), "hint yields to pixels");
+});
+
+test("showImages false suppresses pixels; kitty draws only PNG, reusing pi's conversions", () => {
+  setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: false });
+  const off = pagerFor([imageRow({ showImages: false })]).render(80).map((line) => stripAnsi(line)).join("\n");
+  assert.match(off, /image · png/, "the fact line stays");
+  assert.ok(!off.includes("scroll to view"), "no pixel block when pi's showImages is off");
+
+  setCapabilities({ images: "kitty", trueColor: true, hyperlinks: false });
+  const jpeg = { type: "image", data: pngBase64(100, 4000), mimeType: "image/jpeg" };
+  const unconverted = imageRow({ result: { content: [jpeg], isError: false } });
+  const kittyOff = pagerFor([unconverted]).render(80).map((line) => stripAnsi(line)).join("\n");
+  assert.ok(!kittyOff.includes("scroll to view"), "kitty without a PNG conversion keeps the fact line only");
+
+  const converted = imageRow({
+    result: { content: [jpeg], isError: false },
+    convertedImages: new Map([[0, { data: pngBase64(100, 4000), mimeType: "image/png" }]]),
+  });
+  const pager = pagerFor([converted]);
+  pager.render(80);
+  pager.scrollBy(Number.MAX_SAFE_INTEGER);
+  const settled = pager.render(80);
+  assert.ok(settled.some((line) => line.includes("\x1b_G")), "pi's converted PNG renders through kitty");
+
+  // Dispose deletes every kitty id the pager allocated (§9.13 bounded lifecycle).
+  const writes: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    pager.dispose();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  assert.ok(writes.some((chunk) => chunk.includes("a=d")), "dispose emits the kitty delete sequence");
+});
+
+// --- the trace row's image what-fact (§9.7) ---------------------------------------------
+
+test("an image-bearing read wears `png W×H` in the size cell's berth, dim", () => {
+  const row = imageRow();
+  setTracelineChat({ children: [row] });
+  assert.equal(stripAnsi(toolFactSuffix(row)), "png 100×4000");
+  const multi = imageRow({
+    result: {
+      content: [
+        { type: "image", data: pngBase64(2, 2), mimeType: "image/png" },
+        { type: "image", data: pngBase64(4, 4), mimeType: "image/png" },
+      ],
+      isError: false,
+    },
+  });
+  setTracelineChat({ children: [multi] });
+  assert.equal(stripAnsi(toolFactSuffix(multi)), "2 images");
+});

--- a/tests/traceline/drill-pager.test.ts
+++ b/tests/traceline/drill-pager.test.ts
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 import { getCapabilities, setCapabilities, type TUI } from "@earendil-works/pi-tui";
 
 import { DrillPager } from "../../extensions/pi-traceline/drill-pager.ts";
-import { argumentLines, imageFactLine } from "../../extensions/pi-traceline/drill-pager-content.ts";
+import { argumentLines, codeContextFor, imageFactLine, textBlockLines } from "../../extensions/pi-traceline/drill-pager-content.ts";
 import { internals } from "../../extensions/pi-traceline/index.ts";
 import type { DrillHost, DrillState } from "../../extensions/pi-traceline/drill.ts";
 import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
@@ -101,6 +101,51 @@ test("argumentLines: wraps at the value column, JSON for nested values, [] for n
   assert.deepEqual(argumentLines(undefined, undefined, 80), []);
   assert.deepEqual(argumentLines(undefined, ["array"], 80), []);
   assert.deepEqual(argumentLines(undefined, {}, 80), []);
+});
+
+// --- code results (§9.13: code renders as code, ink-only) -------------------------------
+
+test("codeContextFor claims code only when it is provable", () => {
+  const row = (toolName: string, args: object) => ({ ...imageRow(), toolName, args }) as ToolRowLike;
+  assert.deepEqual(codeContextFor(row("read", { path: "a/b.ts", offset: 40 })), { language: "typescript", nextLine: 40 });
+  assert.deepEqual(codeContextFor(row("read", { path: "a/b.ts" })), { language: "typescript", nextLine: 1 });
+  assert.equal(codeContextFor(row("read", { path: "notes.txt" })), undefined);
+  assert.deepEqual(codeContextFor(row("bash", { command: "sed -n 1,120p dist/tool.js" })), {
+    language: "javascript",
+    nextLine: undefined,
+  });
+  assert.deepEqual(codeContextFor(row("bash", { command: "cat 'src/x.py'" })), { language: "python", nextLine: undefined });
+  assert.equal(codeContextFor(row("bash", { command: "cat a.ts | head" })), undefined, "pipes are not provable");
+  assert.equal(codeContextFor(row("bash", { command: "cat a.ts && rm b" })), undefined, "chains are not provable");
+  assert.equal(codeContextFor(row("bash", { command: "echo x.ts" })), undefined, "only printers count");
+  assert.equal(codeContextFor(row("papercut", { note: "x.ts" })), undefined);
+});
+
+test("code blocks: gutter counts from the offset, continuations hang with a blank gutter", () => {
+  const code = { language: "typescript", nextLine: 98 };
+  const text = "function alpha() {\n    return aaaa bbbb cccc dddd eeee ffff gggg hhhh;\n}\n\nconst z = 1;";
+  const lines = textBlockLines(undefined, text, 40, code).map((line) => stripAnsi(line));
+  assert.equal(lines[0], " 98  function alpha() {");
+  assert.equal(lines[1], " 99      return aaaa bbbb cccc dddd", "numbers right-align in one gutter column");
+  assert.equal(lines[2], "          eeee ffff gggg hhhh;", "continuation keeps a blank gutter and hangs under the indent");
+  assert.equal(lines[3], "100  }");
+  assert.equal(lines[4], "101", "blank lines stay counted");
+  assert.equal(lines[5], "102  const z = 1;");
+  assert.equal(code.nextLine, 103, "the counter advances across blocks of one call");
+  const bashLines = textBlockLines(undefined, "const z = 1;", 40, { language: "typescript", nextLine: undefined });
+  assert.equal(stripAnsi(bashLines[0]!), "const z = 1;", "a bash code result gets no gutter");
+});
+
+test("a code read renders through the pager with the language cell and gutter", () => {
+  setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+  const row = imageRow({
+    toolName: "read",
+    args: { path: "src/answer.ts", offset: 7 },
+    result: { content: [{ type: "text", text: "const answer = 42;" }], isError: false },
+  });
+  const text = pagerFor([row]).render(80).map((line) => stripAnsi(line)).join("\n");
+  assert.match(text, /result · success · 0\.0k ch · typescript/, "the result label names the claimed language");
+  assert.match(text, /7  const answer = 42;/, "the gutter counts from the call's offset");
 });
 
 // --- image result blocks (§9.13: every block accounted for) -----------------------------


### PR DESCRIPTION
The peek pager (alt+t → digit) promised "the complete invocation and the complete result" but showed *less* than the model saw in three cases. This PR makes it the fidelity surface the design language now specifies (§9.13, §9.7 amendments included).

## Invocation fidelity
- A tool with no call renderer (papercut, MCP tools, most extension tools) previously showed a bare tool name. It now renders its complete arguments as aligned `key  value` rows: keys dim in one column, string values verbatim with continuations hanging at the value column, nested objects as indented JSON.

## Image results
- Every image block gets a fact line: `image · png · 1044×646 · 65.6k bytes` (previously a dim `[image]`).
- On kitty/iTerm2-capable terminals the pixels render inline, mirroring pi's native tool row: the row's `showImages` is honoured, pi's async kitty PNG conversions are reused, and pi's kitty PNG-only guard is mirrored.
- Images are **atomic under line windowing**: pixels substitute over their placeholder lines only when the whole block is inside the viewport; a partially scrolled image shows a dim `(image · scroll to view)` hint, never a sliced escape sequence. Pager-allocated kitty ids are deleted on row switch/close/exit (same bounded lifecycle as drill-mode mouse reporting).
- Trace rows with an image result wear a dim `png W×H` what-fact in the size cell's berth instead of a misleading text-only char count (§9.7).

## Code results
- A read whose path names a code language renders as code, ink-only: pi's own theme-derived syntax highlighter (`highlightCode`/`getLanguageFromPath` from pi's main entry, zero new deps), a dim right-aligned line-number gutter counting from the call's offset, a language cell on the result label, and wrapped lines that keep a blank gutter cell and hang under the code's own indentation.
- A bash command that is provably one plain `cat`/`sed`/`head`/`tail`/`bat` of a single code file (no pipes, chains, redirects, substitutions) earns the same ink without the gutter. Anything less certain stays plain: highlighting is a claim about what the text is.

## Tests
- 259 unit + contract tests green; new units cover the argument grammar, atomic image scrolling, kitty disposal, `showImages`/`convertedImages` reuse, the code provability gate, offset numbering across the 99→100 gutter boundary, and hanging continuations.
- New contract file `tests/contract/pi-pager-seams.test.ts` pins every pi seam piggybacked on (read image blocks, `convertedImages` indexing, `showImages` default, kitty PNG guard, bare-name call fallback, highlight exports being line-preserving and ink-only, pi-tui image API).
- New real-pi smoke `test:smoke:pager`: resumes a fixture session with a papercut call, an image read, and a code read, and asserts in a live pi TUI the full args, the image fact line, the trace what-fact, the offset gutter, and actual SGR syntax ink on the code line (`tmux capture-pane -e`).