### PR TITLE
refactor(cachemire): generate retention docs from policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ language. TypeScript, zero runtime dependencies, tests on `node:test`.
 ```bash
 npm run link-pi         # symlink the installed pi runtime into node_modules (types + contract tests); run first on a fresh clone
 npm run link-extensions # symlink the extensions (as directories) into ~/.pi/agent/extensions
-npm run lint            # deterministic agent coding-standard checks
+npm run docs:cache      # regenerate Cachemire retention docs
+npm run lint            # coding-standard and generated-doc drift checks
 npm run typecheck       # tsc against the real installed pi
 npm test                # unit + golden + pi contract tests (zero deps, node:test)
 npm run check           # lint + typecheck + tests
@@ -30,14 +31,11 @@ npm run test:smoke      # launches real pi in tmux with an isolated HOME (local-
 - The contract suite pins every structural assumption about pi internals, so after
   `pi update` a quick `npm test` says exactly which seam (if any) drifted. Test design
   notes: [`docs/testing.md`](./docs/testing.md).
-- Before changing Cachemire retention logic, read the dated
-  [retention audit](./docs/cache-retention-audit-2026-08-04.md) and lifecycle rules in
-  [`docs/pi-cachemire.md`](./docs/pi-cachemire.md). Resolve retention from the exact
-  route, model, documented default and observed outgoing policy. Keep minimum and
-  maximum semantics distinct. Unknown retention earns no idle-time or warmth claim.
-  Usage proves reads and writes, not eviction, routing, replica identity
-  or the whole next prompt. Update `retention.ts`, its evidence tests and both docs
-  together.
+- Before changing Cachemire retention, read the dated
+  [audit](./docs/cache-retention-audit-2026-08-04.md). `retention.ts` drives runtime
+  resolution and generated policy docs; `cacheClock()` owns clock wording. Match the
+  exact route, model and outgoing policy. Keep minimum and maximum semantics distinct,
+  and leave unmatched routes unknown. Run `npm run docs:cache` after policy changes.
 - Goldens regenerate with `UPDATE_GOLDENS=1 npm test`. Review the diff like code.
   Regenerate whenever rendering changes.
 - README screenshots regenerate with the rig in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - **Cachemire: show cache status only when evidence supports action.** Observed
   Anthropic 5-minute and 1-hour TTLs warn shortly before expiry. Restored Anthropic
-  sessions may infer the TTL from `PI_CACHE_RETENTION`. A direct official OpenAI GPT-5
-  GPT-5.6 and later GPT-5 models use OpenAI's documented 30-minute minimum on both
+  sessions may infer the TTL from `PI_CACHE_RETENTION`. GPT-5.6 and later GPT-5 models
+  use OpenAI's documented 30-minute minimum on both
   OpenAI and OpenAI Codex. A direct official OpenAI GPT-5 request below GPT-5.6 gets a
   24-hour maximum only when its outgoing payload contains `prompt_cache_retention:
   "24h"`; other routes make no idle-time or warmth claim. This removes the OpenAI
@@ -13,7 +13,8 @@
   and 512-token entry matching. Re-write forecasts use the prior billed prompt as a
   baseline, not the whole next prompt. Stale and invalidated states retain warning
   emphasis, compaction says only that changed history may be re-written, and the widget
-  sleeps until the next supported warning boundary. Fixes #25.
+  sleeps until the next supported warning boundary. Runtime resolution and generated
+  retention docs now share one typed policy registry; lint rejects drift. Fixes #25.
 - **Contextimate: recognise the Claude 4.7+ tokenizer across routes.** Fable 5,
   Opus 5 and explicit Claude 4.7+ models relayed through Radius or OpenRouter now
   use the same measured profile as Claude 4.7/4.8. Bedrock retains its own payload

--- a/docs/agent-coding-standard.md
+++ b/docs/agent-coding-standard.md
@@ -13,7 +13,8 @@ npm run check
 ```
 
 `npm run lint` runs `scripts/dev/agent-lint.mjs`, a zero-dependency source lint
-for repo-specific invariants. Existing violations are recorded in
+for repo-specific invariants, then checks generated Cachemire retention docs. Existing
+source violations are recorded in
 `scripts/dev/agent-lint-baseline.json` so the rule can prevent regressions while the
 codebase is migrated deliberately. Do not grow the baseline as a way to dodge the
 standard. Fix the code, add a precise `SAFETY:` comment for a real seam, or update a

--- a/docs/cache-retention-audit-2026-08-04.md
+++ b/docs/cache-retention-audit-2026-08-04.md
@@ -4,27 +4,17 @@ Corrected on 5 August 2026 after rechecking the GPT-5.6 model-family default.
 
 ## Outcome
 
-Cachemire can make elapsed-time claims for 3 policy types:
-
-- Anthropic `cache_control` with a 5-minute or 1-hour TTL, with a restored-session
-  inference from `PI_CACHE_RETENTION`
-- the 30-minute minimum for GPT-5.6 and later GPT-5 models on OpenAI and OpenAI Codex
-- the 24-hour maximum on a direct official OpenAI GPT-5 request below GPT-5.6 whose
-  outgoing payload contains `prompt_cache_retention: "24h"`
-
-Other routes have unknown retention. Cachemire makes no idle-time claim for them.
+The generated evidence matrix and runtime resolution use the same typed registry.
 
 ## Evidence reviewed
 
