### PR TITLE
fix(cachemire): show only actionable cache warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Cachemire: show cache status only when it needs attention.** Healthy and unknown
+  cache lifetimes now stay hidden. Known 5-minute and 1-hour caches warn shortly before
+  expiry; OpenAI's best-effort window uses hedged warnings. Stale and invalidated states
+  use warning emphasis, and compaction says only that changed history may be re-written.
+  The widget now sleeps until the next warning boundary instead of waking every second
+  for the whole session. Fixes #25.
 - **Contextimate: recognise the Claude 4.7+ tokenizer across routes.** Fable 5,
   Opus 5 and explicit Claude 4.7+ models relayed through Radius or OpenRouter now
   use the same measured profile as Claude 4.7/4.8. Bedrock retains its own payload

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Small observability and context management tools for [Pi](https://github.com/earendil-works/pi) in the terminal.
 1. [`contextimate`](./extensions/pi-contextimate) breaks down what is filling your context window: sysprompt, AGENTS.md, Skill frontmatter, Tool schemas, and session material. Toggle with ctrl+o on start and /reload.
 2. [`traceline`](./extensions/pi-traceline) collapses tool calls to one trace line each, so you can see the full arc of what Pi did (path taken, context read, bloated tool results). Toggle with ctrl+t (expands/collapses both thinking blocks and tools).
-3. [`cachemire`](./extensions/pi-cachemire) (**experimental**) explains cache behaviour and agent-loop economics: a cache TTL clock above the editor, predicted-then-resolved cache-break notices, a per-turn ledger, and `/cache` forensics. Included in the package as of `0.4.0`; wording, thresholds, and states may still evolve.
+3. [`cachemire`](./extensions/pi-cachemire) (**experimental**) explains cache behaviour and agent-loop economics: warnings when the cache needs attention, predicted-then-resolved cache-break notices, a per-turn ledger, and `/cache` forensics. Included in the package as of `0.4.0`; wording, thresholds, and states may still evolve.
 4. [`meantime`](./extensions/pi-meantime) (**experimental, opt-in**) explains where the wall-clock went: a live tempo line above the editor (waiting / thinking / writing / tools, with `~tok/s`), slow-start and slow-stream notices judged against the session's own medians, and a `/pace` ledger with an active-vs-idle share bar. New in `0.7.0`, and feature-flagged off by default.
 
 See each extension's own `README.md` for details, `docs/` for deeper reference, and [`AGENTS.md`](./AGENTS.md) for development workflows and conventions.
@@ -33,7 +33,7 @@ Expanded mode, with per-section sources and a schema field tree for every active
 ![Contextimate expanded view, excerpt](./docs/img/pi-contextimate-expanded.png)
 
 ### [Cachemire](./extensions/pi-cachemire)
-You now see cache-related warnings inline and a cache shotclock above the editor. `/cache` gives you a full session review by turn.
+You see cache-related warnings inline and above the editor only when the cache needs attention. `/cache` gives you a full session review by turn.
 
 ![Cachemire turn ledger and cache clock](./docs/img/pi-cachemire-clock.png)
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -170,7 +170,10 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   50k ch. Thresholds live in `style.ts`, overridable through the family config
   convention (`~/.pi/agent/pi-<name>.json`, `<cwd>/.pi/pi-<name>.json`)
 - cache materiality (cachemire): notices only above $0.05 or 20k re-written
-  tokens; silence when healthy
+  tokens; silence when healthy. The live cache warning appears only during the final
+  `min(5m, 20%)` of a contract TTL, or the final `min(1m, 20%)` before a documented
+  best-effort window begins. It remains visible after that boundary until the next
+  provider call resolves the state. Unknown cache lifetimes stay silent
 - severity colour is reserved for exceeded thresholds and real states. Nothing is
   tinted for visual interest
 
@@ -219,9 +222,9 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   28.2k (100% of prompt) · the new model already had the prefix cached`, never
   `read 28.2k of 20.6k expected`, which composes two currencies into an impossible
   137% claim
-- certainty ladder: contract-backed evidence gets definite words (`cache cold`);
-  a documented band gets hedged words (`cache fading`); an unknown provider gets
-  `likely`. Never write definite words on soft evidence
+- certainty ladder: contract-backed evidence gets definite words (`cache stale`);
+  a documented band gets hedged words (`cache may be stale`); an unknown provider stays
+  silent. Never write definite words on soft evidence
 - status one-liners are lowercase; Title Case only for panel headers and row labels
 - state causes from observed evidence (payload diffs, usage), never inference,
   and say `unknown` when unknown

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -17,15 +17,18 @@ Everything cachemire shows is four provider-general rules, which is the whole me
    upstream request shape is not observable, so the label weakens to `(rough est ·
    gateway route)`. One exception:
    switching *back* to a model whose own last billed call is still inside its
-   freshness window says `cache may still be warm · last <model> call 2m ago · next
+   freshness window says `cache may still be warm · switched back to <model> · next
    send confirms`, because claiming cold there would be wrong as often as right.
    The hint is deliberately hedged (the payload may have changed in ways only the
    next send reveals) and gated: the prior call must match on provider, model *and*
    wire API, with no compaction on the path since; either failing means its cache
-   entry cannot be revived, and the state stays `cache cold expected`.
+   entry cannot be revived, and the state stays `cache cold expected`. If the prior
+   model's cache lifetime is unknown, Cachemire says the state is unknown and waits for
+   the next send instead of guessing.
 3. **Window**: strength varies by provider: Anthropic has a contract TTL (observed,
    else inferred), OpenAI a documented band (soft ~5m / hard 1h), everyone else is
-   unknown. Wording always matches the strength: countdown / fading / likely.
+   unknown. Healthy and unknown windows stay hidden. A contract gets a countdown near
+   expiry; a documented band gets a hedged warning.
 4. **Currency**: exact token counts and $ are only shown in the tokenizer and price
    card that billed them. After a model switch the old exact count is never displayed
    against the new model. The forecast above is a labelled estimate in the target
@@ -43,9 +46,9 @@ Everything cachemire shows is four provider-general rules, which is the whole me
 
 The TTL anchor is *request start*, not response end: Anthropic reads/refreshes/writes
 cache entries while processing the request input (entries become available once the
-response begins), so a long thinking block burns TTL while it streams. The clock
-ticking during generation is correct: after a 4m thinking block on a 5m TTL, the
-prefix really does have ~1m left.
+response begins), so a long thinking block burns TTL while it streams. A warning can
+therefore appear during generation: after a 4m thinking block on a 5m TTL, the prefix
+really does have ~1m left.
 
 The re-write size the clock shows is provider-exact, not estimated: it is `input +
 cacheRead + cacheWrite` from the last assistant message's usage: the prompt-side token
