### PR TITLE
fix(cachemire): normalize gateway cache reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Cachemire: recover Moonshot and Together cache reads.** A provider overlay
+  normalizes top-level `usage.cached_tokens` before Pi accounts for the response.
 - **Cachemire: keep model-switch forecasts stable through send.** Outgoing payloads
   still provide cache evidence, while provider usage supplies the exact result.
 - **Traceline: show silent `gh pr merge` outcomes.** A successful terminal merge

--- a/docs/cache-provider-stocktake-2026-08-05.md
+++ b/docs/cache-provider-stocktake-2026-08-05.md
@@ -66,12 +66,10 @@ Cachemire therefore reports outcomes for many non-Anthropic and non-OpenAI route
 retention registry covers direct Anthropic and OpenAI, MiniMax M2.7, documented Bedrock
 Claude 4.5 and 4.6 models, Groq GPT-OSS, and supported Cerebras models.
 
-Two normalization gaps remain:
-
-- Moonshot uses top-level `usage.cached_tokens`, which Pi's OpenAI Completions adapter
-  does not read
-- Together can use either `usage.prompt_tokens_details.cached_tokens` or top-level
-  `usage.cached_tokens`; only the first shape reaches Cachemire
+Pi ignores top-level `usage.cached_tokens`, used by Moonshot and some Together
+responses. Cachemire overlays those providers and copies the count into Pi's supported
+nested field when no native cache-read field exists. Existing custom streams win, and
+the overlay is removed on shutdown or reload.
 
 Pricing and a non-zero cached-token count prove a read. They do not prove retention,
 eviction cause, replica identity or future warmth.
@@ -101,8 +99,8 @@ evidence.
 | `minimax` | 3 | Anthropic Messages | MiniMax M2.7, M2.7 highspeed and M3 | 5-minute clock for M2.7 models; usage only for M3 |
 | `minimax-cn` | 3 | Anthropic Messages | MiniMax M2.7, M2.7 highspeed and M3 | 5-minute clock for M2.7 models; usage only for M3 |
 | `mistral` | 30 | Mistral Conversations | Codestral, Devstral, Magistral, Ministral, Mistral, Mixtral and Pixtral | Pi can read returned cache usage, but Mistral publishes no hosted cache contract |
-| `moonshotai` | 10 | OpenAI Completions | Kimi K2 and K3 families | automatic cache, 256-token minimum, unknown lifetime; Pi usage gap |
-| `moonshotai-cn` | 10 | OpenAI Completions | Kimi K2 and K3 families | automatic cache, 256-token minimum, unknown lifetime; Pi usage gap |
+| `moonshotai` | 10 | OpenAI Completions | Kimi K2 and K3 families | observed usage through Cachemire's response shim; automatic cache, 256-token minimum, unknown lifetime |
+| `moonshotai-cn` | 10 | OpenAI Completions | Kimi K2 and K3 families | observed usage through Cachemire's response shim; automatic cache, 256-token minimum, unknown lifetime |
 | `nvidia` | 30 | OpenAI Completions | routed models from 11 vendors | no managed NIM cache contract |
 | `openai` | 38 | OpenAI Responses | GPT-4, GPT-5 and o-series | current 30-minute minimum for GPT-5.6 and later GPT-5 families; current 24-hour maximum for an observed supported pre-GPT-5.6 request |
 | `openai-codex` | 7 | Codex Responses | GPT-5 Codex and GPT-5.6 variants | current 30-minute minimum for GPT-5.6 variants; no backend-specific maximum |
@@ -111,7 +109,7 @@ evidence.
 | `openrouter` | 303 | OpenAI Completions | routed models from more than 30 vendors | explicit Anthropic policy candidate with gateway caveat; usage only otherwise |
 | `qwen-token-plan` | 15 | OpenAI Completions | Qwen, DeepSeek, Kimi, MiniMax and GLM | no Token Plan cache contract |
 | `qwen-token-plan-cn` | 15 | OpenAI Completions | Qwen, DeepSeek, Kimi, MiniMax and GLM | no Token Plan cache contract |
