### PR TITLE
refactor(cachemire): simplify switch forecast IDs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -161,9 +161,8 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
 - **Send-time prompt sizing**: recognized Anthropic, OpenAI, Google and `pi-messages`
   payloads count only system, tool and message fields. Tests pin transformed-payload
   precedence, metadata exclusion, flat image sizing and canonical-history fallback.
-  The `transformMessages` contract also passes a nontrivial normalization callback,
-  while unit fixtures pin known per-API outputs, so cross-provider tool IDs are counted
-  at their wire-safe length rather than raw length.
+  The immediate canonical forecast counts stored tool-call IDs; provider-specific ID
+  rewriting is deliberately left to the authoritative send-time payload.
 - **Restored freshness**: persisted lineage uses the parent entry timestamp as its
   request anchor and response time only as fallback, so long generations do not restore
   an artificially fresh cache.

--- a/extensions/_lib/forecast.ts
+++ b/extensions/_lib/forecast.ts
@@ -1,5 +1,6 @@
 // Estimate canonical history in a target model's currency. This mirrors the
-// size-material rules of pi-ai's transformMessages; the contract suite compares both.
+// material transform rules that significantly affect size; send-time payload sizing
+// remains authoritative for provider-specific serialization.
 
 import {
   builtInHeuristicForModel,
@@ -78,76 +79,11 @@ function countUserContent(forecast: HistoryForecast, content: unknown, visionTar
   }
 }
 