@@ -64,30 +67,34 @@ simply hides, since no cache entry was ever confirmed. If the aborted send did r
 the prefix after all, the next call resolves green (`cache held`), the same correction
 path as any wrong prediction.
 
-## Cold vs likely cold
+## When the warning appears
 
-`cold` is contract-backed: an observed `cache_control` TTL passed (or, for a freshly
-restored anthropic session, the TTL inferred by the same rule pi-ai itself uses
-(`PI_CACHE_RETENTION=long` → 1h, else 5m) until the first live observation replaces
-it), or OpenAI's documented 1h hard cap passed. `fading` covers OpenAI's
-typical-eviction zone, and `likely` wording is reserved for providers cachemire knows
-nothing about.
+A known 5-minute TTL appears during its final minute. A known 1-hour TTL appears during
+its final 5 minutes. Once the TTL passes, the warning remains visible until the next
+provider call establishes the new state. A freshly restored Anthropic session infers the
+TTL by the same rule pi-ai uses (`PI_CACHE_RETENTION=long` means 1h; otherwise 5m) until
+the first live payload replaces it.
 
 OpenAI's implicit cache has no per-request TTL but does have documented behaviour
-(typically evicted after ~5–10m idle, *always* removed within 1h of last use), so it
-gets a three-zone band with honest wording per zone:
+(typically evicted after ~5–10m idle, always removed within 1h of last use). Cachemire
+warns during the final minute before the typical window begins, then uses `may` wording
+until the hard cap. It makes no idle-time claim for providers with an unknown lifetime.
 
 ```
-◍ cache likely warm · 3m since last call
-◍ cache fading · idle 12m of 5m–1h window · next send may re-send ~109.8k (~$1.37)
-◍ cache cold (idle 1h12m > 1h cap) · next send re-sends ~109.8k uncached (~$1.37)
+◍ cache may expire in 30s · typical eviction starts after 5m idle
+◍ cache may be stale · typical eviction window 5m–1h · next send may re-send ~109.8k (~$1.37)
+◍ cache stale · beyond 1h cache cap · next send may re-send ~109.8k uncached (~$1.37)
 ```
+
+Cachemire uses a scheduled wake-up for the next warning boundary. It only updates once
+per second while a visible countdown is in its final 90 seconds, so a healthy cache does
+not trigger continuous UI renders.
 
 ## Thinking levels
 
 Thinking levels are the model-switch pattern one notch weaker. On Anthropic a
 thinking-param change breaks cache, so on a contract window the widget flips at the
-keystroke (`cache stale · thinking level changed · next send re-writes the prompt`)
+keystroke (`cache stale · thinking level changed · next send may re-write the prompt`)
 and the send-time notice names the wire-level change: `cause: thinking changed
 (thinking effort xhigh → thinking effort low)`. How *much* breaks depends on the wire
 form: Anthropic documents that system/tools survive `budget_tokens` changes, but a
@@ -191,8 +198,10 @@ break (e.g. provider-side eviction) still gets a resolved-form line when usage
 arrives; a send that aborts before usage resolves the notice to an explicit "outcome
 unknown".
 
-Compaction is deliberately unsized in flight: Pi's compact event does not provide an
-exact provider-token split for the new prefix. The first billed agent call afterwards
+Compaction immediately warns that the cache is stale and the next send may re-write
+changed history. It does not claim that the whole prompt changed. The warning is
+unsized in flight because Pi's compact event does not provide an exact provider-token
+split for the new prefix. The first billed agent call afterwards
 does, so the resolved notice compares its exact `cacheRead` with the last normal agent
 prompt before compaction: `reused 34.9k of the last pre-compaction 72.5k prompt (48%) ·
 processed 39.1k uncached`. Pi's summarizer request has a separate prompt shape and does not

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -11,25 +11,29 @@ explains when the cache will go cold, why it broke and what the loop cost.
 
 ![Turn ledger lines in the transcript, a resolved break notice naming its cause (thinking changed), and the cache clock above the editor](../../docs/img/pi-cachemire-clock.png)
 
-## Check cache freshness before you send
+## Get warned before the cache expires
 
-A cache clock above the input box counts down the provider's cache freshness from
-the last request. Check it before you press Enter to see whether the next send will
-be cheap or will re-bill the whole prefix.
+Cachemire stays hidden while the cache is healthy. It appears above the input box only
+when the cache is close to expiring, may already be stale, or a change such as compaction
+or a model switch puts the next send at risk.
 
-For Anthropic, the clock shows a contract-TTL countdown. It reads the observed
-`cache_control`, not config. For OpenAI, it shows a documented three-zone band. For
-unknown providers, it uses softer wording. The promised re-write size uses
-provider-exact usage, with one exception: after a model switch it is an estimate in
-the new model's tokenizer, and says so. The pre-send clock estimates canonical history;
-at send time Cachemire re-sizes recognized system, tool and message fields from the
-provider payload it observes, including pi normalization and earlier payload transforms.
-Gateway estimates stay rough because an upstream rewrite can still change them.
+For Anthropic, Cachemire reads the exact TTL from the observed `cache_control`. A
+5-minute cache appears during its final minute; a 1-hour cache appears during its final
+5 minutes. For OpenAI's less certain window, it warns shortly before typical eviction
+begins and uses `may` wording. Providers with unknown cache lifetimes get no guessed
+countdown.
+
+The possible re-write size uses provider-exact usage, with one exception: after a model
+switch it is an estimate in the new model's tokenizer, and says so. At send time
+Cachemire re-sizes recognized system, tool and message fields from the provider payload
+it observes. Gateway estimates stay rough because an upstream rewrite can still change
+them.
 
 ```
-◍ cache 4m30s                                    (green → yellow under 60s)
-◍ cache fading · idle 12m of 5m–1h window · next send may re-send ~109.8k (~$1.37)
-◍ cache cold · next send re-writes ~142.3k (~$2.67)
+◍ cache expires in 58s · next send may re-write ~138.2k (~$2.59)
+◍ cache may be stale · typical eviction window 5m–1h · next send may re-send ~109.8k (~$1.37)
+◍ cache stale · TTL expired · next send may re-write ~142.3k (~$2.67)
+◍ cache stale after compaction · next send may re-write changed history
 ```
 
 ## Find out why the cache broke