-| `together` | 17 | OpenAI Completions | routed models from 10 vendors | usage only; no retention window; partial Pi usage gap |
+| `together` | 17 | OpenAI Completions | routed models from 10 vendors | observed usage through native fields or Cachemire's response shim; no retention window |
 | `vercel-ai-gateway` | 193 | Anthropic Messages | routed models from more than 20 vendors | upstream policy and provider can vary |
 | `xai` | 3 | OpenAI Completions and Responses | Grok 4.3, 4.5 and Build | usage only; entries can be evicted at any time |
 | `xiaomi` | 6 | OpenAI Completions | MiMo V2, V2.5 and Pro variants | usage and pricing only; no public lifetime |

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -17,6 +17,15 @@ The wider provider inventory and implementation record are in
 Cachemire keeps an observed request policy pending until reported cache reads or writes
 confirm that an entry exists.
 
+## Moonshot and Together usage
+
+Moonshot and some Together responses report cache reads in top-level
+`usage.cached_tokens`, which Pi 0.83 does not read. Cachemire overlays `streamSimple` for
+those built-in providers and copies that value into Pi's supported nested field when no
+native cache-read field exists. It leaves custom streams alone and restores prior
+provider config on shutdown or reload. Corrected usage does not provide retention
+evidence.
+
 ## Four rules shape the UI
 
 1. Evidence: Cachemire distinguishes a TTL, a minimum, a maximum and unknown retention.
@@ -162,8 +171,9 @@ an old-model count as the denominator.
 
 ## State stays UI-only
 
-Working state lives in the extension process. Cachemire writes nothing to session
-entries or exports.
+Working state and rendered output live in the extension process. Cachemire adds no custom
+session entries or exports. Corrected Moonshot and Together counts become ordinary Pi
+assistant usage and follow Pi's normal session lifecycle.
 
 On restore, Cachemire rebuilds its ledger and branch baselines from billed usage in
 assistant messages. Payload fingerprints, request-start observations and live retention

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,6 +80,7 @@ it. When `pi update` breaks one, the failure message says exactly which seam mov
 | A collapsed `AssistantMessageComponent` skips empty thinking blocks, emits one label per adjacent thinking run, and keeps native spacers across tool and text boundaries | traceline grouped thinking previews |
 | Two extensions loaded through Pi's real factory loader and `ExtensionRunner` distinguish headless and interactive sessions through `ctx.hasUI`; a headless child cannot write into Cachemire's interactive ledger, while the root still can | cachemire process-global session ownership |
 | Direct OpenAI request payloads can expose `prompt_cache_retention`; Codex OAuth uses a separate backend shape with a cache key but no public API retention field | cachemire route, model and outgoing-policy evidence |
+| OpenAI Completions ignores top-level `usage.cached_tokens`; provider registration and custom fetch remain public extension seams | cachemire Moonshot and Together usage overlay |
 | `ExtensionAPI` exposes `getActiveTools()` ⊆ `getAllTools()` by name; `ToolInfo` has `name`, `description`, `parameters`, `sourceInfo{scope,source,origin,path}`, `promptGuidelines` | contextimate tools section |
 
 Where instantiating real components is impractical, the contract test asserts on the
@@ -175,6 +176,8 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   docs. `retention-evidence.test.ts` pins routes and boundaries; clock tests pin visible
   wording; `pi-cache-retention-seams.test.ts` covers installed Pi routes. `npm run lint`
   rejects stale generated blocks.
+- **Provider response normalization**: tests cover native-field precedence, fragmented
+  SSE, response metadata, provider collisions and cleanup.
 - **Restored freshness**: persisted lineage uses the parent entry timestamp as its
   request anchor and response time only as fallback. Model-level registry policies can
   resolve after restore; request-only evidence stays unknown because the outgoing payload

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -155,10 +155,12 @@ Set `turnSummaryMinCalls` higher if you only want a ledger line for multi-call t
 Cachemire follows these rules:
 
 - Token and cost numbers come from provider-reported usage in assistant messages.
-  The one estimate is the model-switch forecast, which is always labelled `est`.
+  Cachemire normalizes top-level Moonshot and Together cache-read counts before Pi
+  records them.
+- The model-switch forecast is the only estimate and is always labelled `est`.
   Forensic causes come from observed payload diffs. Cachemire does not infer them.
-- Everything Cachemire draws is UI-only. It does not enter LLM context, session
-  entries or exports.
+- Everything Cachemire draws is UI-only and does not enter LLM context. Corrected usage
+  follows Pi's normal session persistence; Cachemire adds no custom session entries.
 - Freshness wording follows the generated policy table above. Unknown retention stays
   silent. Under subscription auth, Cachemire marks savings as notional.
 - Sessions restored with `--continue` rebuild the active ledger and all-branch cache

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -31,6 +31,7 @@ import {
   resolveCacheLineage,
   restoreLineageSnapshots,
 } from "./lineage.ts";