-We checked these sources on 4 August 2026 and rechecked OpenAI on 5 August 2026:
+<!-- BEGIN GENERATED CACHE RETENTION: evidence-sources -->
+- [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching), reviewed 5 August 2026: GPT-5.6 minimum eligibility and legacy extended retention
+- [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), reviewed 4 August 2026: ephemeral cache TTL contracts
+- Installed Pi request builders and model records, reviewed 5 August 2026: `pi-ai/dist/api/openai-responses.js`, `openai-codex-responses.js`, `anthropic-messages.js` and the OpenAI model records
+<!-- END GENERATED CACHE RETENTION: evidence-sources -->
 
-- [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching)
-- [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
-- installed Pi request builders in `pi-ai/dist/api/openai-responses.js`,
-  `openai-codex-responses.js` and `anthropic-messages.js`
-- installed Pi model records in `pi-ai/dist/providers/data/openai.json` and
-  `openai-codex.json`
-- Cachemire request, lifecycle, lineage and rendering paths
+We also checked Cachemire's request, lifecycle, lineage and rendering paths.
 
 OpenAI states that `prompt_cache_options.ttl` applies to GPT-5.6 and later model
 families. Its only supported value is `30m`, which is also the default. A cached prefix
@@ -34,14 +24,14 @@ request shape.
 
 ## Supported evidence
 
-| Route | Evidence available to Cachemire | Safe runtime claim |
-|---|---|---|
-| Anthropic API, live request | outgoing `cache_control` contains a 5-minute or 1-hour TTL | show a TTL clock from the observed request time |
-| Anthropic API, restored session | Pi resolves ordinary calls from `PI_CACHE_RETENTION` | infer 5 minutes, or 1 hour when the value is `long`, until a live payload replaces it |
-| OpenAI or OpenAI Codex, GPT-5.6 and later GPT-5 models | documented model-family default | keep stale warnings off for 30 minutes; after that, say the cache state is unknown |
-| Direct official OpenAI API, GPT-5 below GPT-5.6 | actual outgoing payload contains `prompt_cache_retention: "24h"` | record a 24-hour maximum; stay neutral before it and mark stale when it is reached |
-| Direct official OpenAI API, GPT-5 below GPT-5.6 without that field | no observed supported retention policy | keep retention unknown |
-| Other and gateway routes | no route-specific supported evidence | keep retention unknown |
+<!-- BEGIN GENERATED CACHE RETENTION: policy-table -->
+| Route | Retention evidence | Cachemire behaviour | Evidence source |
+|---|---|---|---|
+| Anthropic, live request | `cache_control` contains a 5m or 1h TTL | use the observed TTL | [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), Installed Pi request builders and model records |
+| Anthropic, restored session | Pi resolves ordinary calls from `PI_CACHE_RETENTION` | infer 5m, or 1h when set to `long`, until a live payload replaces it | Installed Pi request builders and model records |
+| OpenAI or OpenAI Codex, GPT-5.6 and later GPT-5 models | documented `prompt_cache_options.ttl` default | use a 30m minimum; after it ends, show that the cache state is unknown | [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching), Installed Pi request builders and model records |
+| Direct official OpenAI API, GPT-5 below GPT-5.6 | outgoing payload contains `prompt_cache_retention: "24h"` | record a 24h maximum, with no warmth claim before it | [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching), Installed Pi request builders and model records |
+<!-- END GENERATED CACHE RETENTION: policy-table -->
 
 `in_memory` is not a supported Cachemire retention signal. Cachemire also has no
 5-minute to 1-hour OpenAI band.
@@ -63,15 +53,3 @@ remain unexplained.
 The prior billed prompt-side token count is also not the whole next prompt. The next
 request adds the new user message and other suffix content. Cachemire may use the prior
 count as a labelled comparison baseline, but not as an exact next-request size.
-
-## Guardrails
-
-Retention resolution belongs in `extensions/pi-cachemire/retention.ts`. The route,
-model, documented default and observed outgoing policy must support the claim.
-
-`tests/cachemire/retention-evidence.test.ts` covers the evidence matrix.
-`tests/contract/pi-cache-retention-seams.test.ts` detects installed Pi request-shape
-drift. Unknown retention must stay silent at every elapsed time.
-
-Run `npm run check` after a retention change. Update the source date only after checking
-the linked provider documentation again.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -170,12 +170,13 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   50k ch. Thresholds live in `style.ts`, overridable through the family config
   convention (`~/.pi/agent/pi-<name>.json`, `<cwd>/.pi/pi-<name>.json`)
 - cache materiality (cachemire): notices only above $0.05 or 20k re-written
-  tokens; silence when healthy. An Anthropic TTL warning appears only during its final
-  `min(5m, 20%)`. It remains visible after expiry until the next provider call resolves
-  the state. A GPT-5.6 30-minute minimum stays hidden until its boundary, then shows an
-  unknown cache state. An exact switch-back within that minimum may say the cache could
-  still be warm. An observed 24-hour OpenAI maximum appears once reached. It earns no
-  warm state or pre-maximum warning. Routes with unknown retention stay silent
+  tokens; silence when healthy. Retention values come from the typed policy registry,
+  not this visual specification. A contract warning appears only during its final
+  `min(5m, 20%)` and remains visible after expiry until the next provider call resolves
+  the state. A minimum stays hidden until its boundary, then shows an unknown cache
+  state. An exact switch-back within an active minimum may say the cache could still be
+  warm. A maximum appears only once reached, with no warmth claim or advance warning.
+  Routes with unknown retention stay silent
 - severity colour is reserved for exceeded thresholds and real states. Nothing is
   tinted for visual interest
 
@@ -225,11 +226,11 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   28.2k (100% of prompt) · the new model already had the prefix cached`, never
   `read 28.2k of 20.6k expected`, which composes two currencies into an impossible
   137% claim
-- certainty ladder: an observed Anthropic TTL supports definite expiry wording. The
-  documented GPT-5.6 30-minute minimum blocks stale wording until it ends, then changes
-  to an unknown state. An observed 24-hour OpenAI maximum supports definite wording only
-  after it is reached. Unknown retention stays silent. Never infer eviction, routing,
-  replica identity or cache entry identity from provider usage
+- certainty ladder: an observed contract supports definite expiry wording. A minimum
+  blocks stale wording until it ends, then changes to an unknown state. A maximum
+  supports definite wording only after it is reached. Unknown retention stays silent.
+  Never infer eviction, routing, replica identity or cache entry identity from provider
+  usage
 - status one-liners are lowercase; Title Case only for panel headers and row labels
 - state causes from observed evidence (payload diffs, usage), never inference,
   and say `unknown` when unknown

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -8,21 +8,9 @@ wording.
 ## Documented retention behaviour
 
 Cachemire resolves retention from the exact route, model and observed outgoing policy.
-A provider name alone is not enough.
-
-| Route | Retention evidence | Cachemire behaviour |
-|---|---|---|
-| Anthropic, live request | `cache_control` contains a 5-minute or 1-hour TTL | use the observed TTL |
-| Anthropic, restored session | Pi resolves ordinary calls from `PI_CACHE_RETENTION` | infer 5 minutes, or 1 hour when set to `long`, until a live payload replaces it |
-| OpenAI or OpenAI Codex, GPT-5.6 and later GPT-5 models | documented `prompt_cache_options.ttl` default | use a 30-minute minimum; after it ends, show that the cache state is unknown |
-| Direct official OpenAI API, GPT-5 below GPT-5.6 | outgoing payload contains `prompt_cache_retention: "24h"` | record a 24-hour maximum, with no warmth claim before it |
-| Direct official OpenAI API, GPT-5 below GPT-5.6 without that field | no supported observed policy | unknown |
-| Other and gateway routes | no route-specific supported evidence | unknown |
-
-Cachemire does not support `in_memory` as retention evidence. It does not model a
-5-minute to 1-hour OpenAI band. Unknown routes produce no idle-time or warmth claim.
-The dated evidence and source links are in
-[`cache-retention-audit-2026-08-04.md`](./cache-retention-audit-2026-08-04.md).
+A provider name alone is not enough. The generated policy and evidence matrix is in the
+[`cache retention audit`](./cache-retention-audit-2026-08-04.md). Unmatched routes make
+no idle-time or warmth claim.
 
 ## Four rules shape the UI
 
@@ -65,12 +53,6 @@ Reaching the minimum does not classify a later miss as eviction.
 For an observed 24-hour OpenAI maximum, Cachemire stays silent before the maximum and
 marks the cache stale once the maximum is reached. Unknown routes remain silent at every
 elapsed time.
-
-```text
-◍ cache expires in 30s · next send may re-write ~109.8k (~$1.37)
-◍ cache state unknown · 30m retention minimum reached · next send may re-send ~109.8k uncached (~$1.37)
-◍ cache stale · 24h retention maximum reached · next send may re-send ~109.8k uncached (~$1.37)
-```
 
 The widget schedules its next update at a known boundary. It updates once per second
 only during the final 90 seconds of a visible countdown. Healthy and unknown states do

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,7 +44,8 @@ Deliberately **not** tested:
   `internals` object consumed by tests. Pi imports only each extension's default entry
   point, so named test surfaces are runtime-inert. Split files by domain when the code
   needs it, as cachemire's renderer and meantime's timing/render modules do.
-- **Scripts:** `npm run lint` (agent coding-standard source checks),
+- **Scripts:** `npm run lint` (agent coding-standard and generated-doc drift checks),
+  `npm run docs:cache` (regenerate Cachemire retention docs),
   `npm run typecheck`, `npm test` (unit + render + contract),
   `npm run check` (lint + typecheck + tests), and `npm run test:smoke`
   (tmux startup smoke, local-only).
@@ -168,21 +169,14 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   rewriting is deliberately left to the authoritative send-time payload. For live
   accuracy work, the explicit [model-switch forecast probe](../scripts/cachemire/README.md)
   captures sanitized component counts and exact usage without prompt content.
-- **Retention evidence**: `retention-evidence.test.ts` is the route, model and outgoing
-  request-policy matrix. Anthropic uses an observed 5-minute or 1-hour TTL and may infer
-  it from `PI_CACHE_RETENTION` after restore. GPT-5.6 and later GPT-5 models use the
-  documented 30-minute minimum on OpenAI and OpenAI Codex. A direct official OpenAI
-  GPT-5 request below GPT-5.6 gets a 24-hour maximum only when its outgoing payload
-  contains `prompt_cache_retention: "24h"`. Direct OpenAI without that field,
-  `in_memory`, and other routes stay unknown. Unknown retention never becomes warm or
-  cold from elapsed time. The tests make no 5-minute to 1-hour band, replica-identity
-  or 512-token-arithmetic claim.
-  `pi-cache-retention-seams.test.ts` fails when installed Pi request shapes drift.
+- **Retention evidence**: `retention.ts` drives runtime resolution and generated policy
+  docs. `retention-evidence.test.ts` pins routes and boundaries; clock tests pin visible
+  wording; `pi-cache-retention-seams.test.ts` covers installed Pi routes. `npm run lint`
+  rejects stale generated blocks.
 - **Restored freshness**: persisted lineage uses the parent entry timestamp as its
-  request anchor and response time only as fallback. Restored Anthropic sessions may
-  use that anchor with their inferred TTL. Restored GPT-5.6 models keep their documented
-  minimum. Legacy OpenAI retention stays unknown because the outgoing policy was not
-  persisted.
+  request anchor and response time only as fallback. Model-level registry policies can
+  resolve after restore; request-only evidence stays unknown because the outgoing payload
+  was not persisted.
 
 ### meantime
 

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -18,20 +18,18 @@ Cachemire stays hidden while the cache is healthy or its retention is unknown. I
 appears above the input box only at a supported retention boundary, or when a change
 such as compaction or a model switch puts the next send at risk.
 
-For Anthropic, Cachemire reads the 5-minute or 1-hour TTL from the outgoing
-`cache_control`. A 5-minute cache appears during its final minute. A 1-hour cache appears
-during its final 5 minutes. A restored Anthropic session may infer this value from
-`PI_CACHE_RETENTION` until the next live payload arrives.
+<!-- BEGIN GENERATED CACHE RETENTION: policy-table -->
+| Route | Retention evidence | Cachemire behaviour | Evidence source |
+|---|---|---|---|
+| Anthropic, live request | `cache_control` contains a 5m or 1h TTL | use the observed TTL | [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), Installed Pi request builders and model records |
+| Anthropic, restored session | Pi resolves ordinary calls from `PI_CACHE_RETENTION` | infer 5m, or 1h when set to `long`, until a live payload replaces it | Installed Pi request builders and model records |
+| OpenAI or OpenAI Codex, GPT-5.6 and later GPT-5 models | documented `prompt_cache_options.ttl` default | use a 30m minimum; after it ends, show that the cache state is unknown | [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching), Installed Pi request builders and model records |
+| Direct official OpenAI API, GPT-5 below GPT-5.6 | outgoing payload contains `prompt_cache_retention: "24h"` | record a 24h maximum, with no warmth claim before it | [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching), Installed Pi request builders and model records |
+<!-- END GENERATED CACHE RETENTION: policy-table -->
 
-GPT-5.6 and later GPT-5 models have a documented 30-minute minimum on OpenAI and
-OpenAI Codex. Cachemire stays silent during that minimum. When it ends, Cachemire says
-the cache state is unknown because OpenAI may retain the prefix longer.
-
-A direct official OpenAI GPT-5 request below GPT-5.6 gets a 24-hour maximum only when
-its outgoing payload contains `prompt_cache_retention: "24h"`. Cachemire stays silent
-before that maximum and marks the cache stale when it is reached. Direct OpenAI requests
-without that field and other routes have unknown retention. Cachemire does not support
-`in_memory` or a 5-minute to 1-hour OpenAI window.
+The table is generated from Cachemire's runtime policy registry. A minimum is not an
+expiry, and unknown retention never earns an elapsed-time claim. Cachemire does not use
+`in_memory` or an undocumented 5-minute to 1-hour OpenAI band as retention evidence.
 
 The `~` re-write count starts from the prior billed prompt-side usage. It is not the
 whole next prompt, which adds your new message and other suffix content. After a model
@@ -40,13 +38,15 @@ At send time, it sizes recognized system, tool and message fields from the provi
 payload it observes. Gateway estimates stay rough because an upstream rewrite can still
 change them.
 
-```
-◍ cache expires in 58s · next send may re-write ~138.2k (~$2.59)
+<!-- BEGIN GENERATED CACHE RETENTION: clock-examples -->
+```text
+◍ cache expires in 30s · next send may re-write ~109.8k (~$1.37)
 ◍ cache state unknown · 30m retention minimum reached · next send may re-send ~109.8k uncached (~$1.37)
 ◍ cache stale · 24h retention maximum reached · next send may re-send ~109.8k uncached (~$1.37)
-◍ cache stale · TTL expired · next send may re-write ~142.3k (~$2.67)
+◍ cache stale · TTL expired · next send may re-write ~109.8k (~$1.37)
 ◍ cache stale after compaction · next send may re-write changed history
 ```
+<!-- END GENERATED CACHE RETENTION: clock-examples -->
 
 ## Find out why the cache broke
 
@@ -157,15 +157,12 @@ Cachemire follows these rules:
   Forensic causes come from observed payload diffs. Cachemire does not infer them.
 - Everything Cachemire draws is UI-only. It does not enter LLM context, session
   entries or exports.
-- Freshness wording reflects supported evidence. An Anthropic TTL gets a countdown.
-  GPT-5.6 and later GPT-5 models get a 30-minute minimum. An observed 24-hour OpenAI
-  maximum gets a stale state once reached. Other unknown retention stays silent. Under
-  subscription auth, Cachemire marks savings as notional.
+- Freshness wording follows the generated policy table above. Unknown retention stays
+  silent. Under subscription auth, Cachemire marks savings as notional.
 - Sessions restored with `--continue` rebuild the active ledger and all-branch cache
   baselines from session usage. Cachemire marks restored rows and excludes them from
-  savings because their pricing context is unknown. The GPT-5.6 model default and the
-  Anthropic `PI_CACHE_RETENTION` inference survive restore. Payload fingerprints and
-  observed legacy OpenAI retention fields do not.
+  savings because their pricing context is unknown. Model-level policies resolve through
+  the same registry; request-only payload evidence does not survive restore.
 
 ## Understand the model behind the wording
 
@@ -175,15 +172,14 @@ Cachemire uses 4 rules:
 - **Scope** ties a cache entry to the provider, model, wire API and byte-exact prefix.
   Switch-back warmth needs exact identity and an active TTL or minimum. Unknown
   retention waits for billed usage.
-- **Retention** shows an Anthropic countdown, the end of the GPT-5.6 30-minute minimum,
-  or a reached observed 24-hour OpenAI maximum. It makes no elapsed-time claim for
+- **Retention** follows the generated policy table. It makes no elapsed-time claim for
   unknown routes.
 - **Currency** keeps exact tokens and cost in the tokenizer and price card that billed
   them. Cross-model sizes are labelled estimates in the target currency. A prior billed
   prompt count is a baseline, not the whole next prompt.
 
-Read [`docs/pi-cachemire.md`](../../docs/pi-cachemire.md) for the evidence table, clock
-and aborted-send semantics, cause limits and lifecycle trade-offs.
+Read the [retention audit](../../docs/cache-retention-audit-2026-08-04.md) for policy
+evidence and [`docs/pi-cachemire.md`](../../docs/pi-cachemire.md) for lifecycle semantics.
 
 ## Compare Cachemire with the other extensions
 

--- a/extensions/pi-cachemire/clock.ts
+++ b/extensions/pi-cachemire/clock.ts
@@ -1,8 +1,3 @@
-// The cache clock: pure freshness state → widget text (design language §6). Tones are
-// applied by the widget layer in index.ts; everything here is deterministic wording so
-// the golden suite can pin the exact strings. Split from index.ts to keep each file
-// inside its agent context budget.
-
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import type { SwitchForecast } from "./forecast.ts";
 import type { CacheWindow } from "./types.ts";

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -84,8 +84,6 @@ export type {
  * the exact counts on hand are old-model currency, so the prompt is forecast in the
  * target tokenizer and marked est (issue #57). Display is UI-only: nothing cachemire
  * renders enters LLM context, session entries, or exports.
- * Anthropic's observed 5m/1h TTLs get countdowns. GPT-5.6+ gets its documented
- * 30m minimum; an observed legacy OpenAI 24h maximum appears only when reached.
  */
 
 const DEFAULT_CONFIG: CachemireConfig = {
@@ -557,20 +555,17 @@ export default function piCachemire(pi: ExtensionAPI): void {
       s.pendingPreviousWindow = s.window;
     }
     s.pendingCacheGapMs = s.lastRequestAt !== undefined ? requestAt - s.lastRequestAt : undefined;
+    s.pendingRequestWindow = windowForRequest({
+      provider: ctx.model?.provider,
+      model: ctx.model?.id ?? s.pendingFingerprint.model,
+      fingerprint: s.pendingFingerprint,
+      payload: event.payload,
+    }) ?? UNKNOWN_WINDOW;
     if (s.pendingFingerprint.kind === "anthropic" && ctx.model?.provider === "anthropic") {
-      s.pendingRequestWindow = s.pendingFingerprint.ttlMs !== undefined
-        ? { kind: "contract", ttlMs: s.pendingFingerprint.ttlMs, source: "observed" }
-        : UNKNOWN_WINDOW;
       s.providerLabel = "anthropic";
     } else if (s.pendingFingerprint.kind === "openai-responses") {
-      s.pendingRequestWindow = windowForRequest(
-        ctx.model?.provider,
-        ctx.model?.id ?? s.pendingFingerprint.model,
-        event.payload,
-      ) ?? UNKNOWN_WINDOW;
       s.providerLabel = ctx.model?.provider ?? "openai";
     } else {
-      s.pendingRequestWindow = UNKNOWN_WINDOW;
       s.providerLabel = ctx.model?.provider;
     }
     s.pendingRequestAt = requestAt;

--- a/extensions/pi-cachemire/retention.ts
+++ b/extensions/pi-cachemire/retention.ts
@@ -1,7 +1,7 @@
 import { isJsonObject } from "../_lib/boundary.ts";
 import { formatDuration } from "../_lib/fmt.ts";
 import { TTL_LONG_MS, TTL_SHORT_MS } from "./classify.ts";
-import type { CacheWindow } from "./types.ts";
+import type { CacheWindow, RequestFingerprint } from "./types.ts";
 
 export function inferAnthropicTtlMs(
   env: Record<string, string | undefined> = process.env,
@@ -10,16 +10,63 @@ export function inferAnthropicTtlMs(
 }
 
 const OPENAI_MINIMUM_MINOR = 6;
+const OPENAI_EXTENDED_VALUE = "24h";
 
-export const OPENAI_MINIMUM_WINDOW: CacheWindow = {
+export const OPENAI_MINIMUM_WINDOW = {
   kind: "minimum",
   minMs: 30 * 60 * 1000,
-};
+} as const satisfies CacheWindow;
 
-export const OPENAI_EXTENDED_WINDOW: CacheWindow = {
+export const OPENAI_EXTENDED_WINDOW = {
   kind: "maximum",
   maxMs: 24 * 60 * 60 * 1000,
-};
+} as const satisfies CacheWindow;
+
+export const RETENTION_EVIDENCE_SOURCES = {
+  "openai-docs": {
+    label: "OpenAI prompt caching",
+    url: "https://developers.openai.com/api/docs/guides/prompt-caching",
+    reviewedOn: "5 August 2026",
+    detail: `GPT-5.${OPENAI_MINIMUM_MINOR} minimum eligibility and legacy extended retention`,
+  },
+  "anthropic-docs": {
+    label: "Anthropic prompt caching",
+    url: "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
+    reviewedOn: "4 August 2026",
+    detail: "ephemeral cache TTL contracts",
+  },
+  "installed-pi": {
+    label: "Installed Pi request builders and model records",
+    url: undefined,
+    reviewedOn: "5 August 2026",
+    detail: "`pi-ai/dist/api/openai-responses.js`, `openai-codex-responses.js`, " +
+      "`anthropic-messages.js` and the OpenAI model records",
+  },
+} as const;
+
+type RetentionEvidenceSourceId = keyof typeof RETENTION_EVIDENCE_SOURCES;
+
+interface ModelRetentionEvidence {
+  provider?: string;
+  model?: string;
+  env: Record<string, string | undefined>;
+}
+
+interface RequestRetentionEvidence {
+  provider?: string;
+  model?: string;
+  fingerprint: Pick<RequestFingerprint, "kind" | "ttlMs">;
+  payload: unknown;
+}
+
+interface RetentionPolicy {
+  route: string;
+  evidence: string;
+  behavior: string;
+  sourceIds: readonly RetentionEvidenceSourceId[];
+  resolveModel?: (input: ModelRetentionEvidence) => CacheWindow | undefined;
+  resolveRequest?: (input: RequestRetentionEvidence) => CacheWindow | undefined;
+}
 
 function gpt5Minor(model: string | undefined): number | undefined {
   const id = (model ?? "").toLowerCase().split("/").at(-1) ?? "";
@@ -34,27 +81,80 @@ function usesMinimumRetention(provider: string | undefined, model: string | unde
     minor !== undefined && minor >= OPENAI_MINIMUM_MINOR;
 }
 
+export const RETENTION_POLICIES: readonly RetentionPolicy[] = [
+  {
+    route: "Anthropic, live request",
+    evidence: `\`cache_control\` contains a ${formatDuration(TTL_SHORT_MS)} or ` +
+      `${formatDuration(TTL_LONG_MS)} TTL`,
+    behavior: "use the observed TTL",
+    sourceIds: ["anthropic-docs", "installed-pi"],
+    resolveRequest: ({ provider, fingerprint }) =>
+      provider === "anthropic" && fingerprint.kind === "anthropic" && fingerprint.ttlMs !== undefined
+        ? { kind: "contract", ttlMs: fingerprint.ttlMs, source: "observed" }
+        : undefined,
+  },
+  {
+    route: "Anthropic, restored session",
+    evidence: "Pi resolves ordinary calls from `PI_CACHE_RETENTION`",
+    behavior: `infer ${formatDuration(TTL_SHORT_MS)}, or ${formatDuration(TTL_LONG_MS)} when set to ` +
+      "`long`, until a live payload replaces it",
+    sourceIds: ["installed-pi"],
+    resolveModel: ({ provider, env }) => provider === "anthropic"
+      ? { kind: "contract", ttlMs: inferAnthropicTtlMs(env), source: "inferred" }
+      : undefined,
+  },
+  {
+    route: `OpenAI or OpenAI Codex, GPT-5.${OPENAI_MINIMUM_MINOR} and later GPT-5 models`,
+    evidence: "documented `prompt_cache_options.ttl` default",
+    behavior: `use a ${formatDuration(OPENAI_MINIMUM_WINDOW.minMs)} minimum; after it ends, ` +
+      "show that the cache state is unknown",
+    sourceIds: ["openai-docs", "installed-pi"],
+    resolveModel: ({ provider, model }) => usesMinimumRetention(provider, model)
+      ? OPENAI_MINIMUM_WINDOW
+      : undefined,
+    resolveRequest: ({ provider, model, fingerprint }) =>
+      fingerprint.kind === "openai-responses" && usesMinimumRetention(provider, model)
+        ? OPENAI_MINIMUM_WINDOW
+        : undefined,
+  },
+  {
+    route: `Direct official OpenAI API, GPT-5 below GPT-5.${OPENAI_MINIMUM_MINOR}`,
+    evidence: `outgoing payload contains \`prompt_cache_retention: "${OPENAI_EXTENDED_VALUE}"\``,
+    behavior: `record a ${formatDuration(OPENAI_EXTENDED_WINDOW.maxMs)} maximum, ` +
+      "with no warmth claim before it",
+    sourceIds: ["openai-docs", "installed-pi"],
+    resolveRequest: ({ provider, model, fingerprint, payload }) => {
+      if (provider !== "openai" || fingerprint.kind !== "openai-responses" || !isJsonObject(payload)) {
+        return undefined;
+      }
+      const minor = gpt5Minor(model);
+      return minor !== undefined && minor < OPENAI_MINIMUM_MINOR &&
+        payload.prompt_cache_retention === OPENAI_EXTENDED_VALUE
+        ? OPENAI_EXTENDED_WINDOW
+        : undefined;
+    },
+  },
+];
+
 export function windowForModel(
   provider: string | undefined,
   model?: string,
+  env: Record<string, string | undefined> = process.env,
 ): CacheWindow | undefined {
-  if (provider === "anthropic") {
-    return { kind: "contract", ttlMs: inferAnthropicTtlMs(), source: "inferred" };
+  const input = { provider, model, env };
+  for (const policy of RETENTION_POLICIES) {
+    const window = policy.resolveModel?.(input);
+    if (window !== undefined) return window;
   }
-  return usesMinimumRetention(provider, model) ? OPENAI_MINIMUM_WINDOW : undefined;
+  return undefined;
 }
 
-export function windowForRequest(
-  provider: string | undefined,
-  model: string | undefined,
-  payload: unknown,
-): CacheWindow | undefined {
-  if (usesMinimumRetention(provider, model)) return OPENAI_MINIMUM_WINDOW;
-  const minor = gpt5Minor(model);
-  if (provider !== "openai" || minor === undefined || minor >= OPENAI_MINIMUM_MINOR || !isJsonObject(payload)) {
-    return undefined;
+export function windowForRequest(input: RequestRetentionEvidence): CacheWindow | undefined {
+  for (const policy of RETENTION_POLICIES) {
+    const window = policy.resolveRequest?.(input);
+    if (window !== undefined) return window;
   }
-  return payload.prompt_cache_retention === "24h" ? OPENAI_EXTENDED_WINDOW : undefined;
+  return undefined;
 }
 
 export function windowLabel(window: CacheWindow): string {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "scripts": {
     "link-pi": "scripts/dev/link-pi-runtime.sh",
     "link-extensions": "scripts/dev/link-extensions.sh",
-    "lint": "node scripts/dev/agent-lint.mjs",
+    "docs:cache": "node scripts/dev/cache-retention-docs.mjs",
+    "docs:cache:check": "node scripts/dev/cache-retention-docs.mjs --check",
+    "lint": "node scripts/dev/agent-lint.mjs && npm run docs:cache:check",
     "lint:agent": "node scripts/dev/agent-lint.mjs",
     "typecheck": "tsc -p tsconfig.json",
     "test": "node --test 'tests/**/*.test.ts'",

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -5,7 +5,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 884,
+      "extensions/pi-cachemire/index.ts": 879,
       "extensions/pi-contextimate/index.ts": 1573,
       "extensions/pi-traceline/index.ts": 1766,
       "tests/contract/pi-internals.test.ts": 432,

--- a/scripts/dev/cache-retention-docs.mjs
+++ b/scripts/dev/cache-retention-docs.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { cacheClock } from "../../extensions/pi-cachemire/clock.ts";
+import {
+  OPENAI_EXTENDED_WINDOW,
+  OPENAI_MINIMUM_WINDOW,
+  RETENTION_EVIDENCE_SOURCES,
+  RETENTION_POLICIES,
+} from "../../extensions/pi-cachemire/retention.ts";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const check = process.argv.includes("--check");
+const MINUTE = 60_000;
+
+function replaceGeneratedBlock(source, kind, body, path) {
+  const start = `<!-- BEGIN GENERATED CACHE RETENTION: ${kind} -->`;
+  const end = `<!-- END GENERATED CACHE RETENTION: ${kind} -->`;
+  const startAt = source.indexOf(start);
+  const endAt = source.indexOf(end);
+  if (startAt === -1 || endAt === -1 || endAt < startAt) {
+    throw new Error(`${path}: missing generated block markers for ${kind}`);
+  }
+  if (source.indexOf(start, startAt + start.length) !== -1 ||
+      source.indexOf(end, endAt + end.length) !== -1) {
+    throw new Error(`${path}: duplicate generated block markers for ${kind}`);
+  }
+  const afterEnd = endAt + end.length;
+  return source.slice(0, startAt) + `${start}\n${body.trim()}\n${end}` + source.slice(afterEnd);
+}
+
+function sourceLink(source) {
+  return source.url === undefined ? source.label : `[${source.label}](${source.url})`;
+}
+
+function markdownCell(value) {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function policyTable() {
+  const rows = RETENTION_POLICIES.map((policy) =>
+    `| ${markdownCell(policy.route)} | ${markdownCell(policy.evidence)} | ` +
+    `${markdownCell(policy.behavior)} | ` +
+    `${markdownCell(policy.sourceIds.map((id) => sourceLink(RETENTION_EVIDENCE_SOURCES[id])).join(", "))} |`
+  );
+  return [
+    "| Route | Retention evidence | Cachemire behaviour | Evidence source |",
+    "|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}
+
+const evidenceSources = Object.values(RETENTION_EVIDENCE_SOURCES)
+  .map((source) => `- ${sourceLink(source)}, reviewed ${source.reviewedOn}: ${source.detail}`)
+  .join("\n");
+
+function renderedClock(input) {
+  const text = cacheClock(input).text;
+  if (text === "") throw new Error("documentation clock fixture rendered no notice");
+  return `◍ ${text}`;
+}
+
+const contract = { kind: "contract", ttlMs: 5 * MINUTE, source: "observed" };
+const common = { lastRequestAt: 0, cachedTokens: 109_800, rewriteUsd: 1.37 };
+const clockExamples = [
+  "```text",
+  renderedClock({ ...common, now: 4.5 * MINUTE, window: contract }),
+  renderedClock({ ...common, now: 30 * MINUTE, window: OPENAI_MINIMUM_WINDOW }),
+  renderedClock({ ...common, now: 24 * 60 * MINUTE, window: OPENAI_EXTENDED_WINDOW }),
+  renderedClock({ ...common, now: 6 * MINUTE, window: contract }),
+  renderedClock({ ...common, now: MINUTE, window: contract, compacted: true }),
+  "```",
+].join("\n");
+
+const targets = [
+  {
+    path: "extensions/pi-cachemire/README.md",
+    blocks: { "policy-table": policyTable(), "clock-examples": clockExamples },
+  },
+  {
+    path: "docs/cache-retention-audit-2026-08-04.md",
+    blocks: { "evidence-sources": evidenceSources, "policy-table": policyTable() },
+  },
+];
+
+const stale = [];
+for (const target of targets) {
+  const path = `${root}/${target.path}`;
+  const before = readFileSync(path, "utf8");
+  let after = before;
+  for (const [kind, body] of Object.entries(target.blocks)) {
+    after = replaceGeneratedBlock(after, kind, body, target.path);
+  }
+  if (after === before) continue;
+  stale.push(target.path);
+  if (!check) writeFileSync(path, after);
+}
+
+if (check && stale.length > 0) {
+  console.error(`cache retention docs are stale: ${stale.join(", ")}`);
+  console.error("run: npm run docs:cache");
+  process.exitCode = 1;
+} else if (!check) {
+  console.log(stale.length === 0 ? "cache retention docs already current" : `updated ${stale.join(", ")}`);
+}

--- a/tests/cachemire/retention-evidence.test.ts
+++ b/tests/cachemire/retention-evidence.test.ts
@@ -1,5 +1,3 @@
-// Provider retention evidence contract. Update this matrix, retention.ts and the dated
-// table in docs/pi-cachemire.md together when provider documentation changes.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -16,50 +14,62 @@ import {
 const MIN = 60_000;
 const CONTRACT_5M = { kind: "contract", ttlMs: 5 * MIN, source: "observed" } as const;
 
-test("retention resolution requires route, model family and observed request policy", (t) => {
-  const configuredRetention = process.env.PI_CACHE_RETENTION;
-  delete process.env.PI_CACHE_RETENTION;
-  t.after(() => {
-    if (configuredRetention === undefined) delete process.env.PI_CACHE_RETENTION;
-    else process.env.PI_CACHE_RETENTION = configuredRetention;
-  });
+function requestWindow(
+  provider: string,
+  model: string | undefined,
+  payload: unknown,
+  fingerprint: { kind: "anthropic" | "openai-responses" | "unknown"; ttlMs?: number } = {
+    kind: "openai-responses",
+  },
+) {
+  return windowForRequest({ provider, model, payload, fingerprint });
+}
 
-  assert.deepEqual(windowForModel("anthropic"), { kind: "contract", ttlMs: 5 * MIN, source: "inferred" });
+test("retention resolution requires route, model family and observed request policy", () => {
+  assert.deepEqual(
+    windowForModel("anthropic", undefined, {}),
+    { kind: "contract", ttlMs: 5 * MIN, source: "inferred" },
+  );
   assert.equal(windowForModel("openai-codex", "gpt-5.6-sol"), OPENAI_MINIMUM_WINDOW);
   assert.equal(windowForModel("openai", "gpt-5.6"), OPENAI_MINIMUM_WINDOW);
   assert.equal(windowForModel("openai", "gpt-5.10"), OPENAI_MINIMUM_WINDOW);
   assert.equal(windowForModel("openai", "gpt-5.5"), undefined);
   assert.equal(windowForModel("mistral", "gpt-5.6"), undefined);
 
+  assert.deepEqual(
+    requestWindow("anthropic", "claude-opus-4-8", {}, { kind: "anthropic", ttlMs: 5 * MIN }),
+    CONTRACT_5M,
+    "live Anthropic evidence resolves through the same registry",
+  );
   assert.equal(
-    windowForRequest("openai", "gpt-5.4", { prompt_cache_retention: "24h" }),
+    requestWindow("radius", "claude-opus-4-8", {}, { kind: "anthropic", ttlMs: 5 * MIN }),
+    undefined,
+    "an Anthropic-shaped gateway payload does not inherit the direct route contract",
+  );
+  assert.equal(
+    requestWindow("openai", "gpt-5.4", { prompt_cache_retention: "24h" }),
     OPENAI_EXTENDED_WINDOW,
   );
-  assert.equal(windowForRequest("openai", "gpt-5.4", {}), undefined, "an omitted policy is unknown");
+  assert.equal(requestWindow("openai", "gpt-5.4", {}), undefined, "an omitted policy is unknown");
   assert.equal(
-    windowForRequest("openai", undefined, { prompt_cache_retention: "24h" }),
+    requestWindow("openai", undefined, { prompt_cache_retention: "24h" }),
     undefined,
     "an unrecognized model cannot inherit a GPT-5 policy",
   );
   assert.equal(
-    windowForRequest("openai", "gpt-5.4", { prompt_cache_retention: "1h" }),
-    undefined,
-    "unsupported policy values are unknown",
-  );
-  assert.equal(
-    windowForRequest("openai", "gpt-5.6", { prompt_cache_retention: "24h" }),
+    requestWindow("openai", "gpt-5.6", { prompt_cache_retention: "24h" }),
     OPENAI_MINIMUM_WINDOW,
     "GPT-5.6 uses the default minimum, not the deprecated maximum policy",
   );
   assert.equal(
-    windowForRequest("openai", "gpt-5-6-sol", { prompt_cache_retention: "24h" }),
-    undefined,
-    "an unrecognized alias fails closed",
-  );
-  assert.equal(
-    windowForRequest("openai-codex", "gpt-5.6-sol", {}),
+    requestWindow("openai-codex", "gpt-5.6-sol", {}),
     OPENAI_MINIMUM_WINDOW,
     "the documented GPT-5.6 default also applies through Codex",
+  );
+  assert.equal(
+    requestWindow("openai-codex", "gpt-5.6-sol", {}, { kind: "unknown" }),
+    undefined,
+    "the documented route still requires the matching request shape on a live send",
   );
 });
 


### PR DESCRIPTION
## Summary

- make `RETENTION_POLICIES` the typed source for route matching, runtime windows, evidence metadata and documentation rows
- route live Anthropic, restored Anthropic and OpenAI retention resolution through that registry
- generate the README and audit policy tables from the registry
- generate README clock examples through the existing `cacheClock` path used by the widget
- remove duplicate policy tables and clock examples from the engineering guide
- make `npm run lint` reject stale generated blocks

Clock wording remains directly in `clock.ts`; this adds no parallel notice model or renderer.

## Stack

Depends on #75, which establishes the corrected GPT-5.6 minimum semantics encoded by this registry.

## Testing

- `npm run check` (319 tests)
- verified `docs:cache:check` fails after a deliberate generated-block mutation
- verified `docs:cache:check` runs without linked Pi packages

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