@@ -112,9 +116,9 @@ pi -e ./extensions/pi-cachemire
 
 ## Use Cachemire
 
-You do not need to press anything. The clock ticks above the editor, notices appear
-automatically and the turn line follows each turn. Run `/cache` to print the per-call
-ledger table.
+You do not need to press anything. Warnings appear above the editor when the cache needs
+attention, notices appear automatically and the turn line follows each turn. Run `/cache`
+to print the per-call ledger table.
 
 Config lives at `~/.pi/agent/pi-cachemire.json` or `<project>/.pi/pi-cachemire.json`.
 Set `turnSummaryMinCalls` higher if you only want a ledger line for multi-call turns.
@@ -139,9 +143,9 @@ Cachemire follows these rules:
   Forensic causes come from observed payload diffs. Cachemire does not infer them.
 - Everything Cachemire draws is UI-only. It does not enter LLM context, session
   entries or exports.
-- Freshness wording reflects how much is known. A contract TTL gets a definite
-  countdown. A documented band gets fading or cap wording. When nothing is known,
-  Cachemire says "likely". Under subscription auth, it marks savings as notional.
+- Freshness wording reflects how much is known. A contract TTL gets a definite warning.
+  A documented band gets `may` or cap wording. When nothing is known, Cachemire stays
+  silent. Under subscription auth, it marks savings as notional.
 - Sessions restored with `--continue` rebuild the active ledger and all-branch cache
   baselines from session usage. Cachemire marks restored rows and excludes them from
   savings because their pricing context is unknown. Payload fingerprints are not

--- a/extensions/pi-cachemire/clock.ts
+++ b/extensions/pi-cachemire/clock.ts
@@ -9,15 +9,22 @@ import type { SwitchForecast } from "./forecast.ts";
 import type { CacheWindow } from "./types.ts";
 
 export const UNKNOWN_WINDOW: CacheWindow = { kind: "unknown" };
-export const UNKNOWN_TTL_WARM_MS = 10 * 60 * 1000; // soft "likely cold" horizon for implicit caches
+const EXACT_WARNING_MAX_MS = 5 * 60 * 1000;
+const BAND_WARNING_MAX_MS = 60 * 1000;
 