+import { bindProviderUsageOverlays } from "./provider-usage.ts";
 import { renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
 import {
   confirmedWindow,
@@ -226,9 +227,6 @@ function sessionSavings(records: CallRecord[]): { actual: number; uncached: numb
   if (uncached <= 0) return undefined;
   return { actual, uncached, saved: uncached - actual, pct: (1 - actual / uncached) * 100 };
 }
-
-// All number formatting lives in _lib/fmt.ts (family number grammar); the test suite
-// reaches it through this module's internals surface.
 
 // --- ledger lines ----------------------------------------------------------------------
 
@@ -476,6 +474,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
   const s = state();
   const ownerToken = Symbol("pi-cachemire-owner");
   const ownsState = () => g.__piCachemireOwner === ownerToken;
+  bindProviderUsageOverlays(pi);
 
   pi.on("session_start", async (_event, ctx) => {
     if (!ctx.hasUI) return;

--- a/extensions/pi-cachemire/provider-usage.ts
+++ b/extensions/pi-cachemire/provider-usage.ts
@@ -1,0 +1,119 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ProviderConfig,
+} from "@earendil-works/pi-coding-agent";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import type { FetchFunction } from "@earendil-works/pi-ai";
+import { isJsonObject } from "../_lib/boundary.ts";
+
+const PROVIDERS = ["moonshotai", "moonshotai-cn", "together"] as const;
+const openAICompletions = openAICompletionsApi();
+
+type ProviderUsageRegistry = Pick<
+  ExtensionContext["modelRegistry"],
+  "getRegisteredNativeProvider" | "getRegisteredProviderConfig"
+>;
+
+export function normalizeCachedTokenSseLine(line: string): string {
+  const ending = line.endsWith("\r\n") ? "\r\n" : line.endsWith("\n") ? "\n" : "";
+  const body = ending === "" ? line : line.slice(0, -ending.length);
+  const prefix = body.match(/^data:\s*/)?.[0];
+  if (!prefix) return line;
+
+  let frame: unknown;
+  try {
+    frame = JSON.parse(body.slice(prefix.length));
+  } catch {
+    return line;
+  }
+  if (!isJsonObject(frame)) return line;
+
+  const usage = frame.usage;
+  if (!isJsonObject(usage)) return line;
+  const details = usage.prompt_tokens_details;
+  if (details != null && !isJsonObject(details)) return line;
+  if (usage.prompt_cache_hit_tokens != null || details?.cached_tokens != null) return line;
+  const cachedTokens = usage.cached_tokens;
+  if (typeof cachedTokens !== "number" || !Number.isInteger(cachedTokens) || cachedTokens < 0) return line;
+
+  usage.prompt_tokens_details = { ...details, cached_tokens: cachedTokens };
+  return `${prefix}${JSON.stringify(frame)}${ending}`;
+}
+
+function normalizeCachedTokenSse(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let pending = "";
+  return body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller): void {
+      pending += decoder.decode(chunk, { stream: true });
+      let output = "";
+      let newline = pending.indexOf("\n");
+      while (newline !== -1) {
+        output += normalizeCachedTokenSseLine(pending.slice(0, newline + 1));
+        pending = pending.slice(newline + 1);
+        newline = pending.indexOf("\n");
+      }
+      if (output !== "") controller.enqueue(encoder.encode(output));
+    },
+    flush(controller): void {
+      pending += decoder.decode();
+      if (pending !== "") controller.enqueue(encoder.encode(normalizeCachedTokenSseLine(pending)));
+    },
+  }));
+}
+
+export function cachedTokenNormalizingFetch(fetchImpl: FetchFunction): FetchFunction {
+  return async (input, init) => {
+    const response = await fetchImpl(input, init);
+    if (!response.ok || response.body === null) return response;
+
+    const headers = new Headers(response.headers);
+    headers.delete("content-length");
+    return new Response(normalizeCachedTokenSse(response.body), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  };
+}
+
+const normalizedStreamSimple: NonNullable<ProviderConfig["streamSimple"]> = (model, context, options) =>
+  openAICompletions.streamSimple(model, context, {
+    ...options,
+    fetch: cachedTokenNormalizingFetch(options?.fetch ?? globalThis.fetch),
+  });
+
+export function installProviderUsageOverlays(
+  pi: Pick<ExtensionAPI, "registerProvider" | "unregisterProvider">,
+  registry: ProviderUsageRegistry,
+): () => void {
+  const installed: Array<{ provider: typeof PROVIDERS[number]; previous?: ProviderConfig }> = [];
+  for (const provider of PROVIDERS) {
+    if (registry.getRegisteredNativeProvider(provider)) continue;
+    const previous = registry.getRegisteredProviderConfig(provider);
+    if (previous?.streamSimple) continue;
+    pi.registerProvider(provider, {
+      api: "openai-completions",
+      streamSimple: normalizedStreamSimple,
+    });
+    installed.push({ provider, previous });
+  }
+
+  return () => {
+    for (const { provider, previous } of installed) {
+      if (registry.getRegisteredProviderConfig(provider)?.streamSimple !== normalizedStreamSimple) continue;
+      pi.unregisterProvider(provider);
+      if (previous) pi.registerProvider(provider, previous);
+    }
+  };
+}
+
+export function bindProviderUsageOverlays(pi: ExtensionAPI): void {
+  let cleanup: (() => void) | undefined;
+  pi.on("session_start", (_event, ctx) => {
+    cleanup = installProviderUsageOverlays(pi, ctx.modelRegistry);
+  });
+  pi.on("session_shutdown", () => cleanup?.());
+}

--- a/package.json
+++ b/package.json
@@ -42,10 +42,14 @@
     ]
   },
   "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"
   },
   "peerDependenciesMeta": {
+    "@earendil-works/pi-ai": {
+      "optional": true
+    },
     "@earendil-works/pi-coding-agent": {
       "optional": true
     },

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -5,7 +5,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 860,
+      "extensions/pi-cachemire/index.ts": 859,
       "extensions/pi-contextimate/index.ts": 1568,
       "extensions/pi-traceline/index.ts": 1766,
       "tests/contract/pi-internals.test.ts": 432,

--- a/tests/cachemire/model-switch-events.test.ts
+++ b/tests/cachemire/model-switch-events.test.ts
@@ -20,6 +20,8 @@ function extensionProbe(): { handlers: Map<string, Handler[]> } {
       handlers.set(event, [...(handlers.get(event) ?? []), handler]);
     },
     registerCommand(): void {},
+    registerProvider(): void {},
+    unregisterProvider(): void {},
     getThinkingLevel: () => "off",
     getActiveTools: () => [],
     getAllTools: () => [],
@@ -60,6 +62,10 @@ function probeContext(entries: unknown[], api: string, notifications: string[], 
     model: {
       id: "claude-opus-4-8", provider: "anthropic", api, reasoning: false, contextWindow: 200_000,
       cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+    },
+    modelRegistry: {
+      getRegisteredNativeProvider: () => undefined,
+      getRegisteredProviderConfig: () => undefined,
     },
     sessionManager: {
       getEntries: () => entries,

--- a/tests/cachemire/provider-usage.test.ts
+++ b/tests/cachemire/provider-usage.test.ts
@@ -1,0 +1,158 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ExtensionAPI, ProviderConfig } from "@earendil-works/pi-coding-agent";
+import type { Context, FetchFunction, Model } from "@earendil-works/pi-ai";
+
+import {
+  cachedTokenNormalizingFetch,
+  installProviderUsageOverlays,
+  normalizeCachedTokenSseLine,
+} from "../../extensions/pi-cachemire/provider-usage.ts";
+
+const MODEL: Model<"openai-completions"> = {
+  id: "fixture-model",
+  name: "Fixture model",
+  api: "openai-completions",
+  provider: "together",
+  baseUrl: "https://api.together.xyz/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 12 },
+  contextWindow: 128_000,
+  maxTokens: 1_000,
+};
+
+const CONTEXT: Context = {
+  messages: [{ role: "user", content: "Reply with OK", timestamp: 1 }],
+};
+
+const CUSTOM_STREAM = (() => {
+  throw new Error("not called");
+}) as NonNullable<ProviderConfig["streamSimple"]>;
+
+function providerHarness(initial: Iterable<readonly [string, ProviderConfig]> = []) {
+  const registrations: string[] = [];
+  const registered = new Map(initial);
+  const pi = {
+    registerProvider(provider: string, config: ProviderConfig): void {
+      registrations.push(provider);
+      registered.set(provider, { ...registered.get(provider), ...config });
+    },
+    unregisterProvider(provider: string): void {
+      registered.delete(provider);
+    },
+  } as Pick<ExtensionAPI, "registerProvider" | "unregisterProvider">;
+  return {
+    pi,
+    registrations,
+    registered,
+    registry: {
+      getRegisteredNativeProvider: (_provider: string) => undefined,
+      getRegisteredProviderConfig: (provider: string) => registered.get(provider),
+    },
+  };
+}
+
+test("does not override Pi-supported cache fields", () => {
+  for (const line of [
+    'data: {"usage":{"cached_tokens":40,"prompt_tokens_details":{"cached_tokens":0}}}\n',
+    'data: {"usage":{"cached_tokens":40,"prompt_cache_hit_tokens":0}}\n',
+  ]) assert.equal(normalizeCachedTokenSseLine(line), line);
+});
+
+test("streams fragmented UTF-8 and CRLF while preserving response metadata", async () => {
+  const source = [
+    'data: {"choices":[{"delta":{"content":"café"}}]}\r\n\r\n',
+    'data: {"usage":{"prompt_tokens":100,"completion_tokens":5,"cached_tokens":40}}\r\n\r\n',
+    "data: [DONE]\r\n\r\n",
+  ].join("");
+  const bytes = new TextEncoder().encode(source);
+  const ends = [7, bytes.indexOf(0xc3) + 1, bytes.indexOf(0x0d) + 1, bytes.length];
+  const body = new ReadableStream<Uint8Array>({
+    start(controller): void {
+      let start = 0;
+      for (const end of ends) {
+        controller.enqueue(bytes.slice(start, end));
+        start = end;
+      }
+      controller.close();
+    },
+  });
+  const wrapped = cachedTokenNormalizingFetch(async () => new Response(body, {
+    status: 200,
+    statusText: "OK",
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "content-length": String(bytes.length),
+      "x-cachemire-test": "preserved",
+    },
+  }));
+
+  const response = await wrapped("https://example.test");
+  assert.equal(response.statusText, "OK");
+  assert.equal(response.headers.get("x-cachemire-test"), "preserved");
+  assert.equal(response.headers.get("content-length"), null);
+  const text = await response.text();
+  assert.match(text, /café/);
+  assert.match(text, /"prompt_tokens_details":\{"cached_tokens":40\}/);
+  assert.match(text, /\r\n\r\ndata: \[DONE\]\r\n\r\n$/);
+});
+
+test("leaves failed responses untouched", async () => {
+  const response = new Response("failed", { status: 500 });
+  assert.equal(await cachedTokenNormalizingFetch(async () => response)("https://example.test"), response);
+});
+
+test("feeds normalized usage through Pi's accounting", async () => {
+  const harness = providerHarness();
+  const cleanup = installProviderUsageOverlays(harness.pi, harness.registry);
+  const streamSimple = harness.registered.get("together")?.streamSimple;
+  assert.ok(streamSimple);
+  const chunk = {
+    id: "chatcmpl-cachemire",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: MODEL.id,
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    usage: { prompt_tokens: 100, completion_tokens: 5, cached_tokens: 40 },
+  };
+  const fetch: FetchFunction = async () => new Response(
+    `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`,
+    { headers: { "content-type": "text/event-stream" } },
+  );
+  const result = await streamSimple(MODEL, CONTEXT, { apiKey: "test", fetch }).result();
+  assert.equal(result.usage.input, 60);
+  assert.equal(result.usage.cacheRead, 40);
+  assert.equal(result.usage.output, 5);
+  assert.equal(result.usage.totalTokens, 105);
+  assert.ok(Math.abs(result.usage.cost.total - 0.00074) < 1e-12);
+  cleanup();
+});
+
+test("registers the intended providers and respects existing provider streams", () => {
+  const all = providerHarness();
+  const cleanup = installProviderUsageOverlays(all.pi, all.registry);
+  assert.deepEqual(all.registrations, ["moonshotai", "moonshotai-cn", "together"]);
+  cleanup();
+  assert.equal(all.registered.size, 0);
+
+  const previous: ProviderConfig = { name: "Moonshot config" };
+  const collisions = providerHarness([
+    ["moonshotai", previous],
+    ["together", { streamSimple: CUSTOM_STREAM }],
+  ]);
+  collisions.registry.getRegisteredNativeProvider = (provider) => provider === "moonshotai-cn" ? ({} as never) : undefined;
+  const restore = installProviderUsageOverlays(collisions.pi, collisions.registry);
+  assert.deepEqual(collisions.registrations, ["moonshotai"]);
+  restore();
+  assert.deepEqual(collisions.registered.get("moonshotai"), previous);
+  assert.equal(collisions.registered.get("together")?.streamSimple, CUSTOM_STREAM);
+});
+
+test("does not remove a provider stream installed after its own", () => {
+  const harness = providerHarness();
+  const cleanup = installProviderUsageOverlays(harness.pi, harness.registry);
+  harness.registered.set("together", { streamSimple: CUSTOM_STREAM });
+  cleanup();
+  assert.equal(harness.registered.get("together")?.streamSimple, CUSTOM_STREAM);
+});

--- a/tests/cachemire/session-isolation.test.ts
+++ b/tests/cachemire/session-isolation.test.ts
@@ -16,6 +16,8 @@ function extensionProbe(): { pi: ExtensionAPI; handlers: Map<string, Handler[]>;
     registerCommand(name: string, options: { handler: Handler }): void {
       commands.set(name, options.handler);
     },
+    registerProvider(): void {},
+    unregisterProvider(): void {},
     getThinkingLevel(): string {
       return "off";
     },
@@ -45,6 +47,10 @@ function sessionContext(id: string, notifications?: string[]): unknown {
       getSessionId: () => id,
       getEntries: () => [],
       getLeafId: () => undefined,
+    },
+    modelRegistry: {
+      getRegisteredNativeProvider: () => undefined,
+      getRegisteredProviderConfig: () => undefined,
     },
   };
 }