-function shortHash(value: string): string {
-  let h1 = 0xdeadbeef;
-  let h2 = 0x41c6ce57;
-  for (let index = 0; index < value.length; index++) {
-    const code = value.charCodeAt(index);
-    h1 = Math.imul(h1 ^ code, 2_654_435_761);
-    h2 = Math.imul(h2 ^ code, 1_597_334_677);
-  }
-  h1 = Math.imul(h1 ^ (h1 >>> 16), 2_246_822_507) ^ Math.imul(h2 ^ (h2 >>> 13), 3_266_489_909);
-  h2 = Math.imul(h2 ^ (h2 >>> 16), 2_246_822_507) ^ Math.imul(h1 ^ (h1 >>> 13), 3_266_489_909);
-  return (h2 >>> 0).toString(36) + (h1 >>> 0).toString(36);
-}
-
-function normalizedIdPart(value: string, limit = 64): string {
-  return value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, limit).replace(/_+$/, "");
-}
-
-/** Mirror pi-ai's cross-provider ID normalization for the APIs Cachemire can size
- * before provider serialization. The send-time payload remains authoritative. */
-export function normalizeForecastToolCallId(id: string, target: TargetModel, source: ForecastMessage): string {
-  if (target.api === "anthropic-messages" || target.api === "bedrock-converse-stream") {
-    return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
-  }
-  if (target.api === "google-generative-ai" || target.api === "google-vertex") {
-    return target.id.startsWith("claude-") || target.id.startsWith("gpt-oss-")
-      ? id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64)
-      : id;
-  }
-  if (target.api === "mistral-conversations") {
-    const normalized = id.replace(/[^a-zA-Z0-9]/g, "");
-    return normalized.length === 9 ? normalized : shortHash(normalized || id).replace(/[^a-zA-Z0-9]/g, "").slice(0, 9);
-  }
-  if (target.api === "openai-completions") {
-    if (!id.includes("|")) return target.provider === "openai" ? id.slice(0, 40) : id;
-    const separator = id.indexOf("|");
-    const callId = id.slice(0, separator).replace(/[^a-zA-Z0-9_-]/g, "_");
-    const itemId = id.slice(separator + 1).replace(/[^a-zA-Z0-9_-]/g, "_");
-    const combined = itemId.length > 0 ? `${callId}_${itemId}` : callId;
-    if (combined.length <= 40) return combined;
-    const hash = shortHash(id).slice(0, 8);
-    return `${callId.slice(0, Math.max(1, 39 - hash.length))}_${hash}`;
-  }
-  if (["openai-responses", "azure-openai-responses", "openai-codex-responses"].includes(target.api)) {
-    const allowedProviders = target.api === "azure-openai-responses"
-      ? ["openai", "openai-codex", "opencode", "azure-openai-responses"]
-      : ["openai", "openai-codex", "opencode"];
-    const allowedProvider = allowedProviders.includes(target.provider);
-    if (!allowedProvider || !id.includes("|")) return normalizedIdPart(id);
-    const [callId = "", itemId = ""] = id.split("|");
-    const normalizedCall = normalizedIdPart(callId);
-    const foreign = source.provider !== target.provider || source.api !== target.api;
-    let normalizedItem = foreign ? `fc_${shortHash(itemId)}` : normalizedIdPart(itemId);
-    if (!normalizedItem.startsWith("fc_")) normalizedItem = normalizedIdPart(`fc_${normalizedItem}`);
-    return `${normalizedCall}|${normalizedItem}`;
-  }
-  return id;
-}
-
-function countToolCall(
-  forecast: HistoryForecast,
-  block: ForecastBlock,
-  isSame: boolean,
-  source: ForecastMessage,
-  target: TargetModel,
-): void {
-  // Tool calls replay as id/name/arguments; cross-model the thoughtSignature is
-  // stripped and provider serializers normalize the id. Encrypted payload char length
-  // is the size proxy throughout (contextimate's convention).
-  const id = !isSame && typeof block.id === "string" ? normalizeForecastToolCallId(block.id, target, source) : block.id;
-  forecast.textChars += JSON.stringify({ id, name: block.name, arguments: block.arguments }).length;
+function countToolCall(forecast: HistoryForecast, block: ForecastBlock, isSame: boolean): void {
+  // The immediate estimate counts the stored id/name/arguments. Provider-specific ID
+  // rewriting has a small measured effect; the observed send-time payload supersedes
+  // this canonical estimate. Encrypted payload char length remains the size proxy.
+  forecast.textChars += JSON.stringify({ id: block.id, name: block.name, arguments: block.arguments }).length;
   if (isSame && typeof block.thoughtSignature === "string") forecast.keptReasoningChars += block.thoughtSignature.length;
 }
 
@@ -188,7 +124,7 @@ export function forecastHistoryForTarget(messages: readonly ForecastMessage[], t
       const isSame = sameModel(message, target);
       for (const block of blockList(message.content)) {
         if (block.type === "thinking") countThinking(forecast, block, isSame);
-        else if (block.type === "toolCall") countToolCall(forecast, block, isSame, message, target);
+        else if (block.type === "toolCall") countToolCall(forecast, block, isSame);
         else if (block.type === "text") forecast.textChars += (block.text ?? "").length;
       }
       continue;

--- a/tests/contract/pi-transform-messages.test.ts
+++ b/tests/contract/pi-transform-messages.test.ts
@@ -1,19 +1,15 @@
-// Contract: _lib/forecast.ts mirrors the size-material rules of pi-ai's
-// transformMessages. The forecast cannot import that function at runtime (pi's loader
-// only aliases the compat surface), so this suite runs BOTH implementations over the
-// same histories and compares the resulting material char counts. When a case fails
-// after `pi update`, update extensions/_lib/forecast.ts to match the real transform.
+// Contract: _lib/forecast.ts mirrors the material transform rules that significantly
+// affect size. The forecast cannot import transformMessages at runtime (pi's loader
+// only aliases the compat surface), so this suite runs both implementations over the
+// same histories. Provider-specific tool ID rewriting is deliberately left to the
+// authoritative send-time payload.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { transformMessages } from "@earendil-works/pi-ai/api/transform-messages";
 import type { Message, Model, Api } from "@earendil-works/pi-ai";
 
-import {
-  forecastHistoryForTarget,
-  normalizeForecastToolCallId,
-  type ForecastMessage,
-} from "../../extensions/_lib/forecast.ts";
+import { forecastHistoryForTarget, type ForecastMessage } from "../../extensions/_lib/forecast.ts";
 import { ESTIMATED_IMAGE_CHARS } from "../../extensions/_lib/provider-prompt.ts";
 import { assistantMessage } from "../helpers.ts";
 
@@ -138,31 +134,6 @@ test("mirror: same-model replay keeps reasoning payloads", () => {
   assertMirror(richHistory(), opus, "sol/opus history → opus (opus turns replay)");
   const sol = fakeModel({ id: "gpt-5.6-sol" });
   assertMirror(richHistory(), sol, "sol/opus history → sol (sol turns replay)");
-});
-
-test("mirror: cross-provider tool call IDs use pi's normalization callback", () => {
-  const originalId = `call|${"+/=".repeat(180)}`;
-  const history = [
-    assistantMessage(
-      [{ type: "toolCall", id: originalId, name: "read", arguments: { path: "/tmp/x" } }] as AssistantContent,
-      { provider: "openai-codex", api: "openai-codex-responses", model: "gpt-5.6-sol", stopReason: "toolUse" },
-    ),
-    {
-      role: "toolResult", toolCallId: originalId, toolName: "read",
-      content: [{ type: "text", text: "result" }], isError: false, timestamp: 4,
-    } as Message,
-  ];
-  const target = fakeModel({ id: "claude-opus-4-8", api: "anthropic-messages", provider: "anthropic" });
-  const transformed = transformMessages(history, target, (id, model, source) =>
-    normalizeForecastToolCallId(id, model, source as unknown as ForecastMessage));
-  const firstBlock = (transformed[0] as Extract<Message, { role: "assistant" }>).content[0];
-  assert.equal(firstBlock?.type, "toolCall");
-  assert.equal(firstBlock?.type === "toolCall" ? firstBlock.id.length : 0, 64);
-  assert.equal(
-    materialCharsOfForecast(history, target),
-    materialCharsOfTransform(transformed),
-    "the forecast must count the normalized wire ID, not the 545-char source ID",
-  );
 });
 
 test("known divergence: pi synthesizes results for orphaned tool calls; the forecast ignores them", () => {

--- a/tests/contract/pi-transform-messages.test.ts
+++ b/tests/contract/pi-transform-messages.test.ts
@@ -97,13 +97,13 @@ function richHistory(): Message[] {
         { type: "thinking", thinking: "", thinkingSignature: "SIGNATURE-ONLY" },
         { type: "thinking", thinking: "   \n  ", thinkingSignature: undefined }, // blank: vanishes even same-model
         { type: "thinking", thinking: "", thinkingSignature: "REDACTED", redacted: true },
-        { type: "toolCall", id: "t1", name: "read", arguments: { path: "/tmp/x" }, thoughtSignature: "TOOL-THOUGHT" },
+        { type: "toolCall", id: "call|foreign/item+x", name: "read", arguments: { path: "/tmp/x" }, thoughtSignature: "TOOL-THOUGHT" },
       ] as AssistantContent,
       { provider: "openai-codex", api: "openai-codex-responses", model: "gpt-5.6-sol", stopReason: "toolUse" },
     ),
     {
       role: "toolResult",
-      toolCallId: "t1",
+      toolCallId: "call|foreign/item+x",
       toolName: "read",
       content: [
         { type: "text", text: "tool result text" },

--- a/tests/lib/forecast.test.ts
+++ b/tests/lib/forecast.test.ts
@@ -7,7 +7,6 @@ import assert from "node:assert/strict";
 import {
   forecastHistoryForTarget,
   forecastTargetPrompt,
-  normalizeForecastToolCallId,
   type ForecastMessage,
   type TargetModel,
 } from "../../extensions/_lib/forecast.ts";
@@ -71,31 +70,10 @@ test("redacted thinking: kept same-model, dropped cross-model", () => {
   assert.equal(forecastHistoryForTarget(history, opus).keptReasoningChars, 0);
 });
 
-test("cross-provider tool IDs follow target API wire constraints", () => {
-  const source: ForecastMessage = {
-    role: "assistant", content: [], provider: "foreign", api: "foreign-api", model: "old",
-  };
+test("toolCall: stored ID and arguments count, thoughtSignature only for the same model", () => {
   const id = "call|foreign/item";
-  assert.equal(normalizeForecastToolCallId(id, opus, source), "call_foreign_item");
-  assert.equal(
-    normalizeForecastToolCallId(id, { provider: "mistral", id: "mistral-large", api: "mistral-conversations" }, source),
-    "1ca52kv1m",
-  );
-  assert.equal(normalizeForecastToolCallId(id, { provider: "openai", id: "gpt", api: "openai-responses" }, source), "call|fc_16ipy761458vd9");
-  assert.equal(
-    normalizeForecastToolCallId(id, { provider: "azure-openai-responses", id: "gpt", api: "openai-responses" }, source),
-    "call_foreign_item",
-    "Azure is an allowed Responses carrier only on the Azure wire API",
-  );
-  assert.equal(
-    normalizeForecastToolCallId(id, { provider: "azure-openai-responses", id: "gpt", api: "azure-openai-responses" }, source),
-    "call|fc_16ipy761458vd9",
-  );
-});
-
-test("toolCall: arguments always count, thoughtSignature only for the same model", () => {
-  const call = { type: "toolCall", id: "t1", name: "read", arguments: { path: "/tmp/x" }, thoughtSignature: "T".repeat(80) };
-  const argChars = JSON.stringify({ id: "t1", name: "read", arguments: { path: "/tmp/x" } }).length;
+  const call = { type: "toolCall", id, name: "read", arguments: { path: "/tmp/x" }, thoughtSignature: "T".repeat(80) };
+  const argChars = JSON.stringify({ id, name: "read", arguments: { path: "/tmp/x" } }).length;
   const history = [solTurn([call], { stopReason: "toolUse" })];
   const cross = forecastHistoryForTarget(history, opus);
   assert.equal(cross.textChars, argChars);


### PR DESCRIPTION
## Summary

- count stored tool-call IDs in the immediate canonical model-switch forecast
- remove provider-specific ID rewriting and its API matrix
- keep the observed send-time payload authoritative
- preserve immediate estimation, calibration, exact identity accounting and send-time refinement

## Why

The recent-session benchmark found provider-specific ID rewriting changed comparable OpenAI and Anthropic forecasts by at most 0.49%. Removing it cuts 116 net lines without changing exact post-response accounting.

Calibration is deliberately unchanged and tracked separately in #64.

## Validation

- `npm run check`
- 318 tests passed