-/** Conservative warmth: inside a contract TTL, inside a band's *soft* horizon, or
- * inside the implicit-cache horizon. Anything past this must not claim "warm". */
+/** Conservative warmth: inside a contract TTL or a documented band's soft horizon.
+ * Unknown retention never earns a warmth claim. */
 export function withinWarmHorizon(window: CacheWindow | undefined, sinceMs: number): boolean {
   const resolved = window ?? UNKNOWN_WINDOW;
   if (resolved.kind === "contract") return sinceMs <= resolved.ttlMs;
   if (resolved.kind === "band") return sinceMs <= resolved.softMs;
-  return sinceMs <= UNKNOWN_TTL_WARM_MS;
+  return false;
+}
+
+function warningLeadMs(window: Exclude<CacheWindow, { kind: "unknown" }>): number {
+  const boundary = window.kind === "contract" ? window.ttlMs : window.softMs;
+  const maximum = window.kind === "contract" ? EXACT_WARNING_MAX_MS : BAND_WARNING_MAX_MS;
+  return Math.min(maximum, boundary * 0.2);
 }
 
 export interface ClockState {
@@ -52,16 +59,21 @@ function rewriteSuffix(verb: string, cachedTokens?: number, rewriteUsd?: number,
 
 export function cacheClock(input: ClockInput): ClockState {
   if (input.lastRequestAt === undefined) return { phase: "idle", text: "" };
+  if (input.compacted) {
+    return { phase: "stale", text: "cache stale after compaction \u00b7 next send may re-write changed history" };
+  }
   if (input.modelSwitched) {
     const forecast = input.switchForecast;
+    if (forecast?.prior && (!forecast.prior.window || forecast.prior.window.kind === "unknown")) {
+      return { phase: "warm-unknown", text: "cache state unknown \u00b7 model switched \u00b7 next send confirms" };
+    }
     if (forecast !== undefined && forecast.prior !== undefined &&
         withinWarmHorizon(forecast.prior.window, input.now - forecast.prior.requestAt)) {
       // The target model's own last billed call is inside its freshness window: a
       // switch-back may revive that entry, so "cold" would overclaim.
       return {
         phase: "warm-unknown",
-        text: `cache may still be warm \u00b7 last ${forecast.targetId} call ` +
-          `${formatDuration(input.now - forecast.prior.requestAt)} ago \u00b7 next send confirms`,
+        text: `cache may still be warm \u00b7 switched back to ${forecast.targetId} \u00b7 next send confirms`,
       };
     }
     if (forecast?.estTokens === undefined) {
@@ -75,62 +87,75 @@ export function cacheClock(input: ClockInput): ClockState {
         ` to ${forecast.targetProvider} (${confidence})`,
     };
   }
-  if (input.compacted) {
-    // The prefix the clock was timing no longer exists; TTL is moot until the next send.
-    return { phase: "stale", text: "cache stale \u00b7 history compacted \u00b7 next send re-writes the new prefix" };
-  }
   const since = input.now - input.lastRequestAt;
   const window = input.window ?? UNKNOWN_WINDOW;
   if (input.thinkingChanged && window.kind === "contract") {
     // No survival promise here: docs say system/tools outlive *budget* changes, but a
     // live adaptive-effort change on claude-fable-5 re-wrote 100% of the prompt.
-    return { phase: "stale", text: "cache stale \u00b7 thinking level changed \u00b7 next send re-writes the prompt" };
+    return { phase: "stale", text: "cache stale \u00b7 thinking level changed \u00b7 next send may re-write the prompt" };
   }
   if (window.kind === "contract") {
     const remaining = window.ttlMs - since;
     if (remaining <= 0) {
-      return { phase: "cold", text: `cache cold${rewriteSuffix("re-writes", input.cachedTokens, input.rewriteUsd)}` };
+      return { phase: "cold", text: `cache stale \u00b7 TTL expired${rewriteSuffix("may re-write", input.cachedTokens, input.rewriteUsd)}` };
     }
-    // Coarse display above 90s so the widget only re-renders when the label changes.
+    if (remaining > warningLeadMs(window)) return { phase: "idle", text: "" };
+    // Coarse display above 90s so long-retention warnings do not re-render every second.
     const display = remaining > 90_000 ? Math.floor(remaining / 15_000) * 15_000 : remaining;
-    return {
-      phase: remaining <= 60_000 ? "closing" : "fresh",
-      text: `cache ${formatDuration(display)}`,
-    };
+    const suffix = rewriteSuffix("may re-write", input.cachedTokens, input.rewriteUsd);
+    return { phase: "closing", text: `cache expires in ${formatDuration(display)}${suffix}` };
   }
   if (window.kind === "band") {
-    if (since > window.hardMs) {
-      // The hard cap is documented ("always removed within one hour of last use"), so
-      // past it "cold" is definite even without a per-request TTL contract.
-      const suffix = rewriteSuffix("re-sends", input.cachedTokens, input.rewriteUsd, " uncached");
-      return { phase: "cold", text: `cache cold (idle ${formatDuration(since)} > ${formatDuration(window.hardMs)} cap)${suffix}` };
+    const untilTypicalExpiry = window.softMs - since;
+    if (untilTypicalExpiry > warningLeadMs(window)) return { phase: "idle", text: "" };
+    if (untilTypicalExpiry > 0) {
+      return {
+        phase: "closing",
+        text: `cache may expire in ${formatDuration(untilTypicalExpiry)} \u00b7 typical eviction starts after ${formatDuration(window.softMs)} idle`,
+      };
     }
-    if (since > window.softMs) {
+    if (since < window.hardMs) {
       const suffix = rewriteSuffix("may re-send", input.cachedTokens, input.rewriteUsd);
       return {
         phase: "fading",
-        text: `cache fading \u00b7 idle ${formatDuration(since)} of ${formatDuration(window.softMs)}\u2013${formatDuration(window.hardMs)} window${suffix}`,
+        text: `cache may be stale \u00b7 typical eviction window ${formatDuration(window.softMs)}\u2013${formatDuration(window.hardMs)}${suffix}`,
       };
     }
-    return { phase: "warm-unknown", text: `cache likely warm \u00b7 ${formatDuration(since)} since last call` };
+    const suffix = rewriteSuffix("may re-send", input.cachedTokens, input.rewriteUsd, " uncached");
+    return { phase: "cold", text: `cache stale \u00b7 beyond ${formatDuration(window.hardMs)} cache cap${suffix}` };
   }
-  // Unknown window: no contract, only soft language — but past the soft horizon we still
-  // know exactly how much prompt would be re-sent uncached.
-  if (since > UNKNOWN_TTL_WARM_MS) {
-    const suffix = rewriteSuffix("re-sends", input.cachedTokens, input.rewriteUsd, " uncached");
-    return { phase: "cold-unknown", text: `cache likely cold (idle ${formatDuration(since)})${suffix}` };
+  return { phase: "idle", text: "" };
+}
+
+/** Delay until the clock's visible wording can change. Undefined means no timer is needed. */
+export function nextClockUpdateMs(input: ClockInput): number | undefined {
+  if (input.lastRequestAt === undefined || input.compacted) return undefined;
+  if (input.modelSwitched) {
+    const prior = input.switchForecast?.prior;
+    const priorWindow = prior?.window;
+    if (!prior || !priorWindow || priorWindow.kind === "unknown") return undefined;
+    const horizon = priorWindow.kind === "contract" ? priorWindow.ttlMs : priorWindow.softMs;
+    const remaining = horizon - (input.now - prior.requestAt);
+    return remaining >= 0 ? remaining + 1 : undefined;
   }
-  return { phase: "warm-unknown", text: `cache likely warm \u00b7 ${formatDuration(since)} since last call` };
+  const since = input.now - input.lastRequestAt;
+  const window = input.window ?? UNKNOWN_WINDOW;
+  if (window.kind === "unknown" || (input.thinkingChanged && window.kind === "contract")) return undefined;
+
+  const warningAt = (window.kind === "contract" ? window.ttlMs : window.softMs) - warningLeadMs(window);
+  if (since < warningAt) return warningAt - since;
+
+  if (window.kind === "contract") {
+    const remaining = window.ttlMs - since;
+    if (remaining <= 0) return undefined;
+    return Math.min(remaining, remaining > 90_000 ? 15_000 : 1_000);
+  }
+
+  if (since < window.softMs) return Math.min(window.softMs - since, 1_000);
+  if (since < window.hardMs) return window.hardMs - since;
+  return undefined;
 }
 
 export function toneFor(phase: ClockState["phase"]): Tone {
-  switch (phase) {
-    case "fresh":
-    case "warm-unknown":
-      return "success";
-    case "closing":
-      return "warning";
-    default: // cold, stale, cold-unknown, idle
-      return "dim";
-  }
+  return phase === "idle" ? "dim" : "warning";
 }

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -25,7 +25,7 @@ import {
   pastWindow,
   stripCacheControl,
 } from "./classify.ts";
-import { UNKNOWN_WINDOW, cacheClock, toneFor, withinWarmHorizon } from "./clock.ts";
+import { UNKNOWN_WINDOW, cacheClock, nextClockUpdateMs, toneFor, withinWarmHorizon } from "./clock.ts";
 import { activeToolShapes, computeSwitchForecast, type SwitchForecast, type SwitchTarget } from "./forecast.ts";
 import { restoreBranchRecords } from "./ledger.ts";
 import {
@@ -36,6 +36,7 @@ import {
   restoreLineageSnapshots,
 } from "./lineage.ts";
 import { renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
+import { clearCacheWidgetTimer, type CacheWidgetRuntime, resetCacheWidget, updateCacheWidget } from "./widget.ts";
 import type {
   BreakPrediction,
   CacheLineageSnapshot,
@@ -68,8 +69,8 @@ export type {
  * pi-cachemire — explains the cache and loop economics of a pi session.
  *
  * pi's footer already *counts* (input/output/cache read/write/cost); cachemire *explains*:
- *   1. "Am I past TTL?"            → a live cache clock above the editor, counting down the
- *      provider cache TTL from the last request, with the re-write bill once likely cold.
+ *   1. "Am I past TTL?"            → a warning above the editor shortly before a known
+ *      cache window closes, with the possible re-write bill once stale.
  *   2. "Why did the cache break?"  → forensics: every provider request is fingerprinted
  *      (system / tools / history segments, cache_control stripped); on a miss the diff
  *      names the culprit — TTL expiry, compaction, model switch, system prompt edit,
@@ -84,7 +85,7 @@ export type {
  * target tokenizer and marked est (issue #57). Display is UI-only: nothing cachemire
  * renders enters LLM context, session entries, or exports.
  * Anthropic gets the full treatment (explicit breakpoints, 5m/1h TTL, priced writes);
- * other providers degrade honestly to observed reads and soft "likely warm/cold" wording.
+ * documented best-effort windows use hedged warnings and unknown lifetimes stay silent.
  */
 
 const DEFAULT_CONFIG: CachemireConfig = {
@@ -95,7 +96,6 @@ const DEFAULT_CONFIG: CachemireConfig = {
   missWarnUsd: 0.05,
   missWarnTokens: 20_000,
 };
-
 
 // pi-coding-agent never passes cacheRetention to pi-ai, so pi-ai's resolveCacheRetention
 // falls through to this env var alone ("long" → 1h where the model supports it, else 5m).
@@ -133,7 +133,6 @@ function windowLabel(window: CacheWindow): string {
       return "TTL unknown";
   }
 }
-
 
 /**
  * What a pi thinking level becomes on the anthropic wire — mirrors pi-ai's
@@ -424,16 +423,15 @@ interface CachemireState {
   theme?: Theme;
   ui?: Pick<ExtensionUIContext, "setWidget" | "notify">;
   tui?: { requestRender?: (force?: boolean) => void };
-  lastWidgetText?: string;
 }
 
 type CachemireGlobal = typeof globalThis & {
   __piCachemire?: CachemireState;
-  __piCachemireTimer?: ReturnType<typeof setInterval>;
+  __piCachemireWidget?: CacheWidgetRuntime;
   __piCachemireOwner?: symbol;
 };
 const g = globalThis as CachemireGlobal;
-
+const cacheWidget = g.__piCachemireWidget ??= {};
 function state(): CachemireState {
   if (!g.__piCachemire) {
     g.__piCachemire = {
@@ -457,27 +455,25 @@ function state(): CachemireState {
 function econLine(tone: Tone, text: string): string {
   return ink(state().theme, tone, `${GLYPH.econ} ${text}`);
 }
-
 function updateWidget(now = Date.now()): void {
   const s = state();
-  if (!s.ui || !s.config.widget) return;
-  const clock = cacheClock({
-    now,
-    lastRequestAt: s.lastRequestAt,
-    window: s.window,
-    cachedTokens: s.expectedRead,
-    rewriteUsd: s.expectedRead > 0 ? rewriteCostUsd(s.expectedRead, s.rates) : undefined,
-    compacted: s.compacted,
-    modelSwitched: s.modelSwitched,
-    switchForecast: s.switchForecast,
-    thinkingChanged: s.thinkingChanged,
+  updateCacheWidget(cacheWidget, {
+    enabled: s.config.widget,
+    ui: s.ui,
+    renderLine: econLine,
+    clock: {
+      now,
+      lastRequestAt: s.lastRequestAt,
+      window: s.window,
+      cachedTokens: s.expectedRead,
+      rewriteUsd: s.expectedRead > 0 ? rewriteCostUsd(s.expectedRead, s.rates) : undefined,
+      compacted: s.compacted,
+      modelSwitched: s.modelSwitched,
+      switchForecast: s.switchForecast,
+      thinkingChanged: s.thinkingChanged,
+    },
   });
-  const text = clock.phase === "idle" ? "" : econLine(toneFor(clock.phase), clock.text);
-  if (text === s.lastWidgetText) return;
-  s.lastWidgetText = text;
-  s.ui.setWidget("pi-cachemire", text === "" ? undefined : [text]);
 }
-
 function appendChatLine(text: string): Text | undefined {
   const s = state();
   s.notifyFallback ??= (plainText) => s.ui?.notify(plainText, "info");
@@ -562,15 +558,13 @@ export default function piCachemire(pi: ExtensionAPI): void {
     captureTui(ctx.ui, "__pi_cachemire_capture", (tui) => {
       s.tui = tui as CachemireState["tui"];
     });
-    if (g.__piCachemireTimer) clearInterval(g.__piCachemireTimer);
-    g.__piCachemireTimer = s.config.widget ? setInterval(() => updateWidget(), 1000) : undefined;
+    resetCacheWidget(cacheWidget);
     updateWidget();
   });
 
   pi.on("session_shutdown", async () => {
     if (!ownsState()) return;
-    if (g.__piCachemireTimer) clearInterval(g.__piCachemireTimer);
-    g.__piCachemireTimer = undefined;
+    clearCacheWidgetTimer(cacheWidget);
     g.__piCachemireOwner = undefined;
   });
 
@@ -634,8 +628,11 @@ export default function piCachemire(pi: ExtensionAPI): void {
         rates: s.rates,
         switchForecast: s.switchForecast === undefined ? undefined : {
           ...s.switchForecast,
-          priorMayBeWarm: s.switchForecast.prior !== undefined &&
-            withinWarmHorizon(s.switchForecast.prior.window, requestAt - s.switchForecast.prior.requestAt),
+          priorMayBeWarm: s.switchForecast.prior !== undefined && (
+            s.switchForecast.prior.window === undefined ||
+            s.switchForecast.prior.window.kind === "unknown" ||
+            withinWarmHorizon(s.switchForecast.prior.window, requestAt - s.switchForecast.prior.requestAt)
+          ),
         },
       });
       const sizedTokens = prediction?.expectedRewriteTokens ?? prediction?.estimatedRewriteTokens;
@@ -726,6 +723,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     if (!ownsState()) return;
     s.inCompaction = false;
     s.compacted = true;
+    updateWidget();
   });
 
   pi.on("message_end", async (event) => {
@@ -922,6 +920,8 @@ export const internals = {
   anchorForAppend,
   reattachAnchored,
   cacheClock,
+  nextClockUpdateMs,
+  toneFor,
   renderRunSummary,
   renderMissLine,
   renderLedger,

--- a/extensions/pi-cachemire/render.ts
+++ b/extensions/pi-cachemire/render.ts
@@ -41,7 +41,7 @@ function breakingSize(p: BreakPrediction): string {
     return ` \u00b7 sending ~${compactCount(p.estimatedRewriteTokens)} uncached` +
       `${p.targetProvider === undefined ? "" : ` to ${p.targetProvider}`} (${parens})`;
   }
-  if (p.cause.kind === "compaction") return " \u00b7 re-writing the new prefix";
+  if (p.cause.kind === "compaction") return " \u00b7 re-writing changed history";
   if (p.cause.kind === "thinking") {
     // Anthropic documents that system/tools survive *budget* changes; for adaptive
     // effort changes a live test on claude-fable-5 broke 100% of the prompt

--- a/extensions/pi-cachemire/widget.ts
+++ b/extensions/pi-cachemire/widget.ts
@@ -1,0 +1,41 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { type ClockInput, cacheClock, nextClockUpdateMs, toneFor } from "./clock.ts";
+import type { Tone } from "../_lib/style.ts";
+
+export interface CacheWidgetRuntime {
+  timer?: ReturnType<typeof setTimeout>;
+  lastText?: string;
+}
+
+interface CacheWidgetInput {
+  enabled: boolean;
+  ui?: Pick<ExtensionUIContext, "setWidget">;
+  clock: ClockInput;
+  renderLine: (tone: Tone, text: string) => string;
+}
+
+export function clearCacheWidgetTimer(runtime: CacheWidgetRuntime): void {
+  if (runtime.timer) clearTimeout(runtime.timer);
+  runtime.timer = undefined;
+}
+
+export function resetCacheWidget(runtime: CacheWidgetRuntime): void {
+  clearCacheWidgetTimer(runtime);
+  runtime.lastText = undefined;
+}
+
+export function updateCacheWidget(runtime: CacheWidgetRuntime, input: CacheWidgetInput): void {
+  clearCacheWidgetTimer(runtime);
+  if (!input.ui) return;
+  const clock = input.enabled ? cacheClock(input.clock) : { phase: "idle" as const, text: "" };
+  const text = clock.phase === "idle" ? "" : input.renderLine(toneFor(clock.phase), clock.text);
+  if (text !== runtime.lastText) {
+    runtime.lastText = text;
+    input.ui.setWidget("pi-cachemire", text === "" ? undefined : [text]);
+  }
+  if (!input.enabled) return;
+  const delay = nextClockUpdateMs(input.clock);
+  if (delay === undefined) return;
+  runtime.timer = setTimeout(() => updateCacheWidget(runtime, { ...input, clock: { ...input.clock, now: Date.now() } }), Math.max(1, delay));
+  runtime.timer.unref();
+}

--- a/tests/cachemire/economics-and-render.test.ts
+++ b/tests/cachemire/economics-and-render.test.ts
@@ -11,6 +11,7 @@ const {
   cacheClock, renderRunSummary, renderMissLine, renderLedger,
   inferAnthropicTtlMs, predictBreak, renderBreakingLine, renderHeldLine,
   windowForProvider, windowLabel, pastWindow, OPENAI_WINDOW, thinkingLevelsDiffer, wireThinkingEffort,
+  nextClockUpdateMs, toneFor,
 } = internals;
 
 const CONTRACT_5M = { kind: "contract", ttlMs: 5 * 60_000, source: "observed" } as const;
@@ -52,57 +53,85 @@ test("formatting primitives", () => {
   assert.equal(formatDuration(64 * MIN), "1h4m");
 });
 
-test("cache clock phases", () => {
+test("cache clock stays silent until attention is useful", () => {
   assert.equal(cacheClock({ now: 0 }).phase, "idle");
 
-  // Fresh: coarse 15s steps above 90s remaining, so the widget re-renders sparsely.
-  const fresh = cacheClock({ now: 100_000, lastRequestAt: 0, window: CONTRACT_5M });
-  assert.equal(fresh.phase, "fresh");
-  assert.equal(fresh.text, "cache 3m15s"); // 200s remaining → floored to 195s
+  const healthy = cacheClock({ now: 100_000, lastRequestAt: 0, window: CONTRACT_5M });
+  assert.equal(healthy.phase, "idle");
+  assert.equal(healthy.text, "");
 
   const closing = cacheClock({ now: 4 * MIN + 15_000, lastRequestAt: 0, window: CONTRACT_5M });
   assert.equal(closing.phase, "closing");
-  assert.equal(closing.text, "cache 45s");
+  assert.equal(closing.text, "cache expires in 45s");
 
   const cold = cacheClock({ now: 6 * MIN, lastRequestAt: 0, window: CONTRACT_5M, cachedTokens: 142_300, rewriteUsd: 2.67 });
   assert.equal(cold.phase, "cold");
-  assert.equal(cold.text, "cache cold \u00b7 next send re-writes ~142.3k (~$2.67)");
+  assert.equal(cold.text, "cache stale \u00b7 TTL expired \u00b7 next send may re-write ~142.3k (~$2.67)");
 
-  // No TTL contract (OpenAI etc.): soft language, but the re-send size is still exact.
-  assert.equal(cacheClock({ now: 3 * MIN, lastRequestAt: 0 }).text, "cache likely warm \u00b7 3m since last call");
-  const coldUnknown = cacheClock({ now: 535 * MIN, lastRequestAt: 0, cachedTokens: 109_800, rewriteUsd: 1.37 });
-  assert.equal(coldUnknown.phase, "cold-unknown");
-  assert.equal(coldUnknown.text, "cache likely cold (idle 8h55m) \u00b7 next send re-sends ~109.8k uncached (~$1.37)");
-  // Without token info the bare form survives (e.g. before any usage was ever observed).
-  assert.equal(cacheClock({ now: 12 * MIN, lastRequestAt: 0 }).text, "cache likely cold (idle 12m)");
+  // Unknown cache lifetimes stay silent rather than guessing at warm or cold states.
+  assert.deepEqual(cacheClock({ now: 3 * MIN, lastRequestAt: 0 }), { phase: "idle", text: "" });
+  assert.deepEqual(
+    cacheClock({ now: 535 * MIN, lastRequestAt: 0, cachedTokens: 109_800, rewriteUsd: 1.37 }),
+    { phase: "idle", text: "" },
+  );
 
-  // Compaction invalidates the timed prefix outright — TTL is moot until the next send.
   const stale = cacheClock({ now: MIN, lastRequestAt: 0, window: CONTRACT_5M, cachedTokens: 142_300, compacted: true });
   assert.equal(stale.phase, "stale");
-  assert.equal(stale.text, "cache stale \u00b7 history compacted \u00b7 next send re-writes the new prefix");
+  assert.equal(stale.text, "cache stale after compaction \u00b7 next send may re-write changed history");
 
   // Model-switch clock states (target-currency forecast, A→B→A warmth) live in
   // tests/cachemire/model-switch.test.ts.
 
-  // Thinking level change: Anthropic documents message-breakpoint invalidation with
-  // system/tools surviving — a contract-backed stale state. Compaction outranks it.
   const thinking = cacheClock({ now: MIN, lastRequestAt: 0, window: CONTRACT_5M, cachedTokens: 142_300, thinkingChanged: true });
   assert.equal(thinking.phase, "stale");
-  assert.equal(thinking.text, "cache stale \u00b7 thinking level changed \u00b7 next send re-writes the prompt");
+  assert.equal(thinking.text, "cache stale \u00b7 thinking level changed \u00b7 next send may re-write the prompt");
   // Effort lives outside OpenAI's prompt prefix: a band window makes no claim.
-  const bandThinking = cacheClock({ now: 3 * MIN, lastRequestAt: 0, window: OPENAI_WINDOW, thinkingChanged: true });
-  assert.equal(bandThinking.text, "cache likely warm \u00b7 3m since last call");
+  assert.deepEqual(
+    cacheClock({ now: 3 * MIN, lastRequestAt: 0, window: OPENAI_WINDOW, thinkingChanged: true }),
+    { phase: "idle", text: "" },
+  );
+
+  assert.equal(toneFor("closing"), "warning");
+  assert.equal(toneFor("stale"), "warning");
+  assert.equal(toneFor("cold"), "warning");
 });
 
-test("openai band: warm → fading → hard-cap cold", () => {
+test("openai band warns near typical eviction without claiming certainty", () => {
   const base = { lastRequestAt: 0, window: OPENAI_WINDOW, cachedTokens: 109_800, rewriteUsd: 1.37 };
-  assert.equal(cacheClock({ ...base, now: 3 * MIN }).text, "cache likely warm \u00b7 3m since last call");
+  assert.deepEqual(cacheClock({ ...base, now: 3 * MIN }), { phase: "idle", text: "" });
+  assert.equal(
+    cacheClock({ ...base, now: 4 * MIN + 30_000 }).text,
+    "cache may expire in 30s \u00b7 typical eviction starts after 5m idle",
+  );
   const fading = cacheClock({ ...base, now: 12 * MIN });
   assert.equal(fading.phase, "fading");
-  assert.equal(fading.text, "cache fading \u00b7 idle 12m of 5m\u20131h window \u00b7 next send may re-send ~109.8k (~$1.37)");
+  assert.equal(fading.text, "cache may be stale \u00b7 typical eviction window 5m\u20131h \u00b7 next send may re-send ~109.8k (~$1.37)");
   const capped = cacheClock({ ...base, now: 90 * MIN });
   assert.equal(capped.phase, "cold");
-  assert.equal(capped.text, "cache cold (idle 1h30m > 1h cap) \u00b7 next send re-sends ~109.8k uncached (~$1.37)");
+  assert.equal(capped.text, "cache stale \u00b7 beyond 1h cache cap \u00b7 next send may re-send ~109.8k uncached (~$1.37)");
+});
+
+test("cache clock schedules only useful state changes", () => {
+  assert.equal(nextClockUpdateMs({ now: MIN, lastRequestAt: 0 }), undefined, "unknown TTL has no timer");
+  assert.equal(nextClockUpdateMs({ now: MIN, lastRequestAt: 0, window: CONTRACT_5M }), 3 * MIN);
+  assert.equal(nextClockUpdateMs({ now: 4 * MIN + 30_000, lastRequestAt: 0, window: CONTRACT_5M }), 1_000);
+  assert.equal(nextClockUpdateMs({ now: 6 * MIN, lastRequestAt: 0, window: CONTRACT_5M }), undefined);
+  assert.equal(nextClockUpdateMs({ now: 3 * MIN, lastRequestAt: 0, window: OPENAI_WINDOW }), MIN);
+  assert.equal(nextClockUpdateMs({ now: 3 * MIN, lastRequestAt: 0, window: OPENAI_WINDOW, thinkingChanged: true }), MIN);
+  assert.equal(nextClockUpdateMs({ now: 3 * MIN, lastRequestAt: 0, window: CONTRACT_5M, thinkingChanged: true }), undefined);
+  assert.equal(nextClockUpdateMs({ now: 12 * MIN, lastRequestAt: 0, window: OPENAI_WINDOW }), 48 * MIN);
+  assert.equal(nextClockUpdateMs({
+    now: MIN,
+    lastRequestAt: 0,
+    modelSwitched: true,
+    switchForecast: {
+      targetId: "openai/gpt",
+      targetProvider: "openai",
+      estTokens: 10_000,
+      basis: "direct",
+      prior: { requestAt: 0, window: OPENAI_WINDOW },
+    },
+  }), 4 * MIN + 1);
 });
 
 test("thinking level changes are material only when they change the wire params", () => {
@@ -289,7 +318,7 @@ test("break prediction: knowable at request time, silent when healthy", () => {
   const compaction = predictBreak({ ...base, compacted: true, gapMs: 1_000, window: CONTRACT_5M })!;
   assert.equal(compaction.cause.kind, "compaction");
   assert.equal(compaction.expectedRewriteTokens, undefined);
-  assert.equal(renderBreakingLine(compaction), "cache breaking \u00b7 re-writing the new prefix \u00b7 cause: history compacted");
+  assert.equal(renderBreakingLine(compaction), "cache breaking \u00b7 re-writing changed history \u00b7 cause: history compacted");
 });
 
 test("ledger view: rows, totals, and the savings line", () => {

--- a/tests/cachemire/goldens.test.ts
+++ b/tests/cachemire/goldens.test.ts
@@ -59,7 +59,7 @@ const COMPACTION_RECORD: CallRecord = {
 test("cachemire ledger and one-line surfaces golden", () => {
   const clock = (input: Parameters<typeof cacheClock>[0]) => {
     const state = cacheClock(input);
-    return `[${state.phase}] \u25cd ${state.text}`;
+    return state.phase === "idle" ? "[idle] (hidden)" : `[${state.phase}] \u25cd ${state.text}`;
   };
   const base = { lastRequestAt: 0, window: CONTRACT_5M, cachedTokens: 150_300, rewriteUsd: 2.82 };
 

--- a/tests/cachemire/model-switch-events.test.ts
+++ b/tests/cachemire/model-switch-events.test.ts
@@ -78,7 +78,7 @@ const ANTHROPIC_PAYLOAD = {
   messages: [{ role: "user", content: [{ type: "text", text: "next" }] }],
 };
 
-test("event flow: an aborted first send clears its speculative cache clock", async () => {
+test("event flow: a healthy first send and an abort both stay silent", async () => {
   const notifications: string[] = [];
   const widgets: string[] = [];
   const probe = extensionProbe();
@@ -87,9 +87,9 @@ test("event flow: an aborted first send clears its speculative cache clock", asy
   await fire(probe, "session_start", {}, ctx);
   try {
     await fire(probe, "before_provider_request", { payload: ANTHROPIC_PAYLOAD }, ctx);
-    assert.notEqual(widgets.at(-1), "", "the in-flight request starts the cache clock");
+    assert.equal(widgets.at(-1), "", "a healthy cache must not show ambient status");
     await fire(probe, "agent_end");
-    assert.equal(widgets.at(-1), "", "an abort without usage must not leave a fictitious TTL anchor");
+    assert.equal(widgets.at(-1), "", "an abort without usage must not leave a fictitious warning");
   } finally {
     await fire(probe, "session_shutdown", {});
   }

--- a/tests/cachemire/model-switch.test.ts
+++ b/tests/cachemire/model-switch.test.ts
@@ -39,20 +39,24 @@ test("clock: A\u2192B\u2192A switch-back defers to the target's own prior entry"
   // The target model's own last billed call is inside its window: "cold" would overclaim.
   const back = cacheClock({ now: MIN, lastRequestAt: 0, window: CONTRACT_5M, modelSwitched: true, switchForecast: { ...FORECAST, prior: { requestAt: 0, window: BAND } } });
   assert.equal(back.phase, "warm-unknown");
-  assert.equal(back.text, "cache may still be warm \u00b7 last gpt-5.6-luna call 1m ago \u00b7 next send confirms");
+  assert.equal(back.text, "cache may still be warm \u00b7 switched back to gpt-5.6-luna \u00b7 next send confirms");
   // Past the prior's soft horizon the switch-back is cold expected like any other switch.
   const backCold = cacheClock({ now: 10 * MIN, lastRequestAt: 0, window: CONTRACT_5M, modelSwitched: true, switchForecast: { ...FORECAST, prior: { requestAt: 0, window: BAND } } });
   assert.equal(backCold.phase, "cold");
+  // Unknown retention cannot support either a warm or cold claim.
+  const unknown = cacheClock({ now: 10 * MIN, lastRequestAt: 0, window: CONTRACT_5M, modelSwitched: true, switchForecast: { ...FORECAST, prior: { requestAt: 0, window: { kind: "unknown" } } } });
+  assert.equal(unknown.text, "cache state unknown \u00b7 model switched \u00b7 next send confirms");
+  const compacted = cacheClock({ now: MIN, lastRequestAt: 0, window: CONTRACT_5M, modelSwitched: true, compacted: true, switchForecast: { ...FORECAST, prior: { requestAt: 0, window: BAND } } });
+  assert.equal(compacted.text, "cache stale after compaction \u00b7 next send may re-write changed history");
 });
 
-test("warm horizon: contract TTL, band soft edge, implicit-cache horizon", () => {
+test("warm horizon: contract TTL and documented band only", () => {
   assert.equal(withinWarmHorizon(CONTRACT_5M, 4 * MIN), true);
   assert.equal(withinWarmHorizon(CONTRACT_5M, 6 * MIN), false);
   const band = { kind: "band", softMs: 5 * MIN, hardMs: 60 * MIN } as const;
   assert.equal(withinWarmHorizon(band, 4 * MIN), true);
   assert.equal(withinWarmHorizon(band, 30 * MIN), false, "the band maybe-zone must not claim warm");
-  assert.equal(withinWarmHorizon(undefined, 9 * MIN), true);
-  assert.equal(withinWarmHorizon(undefined, 11 * MIN), false);
+  assert.equal(withinWarmHorizon(undefined, 1 * MIN), false, "unknown retention must not guess at warmth");
 });
 
 test("break prediction: model switch sized in the target currency, or silent when warm", () => {

--- a/tests/fixtures/goldens/cachemire-lines.txt
+++ b/tests/fixtures/goldens/cachemire-lines.txt
@@ -10,20 +10,20 @@
   caching saved ~$3.00 vs uncached $7.77 (−39%) · API-priced; notional on subscription
 
 === clock states (widget) ===
-[fresh] ◍ cache 4m
-[closing] ◍ cache 30s
-[cold] ◍ cache cold · next send re-writes ~150.3k (~$2.82)
-[stale] ◍ cache stale · history compacted · next send re-writes the new prefix
-[stale] ◍ cache stale · thinking level changed · next send re-writes the prompt
+[idle] (hidden)
+[closing] ◍ cache expires in 30s · next send may re-write ~150.3k (~$2.82)
+[cold] ◍ cache stale · TTL expired · next send may re-write ~150.3k (~$2.82)
+[stale] ◍ cache stale after compaction · next send may re-write changed history
+[stale] ◍ cache stale · thinking level changed · next send may re-write the prompt
 [cold] ◍ cache cold expected · model switched · next send ~96.4k uncached to openai-codex (est)
 [cold] ◍ cache cold expected · model switched · next send ~96.4k uncached to radius (rough est · gateway route)
-[warm-unknown] ◍ cache may still be warm · last claude-opus-4-8 call 1m ago · next send confirms
+[warm-unknown] ◍ cache may still be warm · switched back to claude-opus-4-8 · next send confirms
 [cold] ◍ cache cold expected · model switched · prompt size known at next send
-[cold] ◍ cache cold (idle 1h10m > 1h cap) · next send re-sends ~64.3k uncached (~$0.12)
+[cold] ◍ cache stale · beyond 1h cache cap · next send may re-send ~64.3k uncached (~$0.12)
 
 === notices (chat lines) ===
 ◍ cache breaking · re-writing ~150.3k (~$2.82) · cause: idle 7m00s > 5m TTL
-◍ cache breaking · re-writing the new prefix · cause: history compacted
+◍ cache breaking · re-writing changed history · cause: history compacted
 ◍ cache breaking · sending ~96.4k uncached to openai-codex (est · ~$0.12) · cause: model switched claude-opus-4-8 → gpt-5.6-luna
 ◍ cache after compaction · reused 34.9k of the last pre-compaction 72.5k prompt (48%) · processed 39.1k uncached
 ◍ cache broke · re-wrote 153.0k of 153.2k prompt (100%) · $2.97 · cause: idle 7m00s > 5m TTL


### PR DESCRIPTION
## Summary

- hide Cachemire while the cache is healthy or its lifetime is unknown
- warn shortly before known TTLs expire and use cautious wording for OpenAI's best-effort window
- make stale, invalidated and post-compaction states prominent without claiming the whole prompt changed
- replace the permanent one-second timer with updates scheduled around warning boundaries
- cover combined compaction, model-switch and thinking-level states

## Tests

- `npm run check` (314 tests)

Fixes #25