--- a/tests/cachemire/tree-lineage.test.ts
+++ b/tests/cachemire/tree-lineage.test.ts
@@ -28,6 +28,8 @@ function extensionProbe(): { handlers: Map<string, Handler[]>; commands: Map<str
     registerCommand(name: string, options: { handler: Handler }): void {
       commands.set(name, options.handler);
     },
+    registerProvider(): void {},
+    unregisterProvider(): void {},
     getThinkingLevel(): string {
       return "off";
     },
@@ -132,6 +134,10 @@ function context(entries: unknown[], leaf: { id: string }, notifications: string
     sessionManager: {
       getEntries: () => entries,
       getLeafId: () => leaf.id,
+    },
+    modelRegistry: {
+      getRegisteredNativeProvider: () => undefined,
+      getRegisteredProviderConfig: () => undefined,
     },
   };
 }

--- a/tests/contract/cachemire-lifecycle.test.ts
+++ b/tests/contract/cachemire-lifecycle.test.ts
@@ -47,12 +47,18 @@ test("real ExtensionRunner keeps a headless child out of Cachemire's interactive
       runtime,
       "pi-cachemire-contract",
     );
+    const modelRegistry = {
+      registerProvider(): void {},
+      unregisterProvider(): void {},
+      getRegisteredNativeProvider: () => undefined,
+      getRegisteredProviderConfig: () => undefined,
+    };
     const runner = new pi.ExtensionRunner(
       [extension],
       runtime,
       cwd,
       pi.SessionManager.inMemory(cwd),
-      {} as never,
+      modelRegistry as never,
     );
     runner.bindCore(
       { getThinkingLevel: (): "off" => "off" } as never,

--- a/tests/contract/pi-cache-retention-seams.test.ts
+++ b/tests/contract/pi-cache-retention-seams.test.ts
@@ -17,6 +17,15 @@ test("direct OpenAI keeps the legacy retention field", () => {
   assert.match(source("openai-responses.js"), /prompt_cache_retention:/);
 });
 
+test("Cachemire's provider usage overlay still owns a real Pi normalization gap", () => {
+  const completions = source("openai-completions.js");
+  assert.match(
+    completions,
+    /rawUsage\.prompt_tokens_details\?\.cached_tokens \?\? rawUsage\.prompt_cache_hit_tokens/,
+  );
+  assert.doesNotMatch(completions, /rawUsage\.cached_tokens/);
+});
+
 function modelRecord(name: string, api: string, model: string): Record<string, unknown> {
   const raw: unknown = JSON.parse(readFileSync(join(piAiRoot, "providers", "data", name), "utf8"));
   if (!isJsonObject(raw) || !isJsonObject(raw[api]) || !isJsonObject(raw[api][model])) {


### PR DESCRIPTION
## Summary

- normalize Moonshot and Together top-level `usage.cached_tokens` through Pi's public provider overlay
- leave native and custom provider streams untouched, then remove Cachemire's overlays on shutdown or reload
- preserve Pi's SSE framing and standard usage accounting without making retention or warmth claims

## Verification

- `npm run check`
- `npm run test:smoke`
