### PR TITLE
Fold repeated Traceline commands within one step

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -409,11 +409,21 @@ row stays on the exact grid and can never overflow. Rows that fit their budget
 simply end early, like prose. A mid-token cut beside a dim ellipsis is legible;
 a wandering ellipsis column is not.
 
-### 9.9 Folded reads
+### 9.9 Repetition folds
 
-Consecutive reads fold into one entity, at two granularities sharing one
-grammar (both adopted against a 400-session corpus of real transcripts, per
-§10):
+Calls in one assistant step whose compact invocation lines are identical fold into
+one row with a dim multiplication count: `mcp call linear_save_issue ×22`. The
+visible invocation is the fold key, not the complete arguments: when Traceline cannot
+show how calls differ, repeating the same line adds no information. Calls from separate
+assistant steps never merge. The folded row sums landed result sizes; any running call
+keeps it running, and any failed call makes it an error. Expanded rows, reads, file
+mutations, image results and record rows do not participate because their individual
+rendering carries information the generic fold cannot preserve. An expanded row also
+splits a fold, so no aggregate crosses a native-rendered block. Ctrl+T restores every
+native row.
+
+Consecutive reads use a richer fold at two granularities sharing one grammar (both
+adopted against a 400-session corpus of real transcripts, per §10):
 
 - paginated reads of one file merge their ranges:
   `read …/index.ts:1-200,201-400 · 2 calls · 37.0k ch`

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -411,16 +411,13 @@ a wandering ellipsis column is not.
 
 ### 9.9 Repetition folds
 
-Calls in one assistant step whose compact invocation lines are identical fold into
-one row with a dim multiplication count: `mcp call linear_save_issue ×22`. The
-visible invocation is the fold key, not the complete arguments: when Traceline cannot
-show how calls differ, repeating the same line adds no information. Calls from separate
-assistant steps never merge. The folded row sums landed result sizes; any running call
-keeps it running, and any failed call makes it an error. Expanded rows, reads, file
-mutations, image results and record rows do not participate because their individual
-rendering carries information the generic fold cannot preserve. An expanded row also
-splits a fold, so no aggregate crosses a native-rendered block. Ctrl+T restores every
-native row.
+Identical compact invocations within one assistant step fold into one row with a dim
+count: `mcp call linear_save_issue ×22`. The visible invocation is the key, so calls
+with different hidden arguments may fold; calls from separate steps never do. Folded
+rows sum landed result sizes and use the worst status: error, then running, then
+success. Expanded rows split folds. Reads, file mutations, image results and record
+rows stay separate because their row-specific facts matter. Ctrl+T restores native
+rows.
 
 Consecutive reads use a richer fold at two granularities sharing one grammar (both
 adopted against a 400-session corpus of real transcripts, per §10):

--- a/extensions/_lib/chat.ts
+++ b/extensions/_lib/chat.ts
@@ -37,6 +37,7 @@ export interface ToolCallRendererLike {
 }
 
 export interface ToolRowDataLike {
+  toolCallId?: unknown;
   toolName?: unknown;
   args?: ToolArgsLike;
   result?: ToolResultLike;

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -135,6 +135,8 @@ Traceline only shows an outcome when the tool output proves it happened. It does
 
 Traceline folds adjacent rows when repetition would hide the useful difference:
 
+- identical compact invocations from one assistant step become one row with a count, for
+  example `mcp call linear_save_issue ×22`; separate steps stay separate
 - repeated `cd`, environment assignment and setup prefixes become `⋯`
 - paginated reads of one file become one row with all ranges, the call count and total size
 - consecutive reads of sibling files become one row: the shared directory prints once,

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -133,9 +133,9 @@ Traceline only shows an outcome when the tool output proves it happened. It does
 
 ## Keep repeated work compact
 
-Traceline folds adjacent rows when repetition would hide the useful difference:
+Traceline folds rows when repetition would hide the useful difference:
 
-- identical compact invocations from one assistant step become one row with a count, for
+- identical compact invocations within one assistant step become one counted row, for
   example `mcp call linear_save_issue ×22`; separate steps stay separate
 - repeated `cd`, environment assignment and setup prefixes become `⋯`
 - paginated reads of one file become one row with all ranges, the call count and total size

--- a/extensions/pi-traceline/drill.ts
+++ b/extensions/pi-traceline/drill.ts
@@ -163,7 +163,8 @@ export function togglePin(st: DrillState): void {
   const row = st.rows[st.selected];
   if (!row) return;
   try {
-    row.setExpanded(row.expanded !== true);
+    const expanded = row.expanded !== true;
+    for (const member of st.host.runRows(row) ?? [row]) member.setExpanded(expanded);
   } catch {
     // Pi seam: never let a pin toggle break the mode.
   }

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -45,6 +45,7 @@ import { handleDrillTerminalInput } from "./drill-input.ts";
 import { resultImageFact } from "./image-fact.ts";
 import { commonDirSegments, compactReadDisplay, cwdRelativePath, lineRange, readDirKey } from "./path-rows.ts";
 import { recordFacts, type RecordTone } from "./records.ts";
+import { adjacentReadGroups, combinedResultChars, foldedStatus, groupedReadRun, groupedRepetitionRun } from "./repetition-fold.ts";
 import {
   captureWriteSnapshot,
   diffStatsFromContents,
@@ -445,8 +446,13 @@ function blockSizeColumnLive(comp: ToolRowLike): boolean {
 function blockSuffixReserve(rows: ToolRowLike[], facts: BlockFacts, available: number): number {
   let widest = 0;
   for (const row of rows) {
-    const run = readRun(row);
-    const suffix = run ? foldedReadSuffix(run.rows, facts) : toolFactSuffix(row, available, facts);
+    const read = readRun(row);
+    const repeated = read ? undefined : repetitionRun(row);
+    const suffix = read
+      ? foldedReadSuffix(read.rows, facts)
+      : repeated
+        ? charSuffix(combinedResultChars(repeated.rows), facts.sizeColumnLive)
+        : toolFactSuffix(row, available, facts);
     widest = Math.max(widest, visibleWidth(suffix));
   }
   return widest > 0 ? widest + 2 : 0;
@@ -1254,54 +1260,36 @@ function sameDirReadRows(comp: ToolRowLike): { rows: ToolRowLike[]; index: numbe
   return { rows, index: selfIndex };
 }
 
-// One file inside a run: the maximal sequence of adjacent same-path calls. A file
-// whose combined landed result reaches warning severity is a breakout (§9.9): it
-// keeps its own row — a pagination fold when paged — rather than melting into the
-// dir fold. Running calls (no result yet) count nothing; when the result lands, the
-// per-render recompute pops a ballooning file out of the fold on its own.
-type ReadFileGroup = { rows: ToolRowLike[]; breakout: boolean };
-
-function readFileGroups(rows: ToolRowLike[]): ReadFileGroup[] {
-  const grouped: { path: string; rows: ToolRowLike[] }[] = [];
-  for (const row of rows) {
-    const path = String(row?.args?.path ?? "");
-    const last = grouped[grouped.length - 1];
-    if (last && last.path === path) last.rows.push(row);
-    else grouped.push({ path, rows: [row] });
-  }
-  return grouped.map((group) => {
-    let combined = 0;
-    for (const row of group.rows) combined += resultTextCharCount(row) ?? 0;
-    return { rows: group.rows, breakout: combined >= sizeThresholds.warning };
-  });
+// Recompute read groups as results land so ballooning files never disappear.
+function readRun(comp: ToolRowLike): { rows: ToolRowLike[]; index: number } | undefined {
+  const run = sameDirReadRows(comp); return run ? groupedReadRun(run, sizeThresholds.warning) : undefined;
 }
 
-// comp's fold unit: a breakout file is a unit of its own; maximal sequences of
-// adjacent sub-warning files merge into one dir-fold unit. A unit folds only when it
-// spans more than one call — a lone sub-warning read beside breakouts renders alone,
-// and a single unpaged read renders exactly as before.
-function readRun(comp: ToolRowLike): { rows: ToolRowLike[]; index: number } | undefined {
-  const run = sameDirReadRows(comp);
-  if (!run) return undefined;
-  const units: { rows: ToolRowLike[]; start: number; breakout: boolean }[] = [];
-  let offset = 0;
-  for (const group of readFileGroups(run.rows)) {
-    const open = units[units.length - 1];
-    if (!group.breakout && open && !open.breakout) open.rows.push(...group.rows);
-    else units.push({ rows: [...group.rows], start: offset, breakout: group.breakout });
-    offset += group.rows.length;
-  }
-  const unit = units.find((u) => run.index >= u.start && run.index < u.start + u.rows.length);
-  if (!unit || unit.rows.length < 2) return undefined;
-  return { rows: unit.rows, index: run.index - unit.start };
+// Reads, mutations, records and images carry facts a generic count cannot preserve.
+function repetitionKey(comp: ToolRowLike): string | undefined {
+  if (comp.expanded === true || toolLabel(comp.toolName) === "read") return undefined;
+  if (inlineMutationRow(comp) || recordRow(comp) || resultImageFact(comp)) return undefined;
+  return stripAnsi(invocationInk(comp)).trim() || undefined;
+}
+
+function repetitionRun(comp: ToolRowLike): { rows: ToolRowLike[]; index: number } | undefined {
+  const found = componentLocation(comp); return found ? groupedRepetitionRun(comp, found.sibs, repetitionKey) : undefined;
+}
+
+function foldedRepetitionLine(rows: ToolRowLike[], width: number): string {
+  const carrier = rows[0]!;
+  const display = rows.find((row) => toolStatus(row) === "error") ?? carrier;
+  const blockRows = blockToolRows(carrier);
+  const facts = blockFacts(blockRows);
+  const available = traceRowAvailable(width);
+  const body = `${invocationInk(display, available)}${dim(` ×${rows.length}`)}`;
+  const suffix = charSuffix(combinedResultChars(rows), facts.sizeColumnLive);
+  return fitTraceRow(carrier, foldedStatus(rows, toolStatus), body, suffix,
+    blockSuffixReserve(blockRows, facts, available), width);
 }
 
 function foldedReadSuffix(rows: ToolRowDataLike[], facts: BlockFacts): string {
-  let total: number | undefined;
-  for (const row of rows) {
-    const chars = resultTextCharCount(row);
-    if (chars !== undefined) total = (total ?? 0) + chars;
-  }
+  const total = combinedResultChars(rows);
   const calls = `${rows.length} calls`;
   const sizeCell = charSuffix(total, facts.sizeColumnLive);
   return total === undefined || !sizeCell ? dim(calls) : `${dim(`${calls}${SEP}`)}${sizeCell}`;
@@ -1354,11 +1342,10 @@ function foldedReadLines(rows: ToolRowLike[], width: number): string[] {
       : verbInk(last, "read");
 
   type FoldCell = { ink: string; plain: string };
-  const cells: FoldCell[] = readFileGroups(rows).map((group) => {
-    const groupPath = String(group.rows[0]?.args?.path ?? "");
-    const base = groupPath.slice(groupPath.lastIndexOf("/") + 1);
+  const cells: FoldCell[] = adjacentReadGroups(rows).map((group) => {
+    const base = group.path.slice(group.path.lastIndexOf("/") + 1);
     const ranges = group.rows
-      .map((row) => lineRange(row?.args).slice(1))
+      .map((row) => lineRange(row.args).slice(1))
       .filter(Boolean)
       .join(",");
     const rangeText = ranges ? `:${ranges}` : "";
@@ -1480,11 +1467,17 @@ function leadingBlank(comp: ToolRowDataLike): boolean {
 // One row's worth of one-line output: folded-run handling plus the group-spacing rule.
 // Shared by the prototype patch and the test suites.
 function renderTraceRow(comp: ToolRowLike, width: number): string[] {
-  const run = readRun(comp);
-  if (run) {
-    if (run.index > 0) return []; // a later call: the unit's first row carries the fold
-    const lines = foldedReadLines(run.rows, width);
+  const read = readRun(comp);
+  if (read) {
+    if (read.index > 0) return []; // a later call: the unit's first row carries the fold
+    const lines = foldedReadLines(read.rows, width);
     return leadingBlank(comp) ? ["", ...lines] : lines;
+  }
+  const repeated = repetitionRun(comp);
+  if (repeated) {
+    if (repeated.index > 0) return [];
+    const line = foldedRepetitionLine(repeated.rows, width);
+    return leadingBlank(comp) ? ["", line] : [line];
   }
   const line = oneLine(comp, width);
   return leadingBlank(comp) ? ["", line] : [line];
@@ -1653,6 +1646,8 @@ export const internals = {
   foldBashPreamble,
   previousBashRow,
   readRun,
+  repetitionRun,
+  foldedRepetitionLine,
   dedupeThinkingLabels,
   // typed test/dev accessors for traceline's Pi seam globals
   setTracelineChat,
@@ -1687,15 +1682,20 @@ export default function piTraceline(pi: ExtensionAPI) {
       }
     },
     traceLines: (comp, width) => {
-      const run = readRun(comp);
-      return run && run.index === 0 ? foldedReadLines(run.rows, width) : [oneLine(comp, width)];
+      const read = readRun(comp);
+      if (read?.index === 0) return foldedReadLines(read.rows, width);
+      const repeated = repetitionRun(comp);
+      return repeated?.index === 0 ? [foldedRepetitionLine(repeated.rows, width)] : [oneLine(comp, width)];
     },
     runRows: (comp) => {
-      const run = readRun(comp);
-      return run && run.index === 0 ? run.rows : undefined;
+      const read = readRun(comp);
+      if (read?.index === 0) return read.rows;
+      const repeated = repetitionRun(comp);
+      return repeated?.index === 0 ? repeated.rows : undefined;
     },
-    // Only one-line mode folds reads away; in native mode every row is its own target.
-    hiddenByFold: (comp) => displayMode() === "oneLine" && (readRun(comp)?.index ?? 0) > 0,
+    // Only one-line mode folds rows away; in native mode every row is its own target.
+    hiddenByFold: (comp) =>
+      displayMode() === "oneLine" && ((readRun(comp)?.index ?? 0) > 0 || (repetitionRun(comp)?.index ?? 0) > 0),
     statusTone,
     mouse: config.drillMouse !== false,
   });

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -45,7 +45,7 @@ import { handleDrillTerminalInput } from "./drill-input.ts";
 import { resultImageFact } from "./image-fact.ts";
 import { commonDirSegments, compactReadDisplay, cwdRelativePath, lineRange, readDirKey } from "./path-rows.ts";
 import { recordFacts, type RecordTone } from "./records.ts";
-import { adjacentReadGroups, combinedResultChars, foldedStatus, groupedReadRun, groupedRepetitionRun } from "./repetition-fold.ts";
+import { adjacentReadGroups, combinedResultChars, groupedReadRun, groupedRepetitionRun } from "./repetition-fold.ts";
 import {
   captureWriteSnapshot,
   diffStatsFromContents,
@@ -1260,9 +1260,9 @@ function sameDirReadRows(comp: ToolRowLike): { rows: ToolRowLike[]; index: numbe
   return { rows, index: selfIndex };
 }
 
-// Recompute read groups as results land so ballooning files never disappear.
 function readRun(comp: ToolRowLike): { rows: ToolRowLike[]; index: number } | undefined {
-  const run = sameDirReadRows(comp); return run ? groupedReadRun(run, sizeThresholds.warning) : undefined;
+  const run = sameDirReadRows(comp);
+  return run ? groupedReadRun(run, sizeThresholds.warning) : undefined;
 }
 
 // Reads, mutations, records and images carry facts a generic count cannot preserve.
@@ -1273,18 +1273,20 @@ function repetitionKey(comp: ToolRowLike): string | undefined {
 }
 
 function repetitionRun(comp: ToolRowLike): { rows: ToolRowLike[]; index: number } | undefined {
-  const found = componentLocation(comp); return found ? groupedRepetitionRun(comp, found.sibs, repetitionKey) : undefined;
+  const found = componentLocation(comp);
+  return found ? groupedRepetitionRun(comp, found.sibs, repetitionKey) : undefined;
 }
 
 function foldedRepetitionLine(rows: ToolRowLike[], width: number): string {
   const carrier = rows[0]!;
-  const display = rows.find((row) => toolStatus(row) === "error") ?? carrier;
+  const failed = rows.find((row) => toolStatus(row) === "error");
+  const status = failed ? "error" : rows.some((row) => toolStatus(row) === "running") ? "running" : "success";
   const blockRows = blockToolRows(carrier);
   const facts = blockFacts(blockRows);
   const available = traceRowAvailable(width);
-  const body = `${invocationInk(display, available)}${dim(` ×${rows.length}`)}`;
+  const body = `${invocationInk(failed ?? carrier, available)}${dim(` ×${rows.length}`)}`;
   const suffix = charSuffix(combinedResultChars(rows), facts.sizeColumnLive);
-  return fitTraceRow(carrier, foldedStatus(rows, toolStatus), body, suffix,
+  return fitTraceRow(carrier, status, body, suffix,
     blockSuffixReserve(blockRows, facts, available), width);
 }
 
@@ -1646,8 +1648,6 @@ export const internals = {
   foldBashPreamble,
   previousBashRow,
   readRun,
-  repetitionRun,
-  foldedRepetitionLine,
   dedupeThinkingLabels,
   // typed test/dev accessors for traceline's Pi seam globals
   setTracelineChat,

--- a/extensions/pi-traceline/repetition-fold.ts
+++ b/extensions/pi-traceline/repetition-fold.ts
@@ -52,13 +52,12 @@ function assistantStepRows(comp: ToolRowLike, siblings: unknown[]): ToolRowLike[
     if (!isAssistantRow(sibling)) continue;
     const content = sibling.lastMessage?.content;
     if (!Array.isArray(content)) continue;
-    const ids = content.flatMap((block: unknown) => {
-      if (!block || typeof block !== "object") return [];
-      const call = block as { type?: unknown; id?: unknown };
-      return call.type === "toolCall" && typeof call.id === "string" ? [call.id] : [];
-    });
-    if (!ids.includes(id)) continue;
-    const stepIds = new Set(ids);
+    const stepIds = new Set<string>();
+    for (const block of content) {
+      const call = block && typeof block === "object" ? block as { type?: unknown; id?: unknown } : undefined;
+      if (call?.type === "toolCall" && typeof call.id === "string") stepIds.add(call.id);
+    }
+    if (!stepIds.has(id)) continue;
     return siblings.filter(
       (row): row is ToolRowLike =>
         isToolRow(row) && typeof row.toolCallId === "string" && stepIds.has(row.toolCallId),

--- a/extensions/pi-traceline/repetition-fold.ts
+++ b/extensions/pi-traceline/repetition-fold.ts
@@ -1,5 +1,3 @@
-// Loss-aware grouping for Traceline's two repetition folds. This module owns only
-// membership and aggregation; index.ts keeps the family rendering grammar.
 import {
   isAssistantRow,
   isToolRow,
@@ -8,7 +6,7 @@ import {
   type ToolRowLike,
 } from "../_lib/chat.ts";
 
-export type FoldRun = { rows: ToolRowLike[]; index: number };
+type FoldRun = { rows: ToolRowLike[]; index: number };
 
 export function combinedResultChars(rows: ToolRowDataLike[]): number | undefined {
   let total: number | undefined;
@@ -18,8 +16,6 @@ export function combinedResultChars(rows: ToolRowDataLike[]): number | undefined
   }
   return total;
 }
-
-type ReadFileGroup = { rows: ToolRowLike[]; breakout: boolean };
 
 export function adjacentReadGroups(rows: ToolRowLike[]): Array<{ path: string; rows: ToolRowLike[] }> {
   const grouped: { path: string; rows: ToolRowLike[] }[] = [];
@@ -32,26 +28,20 @@ export function adjacentReadGroups(rows: ToolRowLike[]): Array<{ path: string; r
   return grouped;
 }
 
-function readFileGroups(rows: ToolRowLike[], warningChars: number): ReadFileGroup[] {
-  return adjacentReadGroups(rows).map((group) => ({
-    rows: group.rows,
-    breakout: (combinedResultChars(group.rows) ?? 0) >= warningChars,
-  }));
-}
-
 export function groupedReadRun(run: FoldRun, warningChars: number): FoldRun | undefined {
   const units: { rows: ToolRowLike[]; start: number; breakout: boolean }[] = [];
   let offset = 0;
-  for (const group of readFileGroups(run.rows, warningChars)) {
+  for (const group of adjacentReadGroups(run.rows)) {
+    const breakout = (combinedResultChars(group.rows) ?? 0) >= warningChars;
     const open = units[units.length - 1];
-    if (!group.breakout && open && !open.breakout) open.rows.push(...group.rows);
-    else units.push({ rows: [...group.rows], start: offset, breakout: group.breakout });
+    if (!breakout && open && !open.breakout) open.rows.push(...group.rows);
+    else units.push({ rows: [...group.rows], start: offset, breakout });
     offset += group.rows.length;
   }
   const unit = units.find((candidate) =>
     run.index >= candidate.start && run.index < candidate.start + candidate.rows.length
-  );
-  if (!unit || unit.rows.length < 2) return undefined;
+  )!;
+  if (unit.rows.length < 2) return undefined;
   return { rows: unit.rows, index: run.index - unit.start };
 }
 
@@ -85,10 +75,10 @@ export function groupedRepetitionRun(
   keyOf: (row: ToolRowLike) => string | undefined,
 ): FoldRun | undefined {
   const key = keyOf(comp);
-  const step = key ? assistantStepRows(comp, siblings) : undefined;
-  if (!key || !step) return undefined;
+  if (!key) return undefined;
+  const step = assistantStepRows(comp, siblings);
+  if (!step) return undefined;
   const self = step.indexOf(comp);
-  if (self < 0) return undefined;
   let start = self;
   let end = self + 1;
   while (start > 0 && step[start - 1]?.expanded !== true) start--;
@@ -96,13 +86,4 @@ export function groupedRepetitionRun(
   const rows = step.slice(start, end).filter((row) => keyOf(row) === key);
   if (rows.length < 2) return undefined;
   return { rows, index: rows.indexOf(comp) };
-}
-
-export function foldedStatus(
-  rows: ToolRowDataLike[],
-  statusOf: (row: ToolRowDataLike) => "success" | "running" | "error",
-): "success" | "running" | "error" {
-  if (rows.some((row) => statusOf(row) === "error")) return "error";
-  if (rows.some((row) => statusOf(row) === "running")) return "running";
-  return "success";
 }

--- a/extensions/pi-traceline/repetition-fold.ts
+++ b/extensions/pi-traceline/repetition-fold.ts
@@ -1,0 +1,108 @@
+// Loss-aware grouping for Traceline's two repetition folds. This module owns only
+// membership and aggregation; index.ts keeps the family rendering grammar.
+import {
+  isAssistantRow,
+  isToolRow,
+  resultTextCharCount,
+  type ToolRowDataLike,
+  type ToolRowLike,
+} from "../_lib/chat.ts";
+
+export type FoldRun = { rows: ToolRowLike[]; index: number };
+
+export function combinedResultChars(rows: ToolRowDataLike[]): number | undefined {
+  let total: number | undefined;
+  for (const row of rows) {
+    const chars = resultTextCharCount(row);
+    if (chars !== undefined) total = (total ?? 0) + chars;
+  }
+  return total;
+}
+
+type ReadFileGroup = { rows: ToolRowLike[]; breakout: boolean };
+
+export function adjacentReadGroups(rows: ToolRowLike[]): Array<{ path: string; rows: ToolRowLike[] }> {
+  const grouped: { path: string; rows: ToolRowLike[] }[] = [];
+  for (const row of rows) {
+    const path = String(row.args?.path ?? "");
+    const last = grouped[grouped.length - 1];
+    if (last && last.path === path) last.rows.push(row);
+    else grouped.push({ path, rows: [row] });
+  }
+  return grouped;
+}
+
+function readFileGroups(rows: ToolRowLike[], warningChars: number): ReadFileGroup[] {
+  return adjacentReadGroups(rows).map((group) => ({
+    rows: group.rows,
+    breakout: (combinedResultChars(group.rows) ?? 0) >= warningChars,
+  }));
+}
+
+export function groupedReadRun(run: FoldRun, warningChars: number): FoldRun | undefined {
+  const units: { rows: ToolRowLike[]; start: number; breakout: boolean }[] = [];
+  let offset = 0;
+  for (const group of readFileGroups(run.rows, warningChars)) {
+    const open = units[units.length - 1];
+    if (!group.breakout && open && !open.breakout) open.rows.push(...group.rows);
+    else units.push({ rows: [...group.rows], start: offset, breakout: group.breakout });
+    offset += group.rows.length;
+  }
+  const unit = units.find((candidate) =>
+    run.index >= candidate.start && run.index < candidate.start + candidate.rows.length
+  );
+  if (!unit || unit.rows.length < 2) return undefined;
+  return { rows: unit.rows, index: run.index - unit.start };
+}
+
+function assistantStepRows(comp: ToolRowLike, siblings: unknown[]): ToolRowLike[] | undefined {
+  const id = typeof comp.toolCallId === "string" ? comp.toolCallId : undefined;
+  if (!id) return undefined;
+  for (const sibling of siblings) {
+    if (!isAssistantRow(sibling)) continue;
+    const content = sibling.lastMessage?.content;
+    if (!Array.isArray(content)) continue;
+    const ids = content.flatMap((block: unknown) => {
+      if (!block || typeof block !== "object") return [];
+      const call = block as { type?: unknown; id?: unknown };
+      return call.type === "toolCall" && typeof call.id === "string" ? [call.id] : [];
+    });
+    if (!ids.includes(id)) continue;
+    const stepIds = new Set(ids);
+    return siblings.filter(
+      (row): row is ToolRowLike =>
+        isToolRow(row) && typeof row.toolCallId === "string" && stepIds.has(row.toolCallId),
+    );
+  }
+  return undefined;
+}
+
+// Pi's durable toolCallId link scopes the fold. Adjacency alone would merge sequential
+// assistant steps whose compact MCP rows happen to look the same.
+export function groupedRepetitionRun(
+  comp: ToolRowLike,
+  siblings: unknown[],
+  keyOf: (row: ToolRowLike) => string | undefined,
+): FoldRun | undefined {
+  const key = keyOf(comp);
+  const step = key ? assistantStepRows(comp, siblings) : undefined;
+  if (!key || !step) return undefined;
+  const self = step.indexOf(comp);
+  if (self < 0) return undefined;
+  let start = self;
+  let end = self + 1;
+  while (start > 0 && step[start - 1]?.expanded !== true) start--;
+  while (end < step.length && step[end]?.expanded !== true) end++;
+  const rows = step.slice(start, end).filter((row) => keyOf(row) === key);
+  if (rows.length < 2) return undefined;
+  return { rows, index: rows.indexOf(comp) };
+}
+
+export function foldedStatus(
+  rows: ToolRowDataLike[],
+  statusOf: (row: ToolRowDataLike) => "success" | "running" | "error",
+): "success" | "running" | "error" {
+  if (rows.some((row) => statusOf(row) === "error")) return "error";
+  if (rows.some((row) => statusOf(row) === "running")) return "running";
+  return "success";
+}

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -116,8 +116,7 @@ test("startup resource list still renders [Section] headers contextimate anchors
 });
 
 // ---------------------------------------------------------------------------------------
-// Real interactive components vs traceline's duck types and prototype patch points.
-
+// Interactive components used through Traceline's duck types.
 test("real ToolExecutionComponent satisfies traceline's duck type and one-line path", () => {
   pi.initTheme(undefined, false);
   const comp = new pi.ToolExecutionComponent(
@@ -131,12 +130,12 @@ test("real ToolExecutionComponent satisfies traceline's duck type and one-line p
   );
 
   assert.equal(traceline.isToolRow(comp), true, "ToolExecutionComponent no longer matches isToolRow (render/setExpanded/toolName)");
+  assert.equal((comp as unknown as { toolCallId?: unknown }).toolCallId, "tool-1", "toolCallId no longer mirrors the call ID");
 
   const proto = Object.getPrototypeOf(comp) as { render?: unknown };
   const descriptor = Object.getOwnPropertyDescriptor(proto, "render");
   assert.ok(descriptor && (descriptor.writable ?? false), "prototype render not writable — traceline patch cannot install");
 
-  // ≥100 ch so the result-size suffix appears (traceline omits it below the fact floor).
   comp.updateResult({ content: [{ type: "text", text: "hello world ".repeat(20) }], isError: false }, false);
   assert.equal(traceline.toolStatus(comp as never), "success", "result/isPartial fields drifted — status colours break");
 
@@ -145,8 +144,6 @@ test("real ToolExecutionComponent satisfies traceline's duck type and one-line p
   assert.ok(visible.includes("read"), `one-line render lost the invocation: ${JSON.stringify(visible)}`);
   assert.ok(/\b0\.2k ch$/.test(visible.trimEnd()), `result-size suffix missing: ${JSON.stringify(visible)}`);
 
-  // A distinct execution reaches the error state; a settled successful component is
-  // never updated to a second final result by Pi's event stream.
   const errorComp = new pi.ToolExecutionComponent(
     "read",
     "tool-error",
@@ -172,8 +169,6 @@ test("real ToolExecutionComponent: bash multiline render seam", () => {
     tmpdir(),
   );
 
-  // Multiline commands render one line per real newline, timeout suffix on the last —
-  // the shape flattenInvocationLines + stripTimeoutSuffix assume (issue #10).
   const callComp = (comp as unknown as { callRendererComponent?: { render?: (w: number) => string[] } }).callRendererComponent;
   assert.ok(callComp && typeof callComp.render === "function", "bash callRendererComponent gone — one-line path falls back");
   const lines = callComp.render(10_000);
@@ -184,11 +179,16 @@ test("real ToolExecutionComponent: bash multiline render seam", () => {
   assert.ok(flat.includes("echo done"), `flattened bash row lost its tail: ${flat}`);
 });
 
-test("real AssistantMessageComponent satisfies traceline's assistant duck type", () => {
-  const component = new pi.AssistantMessageComponent(assistantMessage([{ type: "text", text: "hi" }]));
+test("real AssistantMessageComponent preserves its tool-call link and duck type", () => {
+  const component = new pi.AssistantMessageComponent(assistantMessage([
+    { type: "toolCall", id: "tool-1", name: "read", arguments: { path: "/tmp/contract-fixture.txt" } },
+  ]));
   assert.equal(traceline.isAssistantRow(component), true, "AssistantMessageComponent no longer matches isAssistantRow");
-  // hideThinkingBlock is declared private but traceline reads it duck-typed at runtime.
-  const peek = component as unknown as { hideThinkingBlock: boolean };
+  const peek = component as unknown as {
+    hideThinkingBlock: boolean;
+    lastMessage?: { content?: Array<{ id?: unknown }> };
+  };
+  assert.equal(peek.lastMessage?.content?.[0]?.id, "tool-1", "assistant tool-call ID no longer links to its execution row");
   assert.equal(peek.hideThinkingBlock, false);
   component.setHideThinkingBlock(true);
   assert.equal(peek.hideThinkingBlock, true, "hideThinkingBlock no longer mirrors setHideThinkingBlock — collapse state desyncs");

--- a/tests/traceline/drill.test.ts
+++ b/tests/traceline/drill.test.ts
@@ -270,10 +270,13 @@ test("a folded read run is one numbered target", () => {
 
   // §9.9's sibling-file dir fold is also one target, carried by its first row.
   const sibling = toolComp({ args: { path: "/tmp/demo/sibling.ts" } });
-  enterDrillMode(makeHost([page1, page2, sibling]));
+  const calls: CustomCall[] = [];
+  enterDrillMode(makeHost([page1, page2, sibling], calls));
   const dirFold = drillState()!;
   assert.equal(dirFold.rows.length, 1, "a sibling dir fold is one target");
   assert.equal(dirFold.rows[0], page1, "the dir fold's carrier is its first row");
+  calls[0]!.component.handleInput!("p");
+  assert.ok([page1, page2, sibling].every((row) => row.expanded === true), "pin expands every member of a folded target");
 });
 
 // --- mouse -------------------------------------------------------------------------------

--- a/tests/traceline/repetition.test.ts
+++ b/tests/traceline/repetition.test.ts
@@ -17,7 +17,6 @@ const {
   bashPreambleRun,
   foldBashPreamble,
   renderTraceRow,
-  repetitionRun,
   setTracelineChat,
   setTracelineThemeGetter,
 } = internals;
@@ -67,11 +66,6 @@ test("identical compact invocations in one assistant step fold with a count and 
   const c = mcpComp("NEXSELL-3", 900);
   setTracelineChat({ children: [assistantBefore([a, b, c]), a, b, c] });
 
-  const run = repetitionRun(b);
-  assert.ok(run, "a middle call must see its assistant-step fold");
-  assert.equal(run!.rows.length, 3);
-  assert.equal(run!.index, 1);
-
   const first = renderTraceRow(a, 100);
   const visible = stripAnsi(first.at(-1)!);
   assert.ok(visible.includes("mcp call linear_save_issue ×3"), visible);
@@ -85,8 +79,6 @@ test("identical invocations in separate assistant steps stay separate", () => {
   const b = mcpComp("NEXSELL-2", 300);
   setTracelineChat({ children: [assistantBefore([a]), a, assistantBefore([b]), b] });
 
-  assert.equal(repetitionRun(a), undefined);
-  assert.equal(repetitionRun(b), undefined);
   assert.ok(!stripAnsi(renderTraceRow(a, 100).at(-1)!).includes("×"));
   assert.ok(!stripAnsi(renderTraceRow(b, 100).at(-1)!).includes("×"));
 });
@@ -97,9 +89,8 @@ test("an expanded row splits a same-step repetition fold", () => {
   const c = mcpComp("NEXSELL-3", 100);
   setTracelineChat({ children: [assistantBefore([a, expanded, c]), a, expanded, c] });
 
-  assert.equal(repetitionRun(a), undefined, "a fold cannot cross a native expanded row");
-  assert.equal(repetitionRun(expanded), undefined);
-  assert.equal(repetitionRun(c), undefined);
+  assert.ok(!stripAnsi(renderTraceRow(a, 100).at(-1)!).includes("×"));
+  assert.ok(!stripAnsi(renderTraceRow(c, 100).at(-1)!).includes("×"));
 });
 
 test("a failed member makes the folded repetition visibly fail", () => {

--- a/tests/traceline/repetition.test.ts
+++ b/tests/traceline/repetition.test.ts
@@ -16,6 +16,8 @@ const {
   oneLine,
   bashPreambleRun,
   foldBashPreamble,
+  renderTraceRow,
+  repetitionRun,
   setTracelineChat,
   setTracelineThemeGetter,
 } = internals;
@@ -39,12 +41,76 @@ function bashComp(command: string): ToolRowLike {
   } as ToolRowLike;
 }
 
+function mcpComp(id: string, resultChars: number, isError = false): ToolRowLike {
+  return {
+    toolName: "mcp",
+    args: { tool: "linear_save_issue", args: { id } },
+    result: { content: [{ type: "text", text: "x".repeat(resultChars) }], isError },
+    isPartial: false,
+    render: () => [],
+    setExpanded: () => {},
+    callRendererComponent: { render: () => ["mcp call linear_save_issue"] },
+  } as ToolRowLike;
+}
+
 const proseBefore = (rows: ToolRowLike[]) => assistantBefore(rows, [{ type: "text", text: "now let me check" }]);
 const collapsedThinkingBefore = (row: ToolRowLike) => assistantBefore([row], [{ type: "thinking", thinking: "hmm" }], true);
 
 beforeEach(() => {
   setTracelineChat(undefined);
   setTracelineThemeGetter(undefined);
+});
+
+test("identical compact invocations in one assistant step fold with a count and combined size", () => {
+  const a = mcpComp("NEXSELL-1", 700);
+  const b = mcpComp("NEXSELL-2", 800);
+  const c = mcpComp("NEXSELL-3", 900);
+  setTracelineChat({ children: [assistantBefore([a, b, c]), a, b, c] });
+
+  const run = repetitionRun(b);
+  assert.ok(run, "a middle call must see its assistant-step fold");
+  assert.equal(run!.rows.length, 3);
+  assert.equal(run!.index, 1);
+
+  const first = renderTraceRow(a, 100);
+  const visible = stripAnsi(first.at(-1)!);
+  assert.ok(visible.includes("mcp call linear_save_issue ×3"), visible);
+  assert.ok(visible.endsWith("2.4k ch"), `landed result sizes sum: ${visible}`);
+  assert.deepEqual(renderTraceRow(b, 100), [], "later repeated calls render nothing");
+  assert.deepEqual(renderTraceRow(c, 100), [], "the first call carries the fold");
+});
+
+test("identical invocations in separate assistant steps stay separate", () => {
+  const a = mcpComp("NEXSELL-1", 200);
+  const b = mcpComp("NEXSELL-2", 300);
+  setTracelineChat({ children: [assistantBefore([a]), a, assistantBefore([b]), b] });
+
+  assert.equal(repetitionRun(a), undefined);
+  assert.equal(repetitionRun(b), undefined);
+  assert.ok(!stripAnsi(renderTraceRow(a, 100).at(-1)!).includes("×"));
+  assert.ok(!stripAnsi(renderTraceRow(b, 100).at(-1)!).includes("×"));
+});
+
+test("an expanded row splits a same-step repetition fold", () => {
+  const a = mcpComp("NEXSELL-1", 100);
+  const expanded = { ...mcpComp("NEXSELL-2", 100), expanded: true } as ToolRowLike;
+  const c = mcpComp("NEXSELL-3", 100);
+  setTracelineChat({ children: [assistantBefore([a, expanded, c]), a, expanded, c] });
+
+  assert.equal(repetitionRun(a), undefined, "a fold cannot cross a native expanded row");
+  assert.equal(repetitionRun(expanded), undefined);
+  assert.equal(repetitionRun(c), undefined);
+});
+
+test("a failed member makes the folded repetition visibly fail", () => {
+  const ok = mcpComp("NEXSELL-1", 100);
+  const failed = mcpComp("NEXSELL-2", 100, true);
+  setTracelineChat({ children: [assistantBefore([ok, failed]), ok, failed] });
+
+  const line = renderTraceRow(ok, 100).at(-1)!;
+  assert.ok(line.includes("\x1b[31m›"), "the folded bullet is red when any call failed");
+  assert.ok(line.includes("\x1b[31m\x1b[1mmcp"), "the folded invocation keeps error emphasis");
+  assert.ok(stripAnsi(line).includes("×2"));
 });
 
 test("leading set drops on first appearance; repeated context folds to a dim ⋯", () => {

--- a/tests/traceline/repetition.test.ts
+++ b/tests/traceline/repetition.test.ts
@@ -71,7 +71,6 @@ test("identical compact invocations in one assistant step fold with a count and 
   assert.ok(visible.includes("mcp call linear_save_issue ×3"), visible);
   assert.ok(visible.endsWith("2.4k ch"), `landed result sizes sum: ${visible}`);
   assert.deepEqual(renderTraceRow(b, 100), [], "later repeated calls render nothing");
-  assert.deepEqual(renderTraceRow(c, 100), [], "the first call carries the fold");
 });
 
 test("identical invocations in separate assistant steps stay separate", () => {


### PR DESCRIPTION
## Summary

- fold identical compact tool invocations from one assistant step into one row with a multiplication count
- aggregate result size and status while keeping separate assistant steps distinct
- preserve expanded-row, drill, read, mutation, record, and image semantics
- document the repetition-fold grammar

## Verification

- `npm test` (267 tests passed)
- `npm run lint`
- rendered and visually checked a 24-call MCP fold
- 100-row render benchmark: 32 ms

## Known unrelated check failure

`npm run typecheck` currently fails on the existing `tests/contract/cachemire-lifecycle.test.ts` fixture because the installed Pi `ExtensionContextActions` now requires `getScopedModels`. This branch does not touch that fixture or contract.