### PR TITLE
Contextimate: calibrate Kimi, GLM, Cohere and Grok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ scripts/dev/bash-corpus/out/
 .pi/
 *.log
 *.local.md
+__pycache__/
+*.py[cod]
 
 # pi-contextimate local validation artifacts
 .pi-contextimate-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Contextimate adds measured Kimi, GLM, Cohere and Grok text profiles. Exact
+  tokenizer artifacts or xAI token streams define conservative model groups across
+  concrete relay IDs. Dynamic aliases and unverified GLM Turbo variants stay unknown.
+  The manual provider checker now supports Cohere raw text. A separate optional xAI
+  SDK checker fingerprints exact token streams without adding runtime dependencies.
+
 ## 0.10.0 (2026-08-05)
 
 - Cachemire now forecasts model switches in the target model's tokens and prices. It

--- a/docs/contextimate-family-calibration-evidence-2026-08-05.json
+++ b/docs/contextimate-family-calibration-evidence-2026-08-05.json
@@ -1,0 +1,797 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "studyDate": "2026-08-05",
+  "purpose": "Evidence behind Contextimate raw-text tokenizer families and divisors. No source text or credentials.",
+  "openTokenizers": {
+    "corpusVersion": "2026-08-05.1",
+    "corpusRevision": "556dd115a77839773e143afc0d982afa59eb7479",
+    "corpusFiles": {
+      "config-json": [
+        "package.json",
+        "tsconfig.json"
+      ],
+      "instructions-core": [
+        "AGENTS.md",
+        "docs/agent-coding-standard.md"
+      ],
+      "instructions-design": [
+        "docs/design-language.md"
+      ],
+      "session-code": [
+        "extensions/_lib/heuristics.ts",
+        "extensions/_lib/tool-payloads.ts"
+      ],
+      "session-tests": [
+        "tests/contextimate/heuristics.test.ts",
+        "tests/contextimate/provider-check.test.ts"
+      ]
+    },
+    "pythonVersion": "3.12.13",
+    "dependencies": {
+      "huggingface-hub": "1.26.0",
+      "tiktoken": "0.13.0",
+      "tokenizers": "0.22.2"
+    },
+    "profiles": [
+      {
+        "profile": "Kimi",
+        "familyArtifacts": [
+          {
+            "repository": "moonshotai/Kimi-K2.5",
+            "revision": "4d01dfe0332d63057c186e0b262165819efb6611",
+            "sha256": "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103",
+            "patternSha256": "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
+          },
+          {
+            "repository": "moonshotai/Kimi-K2-Instruct",
+            "revision": "fd1984e2b7a3350dbf7305fe73a4ede25c14de50",
+            "sha256": "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103",
+            "patternSha256": "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
+          },
+          {
+            "repository": "moonshotai/Kimi-K2-Instruct-0905",
+            "revision": "ac6c49f04883bd0a0598b790693a72061c676629",
+            "sha256": "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103",
+            "patternSha256": "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
+          },
+          {
+            "repository": "moonshotai/Kimi-K2.6",
+            "revision": "7eb5002f6aadc958aed6a9177b7ed26bb94011bb",
+            "sha256": "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103",
+            "patternSha256": "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
+          },
+          {
+            "repository": "moonshotai/Kimi-K2.7-Code",
+            "revision": "74797c9c62378b951a1f6fcf5c4631024e9b8bef",
+            "sha256": "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103",
+            "patternSha256": "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
+          },
+          {
+            "repository": "moonshotai/Kimi-K3",
+            "revision": "9f62e4e9fffbd0a83ddd60e1c209d828994b3569",
+            "sha256": "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103",
+            "patternSha256": "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
+          }
+        ],
+        "samples": {
+          "config-json": {
+            "chars": 2773,
+            "tokens": 818,
+            "charsPerToken": 3.39
+          },
+          "instructions-core": {
+            "chars": 8097,
+            "tokens": 1827,
+            "charsPerToken": 4.4319
+          },
+          "instructions-design": {
+            "chars": 46622,
+            "tokens": 11600,
+            "charsPerToken": 4.0191
+          },
+          "session-code": {
+            "chars": 15088,
+            "tokens": 3741,
+            "charsPerToken": 4.0331
+          },
+          "session-tests": {
+            "chars": 18502,
+            "tokens": 5035,
+            "charsPerToken": 3.6747
+          }
+        },
+        "text": {
+          "chars": 54719,
+          "tokens": 13427,
+          "charsPerToken": 4.0753,
+          "recommendedDenominator": 4.1
+        },
+        "session": {
+          "chars": 33590,
+          "tokens": 8776,
+          "charsPerToken": 3.8275,
+          "recommendedDenominator": 3.8
+        },
+        "configurationSha256": "12fcab43d2b6068f46769f5ff373960bf7c17a94d7abbc50e2491306b2f6cf58"
+      },
+      {
+        "profile": "GLM 4.5",
+        "familyArtifacts": [
+          {
+            "repository": "zai-org/GLM-4.5",
+            "revision": "cbb2c7cfb52fa128a9660cb1a7a78e017899e115",
+            "sha256": "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+          },
+          {
+            "repository": "zai-org/GLM-4.5-Air",
+            "revision": "a24ceef6ce4f3536971efe9b778bdaa1bab18daa",
+            "sha256": "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+          },
+          {
+            "repository": "zai-org/GLM-4.5V",
+            "revision": "ed47433b37111465ec527affaaddceff371bca04",
+            "sha256": "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+          },
+          {
+            "repository": "zai-org/GLM-4.6",
+            "revision": "be72194883d968d7923a07e2f61681ea9a2826d1",
+            "sha256": "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+          },
+          {
+            "repository": "zai-org/GLM-4.6V",
+            "revision": "4e2d47eb0b41c5280d8294b17cef9e94fdcfff46",
+            "sha256": "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+          },
+          {
+            "repository": "zai-org/GLM-4.6V-Flash",
+            "revision": "411bb4d77144a3f03accbf4b780f5acb8b7cde4e",
+            "sha256": "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+          },
+          {
+            "repository": "zai-org/GLM-4.7",
+            "revision": "602d01efcdd332c5238ca4bcede555defbe83eb7",
+            "sha256": "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+          }
+        ],
+        "samples": {
+          "config-json": {
+            "chars": 2773,
+            "tokens": 813,
+            "charsPerToken": 3.4108
+          },
+          "instructions-core": {
+            "chars": 8097,
+            "tokens": 1847,
+            "charsPerToken": 4.3839
+          },
+          "instructions-design": {
+            "chars": 46622,
+            "tokens": 11681,
+            "charsPerToken": 3.9913
+          },
+          "session-code": {
+            "chars": 15088,
+            "tokens": 3704,
+            "charsPerToken": 4.0734
+          },
+          "session-tests": {
+            "chars": 18502,
+            "tokens": 5007,
+            "charsPerToken": 3.6952
+          }
+        },
+        "text": {
+          "chars": 54719,
+          "tokens": 13528,
+          "charsPerToken": 4.0449,
+          "recommendedDenominator": 4.0
+        },
+        "session": {
+          "chars": 33590,
+          "tokens": 8711,
+          "charsPerToken": 3.856,
+          "recommendedDenominator": 3.9
+        }
+      },
+      {
+        "profile": "GLM 5",
+        "familyArtifacts": [
+          {
+            "repository": "zai-org/GLM-5",
+            "revision": "4e6698ba8e85059d749020e3c4d2123719f23926",
+            "sha256": "19e773648cb4e65de8660ea6365e10acca112d42a854923df93db4a6f333a82d"
+          },
+          {
+            "repository": "zai-org/GLM-4.7-Flash",
+            "revision": "7dd20894a642a0aa287e9827cb1a1f7f91386b67",
+            "sha256": "19e773648cb4e65de8660ea6365e10acca112d42a854923df93db4a6f333a82d"
+          },
+          {
+            "repository": "zai-org/GLM-5.1",
+            "revision": "26e1bd6e011feb778d25ae34b09b07074139d92d",
+            "sha256": "19e773648cb4e65de8660ea6365e10acca112d42a854923df93db4a6f333a82d"
+          },
+          {
+            "repository": "zai-org/GLM-5.2",
+            "revision": "b4734de4facf877f85769a911abafc5283eab3d9",
+            "sha256": "19e773648cb4e65de8660ea6365e10acca112d42a854923df93db4a6f333a82d"
+          }
+        ],
+        "samples": {
+          "config-json": {
+            "chars": 2773,
+            "tokens": 813,
+            "charsPerToken": 3.4108
+          },
+          "instructions-core": {
+            "chars": 8097,
+            "tokens": 1847,
+            "charsPerToken": 4.3839
+          },
+          "instructions-design": {
+            "chars": 46622,
+            "tokens": 11674,
+            "charsPerToken": 3.9937
+          },
+          "session-code": {
+            "chars": 15088,
+            "tokens": 3704,
+            "charsPerToken": 4.0734
+          },
+          "session-tests": {
+            "chars": 18502,
+            "tokens": 5007,
+            "charsPerToken": 3.6952
+          }
+        },
+        "text": {
+          "chars": 54719,
+          "tokens": 13521,
+          "charsPerToken": 4.047,
+          "recommendedDenominator": 4.0
+        },
+        "session": {
+          "chars": 33590,
+          "tokens": 8711,
+          "charsPerToken": 3.856,
+          "recommendedDenominator": 3.9
+        }
+      },
+      {
+        "profile": "Command R",
+        "familyArtifacts": [
+          {
+            "repository": "mlx-community/c4ai-command-r-08-2024-4bit",
+            "revision": "563c818b2a8358765f78d30156f6e36f93b57110",
+            "sha256": "f7e773a231706a3ee5d05050ff27aa122a19df09ee7dd59eafa906b7487035b9",
+            "coreSha256": "2bcc46184ba3b57d82c76cdeb373c32e65cb570633a7237e1b01c175faf3758e"
+          },
+          {
+            "repository": "mlx-community/c4ai-command-r-plus-08-2024-4bit",
+            "revision": "c1793cf166ecc2e82bca7979d72cc91a95dd4d76",
+            "sha256": "c69a7ea6c0927dfac8c349186ebcf0466a4723c21cbdb2e850cf559f0bee92b8",
+            "coreSha256": "2bcc46184ba3b57d82c76cdeb373c32e65cb570633a7237e1b01c175faf3758e"
+          }
+        ],
+        "samples": {
+          "config-json": {
+            "chars": 2773,
+            "tokens": 872,
+            "charsPerToken": 3.18
+          },
+          "instructions-core": {
+            "chars": 8097,
+            "tokens": 1975,
+            "charsPerToken": 4.0997
+          },
+          "instructions-design": {
+            "chars": 46622,
+            "tokens": 11823,
+            "charsPerToken": 3.9433
+          },
+          "session-code": {
+            "chars": 15088,
+            "tokens": 4117,
+            "charsPerToken": 3.6648
+          },
+          "session-tests": {
+            "chars": 18502,
+            "tokens": 5677,
+            "charsPerToken": 3.2591
+          }
+        },
+        "text": {
+          "chars": 54719,
+          "tokens": 13798,
+          "charsPerToken": 3.9657,
+          "recommendedDenominator": 4.0
+        },
+        "session": {
+          "chars": 33590,
+          "tokens": 9794,
+          "charsPerToken": 3.4297,
+          "recommendedDenominator": 3.4
+        }
+      },
+      {
+        "profile": "North Mini Code",
+        "familyArtifacts": [
+          {
+            "repository": "CohereLabs/North-Mini-Code-1.0",
+            "revision": "d11e61a842617a22dc328552fa5bb86231ee4f37",
+            "sha256": "14bd1c49d7d11874921d324986713df4be21cd06060530c497dacef99919b7a5"
+          }
+        ],
+        "samples": {
+          "config-json": {
+            "chars": 2773,
+            "tokens": 758,
+            "charsPerToken": 3.6583
+          },
+          "instructions-core": {
+            "chars": 8097,
+            "tokens": 1784,
+            "charsPerToken": 4.5387
+          },
+          "instructions-design": {
+            "chars": 46622,
+            "tokens": 11336,
+            "charsPerToken": 4.1127
+          },
+          "session-code": {
+            "chars": 15088,
+            "tokens": 3629,
+            "charsPerToken": 4.1576
+          },
+          "session-tests": {
+            "chars": 18502,
+            "tokens": 4884,
+            "charsPerToken": 3.7883
+          }
+        },
+        "text": {
+          "chars": 54719,
+          "tokens": 13120,
+          "charsPerToken": 4.1707,
+          "recommendedDenominator": 4.2
+        },
+        "session": {
+          "chars": 33590,
+          "tokens": 8513,
+          "charsPerToken": 3.9457,
+          "recommendedDenominator": 3.9
+        }
+      }
+    ]
+  },
+  "xaiTokenStreams": {
+    "corpusVersion": "2026-08-05.1",
+    "corpus": [
+      {
+        "fixture": "ascii",
+        "chars": 88,
+        "sha256": "79fd1b070b589b5db9499a98dae340ced185e78e2b47f2419b804402ebad89a1"
+      },
+      {
+        "fixture": "code",
+        "chars": 124,
+        "sha256": "5da8f986203dfbd14b59efc45a78c7a109886eca950f12f984ccc7bcae852716"
+      },
+      {
+        "fixture": "controls",
+        "chars": 79,
+        "sha256": "114b849424765a0c4cd4553368292231df80afe8c59795f450d009dc7927a7ff"
+      },
+      {
+        "fixture": "multilingual",
+        "chars": 95,
+        "sha256": "f841df94670956da67d24aa6e206b1d87544f852a293ffcebef674c9225832bc"
+      },
+      {
+        "fixture": "random-ascii-4096",
+        "chars": 4096,
+        "sha256": "c29e2f0d06cdddb3482b4a563d0126a876ff73500e8484dba59a4ff32857d86a"
+      },
+      {
+        "fixture": "whitespace",
+        "chars": 65,
+        "sha256": "2adb3fcc987b6a67e58eadd3b4d3c2ab7f3514f8ea7121b442183b0794b26ed4"
+      }
+    ],
+    "contextimateCorpusRevision": null,
+    "pythonVersion": "3.12.13",
+    "xaiSdkVersion": "1.17.0",
+    "models": [
+      {
+        "requestedModel": "grok-4.20-0309-reasoning",
+        "resolvedModels": [
+          "grok-4.20-0309-reasoning"
+        ],
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
+        "samples": [
+          {
+            "fixture": "ascii",
+            "chars": 88,
+            "tokens": 29,
+            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
+          },
+          {
+            "fixture": "code",
+            "chars": 124,
+            "tokens": 38,
+            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
+          },
+          {
+            "fixture": "controls",
+            "chars": 79,
+            "tokens": 29,
+            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
+          },
+          {
+            "fixture": "multilingual",
+            "chars": 95,
+            "tokens": 35,
+            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
+          },
+          {
+            "fixture": "random-ascii-4096",
+            "chars": 4096,
+            "tokens": 2848,
+            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
+          },
+          {
+            "fixture": "whitespace",
+            "chars": 65,
+            "tokens": 25,
+            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
+          }
+        ]
+      },
+      {
+        "requestedModel": "grok-4.20-0309-non-reasoning",
+        "resolvedModels": [
+          "grok-4.20-0309-non-reasoning"
+        ],
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
+        "samples": [
+          {
+            "fixture": "ascii",
+            "chars": 88,
+            "tokens": 29,
+            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
+          },
+          {
+            "fixture": "code",
+            "chars": 124,
+            "tokens": 38,
+            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
+          },
+          {
+            "fixture": "controls",
+            "chars": 79,
+            "tokens": 29,
+            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
+          },
+          {
+            "fixture": "multilingual",
+            "chars": 95,
+            "tokens": 35,
+            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
+          },
+          {
+            "fixture": "random-ascii-4096",
+            "chars": 4096,
+            "tokens": 2848,
+            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
+          },
+          {
+            "fixture": "whitespace",
+            "chars": 65,
+            "tokens": 25,
+            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
+          }
+        ]
+      },
+      {
+        "requestedModel": "grok-4.20-multi-agent",
+        "resolvedModels": [
+          "grok-4.20-multi-agent-0309"
+        ],
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
+        "samples": [
+          {
+            "fixture": "ascii",
+            "chars": 88,
+            "tokens": 29,
+            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
+          },
+          {
+            "fixture": "code",
+            "chars": 124,
+            "tokens": 38,
+            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
+          },
+          {
+            "fixture": "controls",
+            "chars": 79,
+            "tokens": 29,
+            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
+          },
+          {
+            "fixture": "multilingual",
+            "chars": 95,
+            "tokens": 35,
+            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
+          },
+          {
+            "fixture": "random-ascii-4096",
+            "chars": 4096,
+            "tokens": 2848,
+            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
+          },
+          {
+            "fixture": "whitespace",
+            "chars": 65,
+            "tokens": 25,
+            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
+          }
+        ]
+      },
+      {
+        "requestedModel": "grok-4.3",
+        "resolvedModels": [
+          "grok-4.3"
+        ],
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
+        "samples": [
+          {
+            "fixture": "ascii",
+            "chars": 88,
+            "tokens": 29,
+            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
+          },
+          {
+            "fixture": "code",
+            "chars": 124,
+            "tokens": 38,
+            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
+          },
+          {
+            "fixture": "controls",
+            "chars": 79,
+            "tokens": 29,
+            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
+          },
+          {
+            "fixture": "multilingual",
+            "chars": 95,
+            "tokens": 35,
+            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
+          },
+          {
+            "fixture": "random-ascii-4096",
+            "chars": 4096,
+            "tokens": 2848,
+            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
+          },
+          {
+            "fixture": "whitespace",
+            "chars": 65,
+            "tokens": 25,
+            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
+          }
+        ]
+      },
+      {
+        "requestedModel": "grok-build-0.1",
+        "resolvedModels": [
+          "grok-build-0.1"
+        ],
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
+        "samples": [
+          {
+            "fixture": "ascii",
+            "chars": 88,
+            "tokens": 29,
+            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
+          },
+          {
+            "fixture": "code",
+            "chars": 124,
+            "tokens": 38,
+            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
+          },
+          {
+            "fixture": "controls",
+            "chars": 79,
+            "tokens": 29,
+            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
+          },
+          {
+            "fixture": "multilingual",
+            "chars": 95,
+            "tokens": 35,
+            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
+          },
+          {
+            "fixture": "random-ascii-4096",
+            "chars": 4096,
+            "tokens": 2848,
+            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
+          },
+          {
+            "fixture": "whitespace",
+            "chars": 65,
+            "tokens": 25,
+            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
+          }
+        ]
+      },
+      {
+        "requestedModel": "grok-4.5",
+        "resolvedModels": [
+          "grok-4.5"
+        ],
+        "fingerprint": "f892196825e9e0e9cb782d8b18502de6e97c561a034a89ad256f0bb2f3b9a6a3",
+        "samples": [
+          {
+            "fixture": "ascii",
+            "chars": 88,
+            "tokens": 30,
+            "digest": "88fad8485419cd1b4eefbc0b2ac67eeef94d7c9407cf381c1a30615d2cbd3327"
+          },
+          {
+            "fixture": "code",
+            "chars": 124,
+            "tokens": 42,
+            "digest": "54531335be6cb5b4929dceaf023c75b377393e6518a87b6e1ef9633c65b06a8b"
+          },
+          {
+            "fixture": "controls",
+            "chars": 79,
+            "tokens": 33,
+            "digest": "3129d8c045771dbabb08434020960991ef8113fcc53fe685975b4f8ec75f1f83"
+          },
+          {
+            "fixture": "multilingual",
+            "chars": 95,
+            "tokens": 23,
+            "digest": "9a239dd3c922d12a10433dbec56b4bc9cd667b6c26084658e9c27b1b2c164a4d"
+          },
+          {
+            "fixture": "random-ascii-4096",
+            "chars": 4096,
+            "tokens": 3136,
+            "digest": "0360d76b930196e29a61faf2484c3130b691d3c4b63649319bafd59728781b55"
+          },
+          {
+            "fixture": "whitespace",
+            "chars": 65,
+            "tokens": 28,
+            "digest": "1fce01d76aa14a902c4909de7784fffb55dd547121c2ed24f86ff2b2073da2ed"
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
+        "models": [
+          "grok-4.20-0309-reasoning",
+          "grok-4.20-0309-non-reasoning",
+          "grok-4.20-multi-agent",
+          "grok-4.3",
+          "grok-build-0.1"
+        ]
+      },
+      {
+        "fingerprint": "f892196825e9e0e9cb782d8b18502de6e97c561a034a89ad256f0bb2f3b9a6a3",
+        "models": [
+          "grok-4.5"
+        ]
+      }
+    ]
+  },
+  "xaiAliases": [
+    {
+      "requestedModel": "grok-4.20",
+      "resolvedModels": [
+        "grok-4.20-0309-reasoning"
+      ],
+      "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7"
+    },
+    {
+      "requestedModel": "grok-latest",
+      "resolvedModels": [
+        "grok-4.3"
+      ],
+      "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7"
+    },
+    {
+      "requestedModel": "grok-build-latest",
+      "resolvedModels": [
+        "grok-4.5"
+      ],
+      "fingerprint": "f892196825e9e0e9cb782d8b18502de6e97c561a034a89ad256f0bb2f3b9a6a3"
+    }
+  ],
+  "xaiContextimateProfiles": {
+    "corpusRevision": "556dd115a77839773e143afc0d982afa59eb7479",
+    "corpus": [
+      {
+        "fixture": "contextimate:config-json",
+        "chars": 2773,
+        "sha256": "acb1f1523d91d863c98e5f048cf760f9faf3318e6151176bcc33fb2333383e8b"
+      },
+      {
+        "fixture": "contextimate:instructions-core",
+        "chars": 8097,
+        "sha256": "fd175991b2936dbbfbf4bc8dc9511c1802bafd3ef6fb2005dc720829e2e19be7"
+      },
+      {
+        "fixture": "contextimate:instructions-design",
+        "chars": 46622,
+        "sha256": "e73b587f20a5db5eab012898e32f4fc0c3a6f06b1ab9919398d25a83a09f4add"
+      },
+      {
+        "fixture": "contextimate:session-code",
+        "chars": 15088,
+        "sha256": "84c16e153c98677aa7f9b4aa04b5e104f1541c2eed3e6d7d619c2255c79fcb81"
+      },
+      {
+        "fixture": "contextimate:session-tests",
+        "chars": 18502,
+        "sha256": "0047a58314e01fa664c9cba0528ff32576a9b1a4831a6c1cc716dc7b132aa22a"
+      }
+    ],
+    "models": [
+      {
+        "requestedModel": "grok-4.3",
+        "resolvedModels": [
+          "grok-4.3"
+        ],
+        "contextimateProfile": {
+          "text": {
+            "chars": 54719,
+            "tokens": 13177,
+            "charsPerToken": 4.1526,
+            "recommendedDenominator": 4.2
+          },
+          "session": {
+            "chars": 33590,
+            "tokens": 8659,
+            "charsPerToken": 3.8792,
+            "recommendedDenominator": 3.9
+          }
+        }
+      },
+      {
+        "requestedModel": "grok-4.5",
+        "resolvedModels": [
+          "grok-4.5"
+        ],
+        "contextimateProfile": {
+          "text": {
+            "chars": 54719,
+            "tokens": 13506,
+            "charsPerToken": 4.0515,
+            "recommendedDenominator": 4.1
+          },
+          "session": {
+            "chars": 33590,
+            "tokens": 9274,
+            "charsPerToken": 3.622,
+            "recommendedDenominator": 3.6
+          }
+        }
+      }
+    ]
+  },
+  "hostedProbe": {
+    "status": "Exploratory cross-check only; it did not define the shipped raw-text profiles.",
+    "requests": 78,
+    "models": 26,
+    "reportedCostUsd": 0.1215,
+    "caveat": "One GLM request generated 38,918 hidden reasoning tokens despite max_tokens 1."
+  }
+}

--- a/docs/contextimate-tokenizer-coverage-audit-2026-08-05.md
+++ b/docs/contextimate-tokenizer-coverage-audit-2026-08-05.md
@@ -30,7 +30,9 @@ The provider checker now supports:
 | Vertex AI | sections and complete count request |
 | Amazon Bedrock | sections and complete Converse request for supported models |
 | Kimi | system-message section |
+| Cohere | raw system text for a named model |
 | Z.AI | system-message and tool sections for supported GLM models |
+| xAI | exact token-stream fingerprints through the optional Python SDK checker |
 
 Contextimate now resolves tokenizer family separately from wire API shape. Kimi, MiniMax and Vercel models no longer inherit Claude token density merely because Pi sends Anthropic-shaped requests.
 
@@ -134,7 +136,7 @@ Selectors such as `auto`, `free`, `fusion`, `big-pickle`, `mai-code-1-flash-pick
 | Kimi | `POST /v1/tokenizers/estimate-token-count` | messages and multimodal parts, but no top-level tool definitions or assistant tool calls |
 | Z.AI | `POST /api/paas/v4/tokenizer` | messages and up to 128 tools; published model enum lists GLM 4.5, 4.6 and 4.6V |
 | Cohere | `POST /v1/tokenize` | one text string for a named model |
-| xAI | `TokenizeText` | one text string for an accepted Grok model; current Grok IDs need a capability check |
+| xAI | `TokenizeText` | one text string for a named Grok model; current 4.20, 4.3, Build 0.1 and 4.5 IDs were checked |
 
 ### Public local tokenizers
 
@@ -167,6 +169,32 @@ A raw tokenizer does not include role delimiters, tool-schema conversion, hidden
 
 Fast, batch, regional and free suffixes usually preserve the named family. Record the route separately because the template can still differ.
 
+## Kimi, GLM, Cohere and Grok calibration
+
+We tested five public, Pi-shaped corpora. They contain 54,719 characters of instructions, 33,590 characters of TypeScript and tests, and 2,773 characters of JSON. Local studies used pinned official tokenizer artifacts. Grok used xAI's `TokenizeText` API. Small hosted probes cross-checked the direction of the results. They did not define the raw profiles.
+
+The [machine-readable evidence](./contextimate-family-calibration-evidence-2026-08-05.json) records exact revisions, hashes, counts, token-stream digests and dependency versions. It contains no source text or credentials.
+
+| Profile | Text chars/token | Session chars/token | Evidence and sharing boundary |
+|---|---:|---:|---|
+| Kimi | 4.1 | 3.8 | K2 through K3 share rank hash `b6c497a7469b…` and preprocessing hash `de5781783b19…`; thinking and chat controls differ |
+| GLM 4.5 | 4.0 | 3.9 | GLM 4.5 Air/V, 4.6/V/V-Flash and standard 4.7 use tokenizer hash `934066501641…` |
+| GLM 5 | 4.0 | 3.9 | GLM 4.7-Flash, 5, 5.1 and 5.2 use tokenizer hash `19e773648cb4…` |
+| Command R | 4.0 | 3.4 | Command R and R+ 08-2024 have the same ordinary-text vocabulary and merges; their special tokens differ |
+| North Mini Code | 4.2 | 3.9 | separate tokenizer hash `14bd1c49d7d1…` |
+| Grok 4.20/4.3 | 4.2 | 3.9 | Grok 4.20 reasoning, non-reasoning and multi-agent, 4.3 and Build 0.1 returned identical token IDs, strings and bytes |
+| Grok 4.5 | 4.1 | 3.6 | a distinct xAI token stream; `grok-build-latest` currently resolves here |
+
+The xAI fingerprint used six fixtures covering prose, code, multilingual text, whitespace, control-like strings and deterministic random text. Corpus version `2026-08-05.1` put Grok 4.20 reasoning, non-reasoning and multi-agent, 4.3 and Build 0.1 under fingerprint `6b2720117257…`. Grok 4.5 produced `f892196825e9…`.
+
+At measurement time, `grok-4.20` resolved to `grok-4.20-0309-reasoning`. `grok-latest` resolved to `grok-4.3`, while `grok-build-latest` resolved to `grok-4.5`. Contextimate leaves `latest` aliases unknown before routing because their targets can change.
+
+GLM 5 Turbo, GLM 5V Turbo, GLM 4.7 FlashX and beta Grok aliases remain unknown: their names are not proof of a published tokenizer. The same rule applies to `auto`, `free`, fusion and picker routes.
+
+The hosted sweep made 78 tiny requests across 26 routes and cost about $0.1215. One GLM request produced 38,918 hidden reasoning tokens despite `max_tokens: 1`. Future studies should prefer count or tokenizer endpoints because some models require generation reasoning.
+
+These profiles cover visible text. Chat templates, tool conversion, hidden instructions and route overhead stay separate. The wire API still selects the tool payload shape, and unmeasured tool denominators remain at 4.
+
 ## Contextimate policy
 
 Resolve these facts independently:
@@ -175,11 +203,15 @@ Resolve these facts independently:
 - wire API shape, for system and tool serialization
 - tokenizer family and revision, for token density
 
-Current measured profiles remain:
+Measured profiles now cover:
 
 - Claude 4.5 and 4.6
 - Claude 4.7 and later
 - OpenAI Codex and Responses
+- Kimi K2 through K3 raw text
+- GLM 4.5-generation and GLM 5-generation raw text
+- Cohere Command R/R+ 08-2024 and North Mini Code raw text
+- Grok 4.20/4.3/Build 0.1 and Grok 4.5 raw text
 
 Gemini, Bedrock, Mistral and unidentified families remain estimates at characters divided by 4 until calibration data supports a better profile. API compatibility alone does not change that denominator.
 
@@ -191,28 +223,27 @@ Prioritise measured profiles in this order:
 
 1. Gemini 2.x and 3.x
 2. DeepSeek V3 and V4
-3. GLM 4 and 5
-4. Kimi K2 and K3
-5. Qwen 2.5, 3 and 3.5 or later
-6. MiniMax M1 and M2 or later
-7. Mistral revisions
-8. Llama 3 and 4
-9. Gemma 3 and 4
-10. MiMo revisions
+3. Qwen 2.5, 3 and 3.5 or later
+4. MiniMax M1 and M2 or later
+5. Mistral revisions
+6. Llama 3 and 4
+7. Gemma 3 and 4
+8. MiMo revisions
 
 Still requiring a capability check:
 
 - Kimi Coding membership keys against the public Moonshot endpoint
 - Z.AI Coding Plan keys against the tokenizer endpoint
-- GLM model IDs newer than the published tokenizer enum
-- current xAI model IDs against `TokenizeText`
+- GLM model IDs newer than the published tokenizer enum, including 5 Turbo and 5V Turbo
 - whether DashScope still documents a Qwen tokenization service and which plans can use it
 - Azure support for OpenAI's Responses input-token endpoint
 
-No paid provider generation was run for this audit.
+The family follow-up used about $0.1215 of paid OpenRouter generation. Direct xAI checks used `TokenizeText`, not generation.
 
 ## Sources
 
+- [Pinned open-tokenizer study](../scripts/contextimate/study-open-tokenizers.py)
+- [Exact xAI token-stream checker](../scripts/contextimate/check-xai-tokenizers.py)
 - [Anthropic token counting](https://platform.claude.com/docs/en/build-with-claude/token-counting)
 - [OpenAI Responses input-token count](https://developers.openai.com/api/reference/resources/responses/subresources/input_tokens/methods/count)
 - [Gemini countTokens](https://ai.google.dev/api/tokens)
@@ -222,6 +253,11 @@ No paid provider generation was run for this audit.
 - [Z.AI tokenizer](https://docs.z.ai/api-reference/tools/tokenizer.md)
 - [Cohere tokenize](https://docs.cohere.com/reference/tokenize)
 - [xAI tokenizer example](https://github.com/xai-org/xai-sdk-python/blob/main/examples/sync/tokenizer.py)
+- [Kimi K2.5 tokenizer artifacts](https://huggingface.co/moonshotai/Kimi-K2.5/tree/4d01dfe0332d63057c186e0b262165819efb6611)
+- [GLM 4.5 tokenizer artifacts](https://huggingface.co/zai-org/GLM-4.5/tree/cbb2c7cfb52fa128a9660cb1a7a78e017899e115)
+- [GLM 5 tokenizer artifacts](https://huggingface.co/zai-org/GLM-5/tree/4e6698ba8e85059d749020e3c4d2123719f23926)
+- [Cohere Command R 08-2024 tokenizer](https://huggingface.co/CohereLabs/c4ai-command-r-08-2024)
+- [Cohere North Mini Code tokenizer](https://huggingface.co/CohereLabs/North-Mini-Code-1.0)
 - [Google local tokenizer](https://github.com/googleapis/python-genai/blob/main/google/genai/local_tokenizer.py)
 - [Mistral common](https://github.com/mistralai/mistral-common)
 - [OpenAI Harmony](https://github.com/openai/harmony)

--- a/docs/pi-contextimate.md
+++ b/docs/pi-contextimate.md
@@ -35,6 +35,22 @@ Divisors depend on content shape: repetitive prose tokenizes around chars ÷ 7, 
 
 The session divisors were validated by replaying 194 local session transcripts (16,479 assistant turns) against recorded provider usage: chars ÷ 2.6 beat a blanket chars ÷ 4 on 20 of 24 Anthropic transcripts, with median error 0.6 to 2.1% against 2.8 to 4.7%. OpenAI-Codex session material sits at chars ÷ 4, so the blanket value is already right there. `pi-contextimate-evaluate-transcripts` re-runs this evaluation.
 
+A second study on 5 August 2026 covered Kimi, GLM, Cohere and Grok. It counted 54,719 characters of public instructions and 33,590 characters of TypeScript and tests. Local checks used pinned official tokenizer artifacts. xAI checks used exact token IDs and bytes from `TokenizeText`.
+
+| Raw tokenizer profile | Text divisor | Session divisor |
+|---|---:|---:|
+| Kimi K2 through K3 | 4.1 | 3.8 |
+| GLM 4.5 variants, 4.6 variants and standard 4.7 | 4.0 | 3.9 |
+| GLM 4.7-Flash, 5, 5.1 and 5.2 | 4.0 | 3.9 |
+| Command R/R+ 08-2024 | 4.0 | 3.4 |
+| North Mini Code | 4.2 | 3.9 |
+| Grok 4.20 variants, 4.3 and Build 0.1 | 4.2 | 3.9 |
+| Grok 4.5 | 4.1 | 3.6 |
+
+These profiles cover visible text only. Kimi versions share one base rank file but use different control vocabularies. GLM has two proven tokenizer generations. Command R and R+ share ordinary-text merges, but some special tokens differ.
+
+Exact xAI fingerprints put Grok 4.20 reasoning, non-reasoning and multi-agent, 4.3 and Build 0.1 together. Grok 4.5 is separate. Dynamic aliases and unverified GLM Turbo variants use the fallback until routing identifies a concrete model. The [tokenizer coverage audit](./contextimate-tokenizer-coverage-audit-2026-08-05.md) contains the full evidence.
+
 ## Tool schemas
 
 Raw size fails in both directions: minified JSON at chars ÷ 4 overcounts OpenAI schemas by roughly 2x, and no single divisor tracks schema shape (enums, nesting, description length).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -261,8 +261,9 @@ Designed now so the features land with their proofs:
   compat) while the title changes.
 - **#8 (provider token check):** the checker is a script (`scripts/contextimate/
   check-provider-tokens.ts`) whose request builders are pure and unit-tested against current
-  Pi payload shapes and provider count schemas. Network execution is manual; tests never
-  call providers.
+  Pi payload shapes and provider count schemas. The Cohere executor is tested with a mocked
+  response. The separate xAI Python checker has an offline fingerprint self-test. Network
+  execution is manual; tests never call providers.
 - **#7 (click UX decision):** resolved by removal; click-to-expand shipped, proved
   unusable in practice, and was deleted (v0.5.18). Ctrl+T is the whole surface.
 

--- a/extensions/_lib/heuristics.ts
+++ b/extensions/_lib/heuristics.ts
@@ -46,6 +46,13 @@ export function estimateCharsAsTokens(chars: number, denominator: number): numbe
 
 const CLAUDE_47_PLUS_MODEL = /claude.*(?:4[-.]?[7-9](?=$|[-.:@])|(?:fable|opus|sonnet|haiku)[-.]?5(?=$|[-.:@]))|4[-.]?[7-9](?=$|[-.:@]).*claude/;
 const CLAUDE_45_46_MODEL = /claude.*4[-.]?[56]|4[-.]?[56].*claude/;
+const KIMI_MODEL = /(?:^|[/@._-])kimi-k(?:2(?:p6|p7-code|[.]5|[.]6|[.]7-code|-(?:0711-preview|0905(?:-preview)?|thinking(?:-turbo)?|turbo-preview|instruct(?:-0905)?))?|3)(?:-(?:fast|highspeed|turbo)|:free)?$/;
+const GLM_45_MODEL = /(?:^|[/@._-])glm-4[.](?:5(?:-air|v)?|6(?:v(?:-flash)?)?|7)(?::free)?$/;
+const GLM_5_MODEL = /(?:^|[/@._-])glm-(?:4[.]7-flash|5(?:[.](?:1|2)|p2)?)(?:-(?:fast|free)|:free)?$/;
+const COMMAND_R_MODEL = /(?:^|[/@._-])command-r(?:-plus)?-08-2024(?::free)?$/;
+const NORTH_MINI_CODE_MODEL = /(?:^|[/@._-])north-mini-code(?:-1[.]0|(?:-|:)free)?$/;
+const GROK_420_43_MODEL = /(?:^|[/@._-])grok-(?:4[.]20(?:-(?:(?:0309-)?(?:non-)?reasoning|multi-agent(?:-0309)?))?|4[.]3|build-0[.]1)(?::free)?$/;
+const GROK_45_MODEL = /(?:^|[/@._-])grok-4[.]5(?::free)?$/;
 
 function familyAtLeast(modelId: string, family: string, major: number, minor: number): boolean {
   const versionPattern = `${family}[-.]?(\\d{1,2})(?:[-.](\\d{1,2}))?(?=$|[-.:@])`;
@@ -91,18 +98,66 @@ const CLAUDE_GENERIC: TokenizerProfile = {
   textDenominator: 3.5,
   sessionDenominator: 3.5,
 };
+const KIMI_RAW: TokenizerProfile = {
+  label: "Kimi tokenizer",
+  textDenominator: 4.1,
+  sessionDenominator: 3.8,
+};
+const GLM_45: TokenizerProfile = {
+  label: "GLM 4.5 tokenizer",
+  textDenominator: 4,
+  sessionDenominator: 3.9,
+};
+const GLM_5: TokenizerProfile = {
+  label: "GLM 5 tokenizer",
+  textDenominator: 4,
+  sessionDenominator: 3.9,
+};
+const COMMAND_R: TokenizerProfile = {
+  label: "Command R tokenizer",
+  textDenominator: 4,
+  sessionDenominator: 3.4,
+};
+const NORTH_MINI_CODE: TokenizerProfile = {
+  label: "North Mini Code tokenizer",
+  textDenominator: 4.2,
+  sessionDenominator: 3.9,
+};
+const GROK_420_43: TokenizerProfile = {
+  label: "Grok 4.20/4.3 tokenizer",
+  textDenominator: 4.2,
+  sessionDenominator: 3.9,
+};
+const GROK_45: TokenizerProfile = {
+  label: "Grok 4.5 tokenizer",
+  textDenominator: 4.1,
+  sessionDenominator: 3.6,
+};
 
 function isClaudeModel(model: ModelSummary): boolean {
   return model.provider.toLowerCase().includes("anthropic") || model.id.toLowerCase().includes("claude");
 }
 
+function isKimiModel(model: ModelSummary, id: string): boolean {
+  if (KIMI_MODEL.test(id)) return true;
+  if (model.provider.toLowerCase() !== "kimi-coding") return false;
+  return /^(?:k3(?:-256k)?|kimi-for-coding(?:-highspeed)?)$/.test(id);
+}
+
 function tokenizerProfile(model: ModelSummary): TokenizerProfile | undefined {
+  const id = model.id.toLowerCase();
   if (isClaudeModel(model)) {
-    const id = model.id.toLowerCase();
     if (CLAUDE_47_PLUS_MODEL.test(id)) return CLAUDE_47_PLUS;
     if (CLAUDE_45_46_MODEL.test(id)) return CLAUDE_45_46;
     return CLAUDE_GENERIC;
   }
+  if (isKimiModel(model, id)) return KIMI_RAW;
+  if (GLM_5_MODEL.test(id)) return GLM_5;
+  if (GLM_45_MODEL.test(id)) return GLM_45;
+  if (COMMAND_R_MODEL.test(id)) return COMMAND_R;
+  if (NORTH_MINI_CODE_MODEL.test(id)) return NORTH_MINI_CODE;
+  if (GROK_420_43_MODEL.test(id)) return GROK_420_43;
+  if (GROK_45_MODEL.test(id)) return GROK_45;
   if (model.provider.toLowerCase().includes("openai-codex")) {
     return { label: "OpenAI-Codex heuristic", textDenominator: 4, sessionDenominator: 4 };
   }

--- a/extensions/pi-contextimate/README.md
+++ b/extensions/pi-contextimate/README.md
@@ -43,7 +43,7 @@ How to read the numbers:
 
 - every `~` number is an estimate; `Total request` drops it only when Pi's current total is fully provider-reported, and keeps it when trailing messages add a local estimate
 - the dim hint line under the header states the counting method once, for example `counts ch ÷ 2.6 (Claude 4.7+ heuristic)`; data rows carry only their raw size, like `(9.2k ch)`
-- the method follows the active model, so switching models re-estimates immediately; named Claude 4.7+ models keep their tokenizer profile through supported Radius and OpenRouter relays
+- the method follows the active model, so switching models re-estimates immediately; concrete Claude, Kimi, GLM, Cohere and Grok model IDs keep their measured raw-text profile through supported relays, while dynamic aliases stay unknown until routing selects a model
 - until the first post-switch response, `Total request` names its old currency (`pre-switch usage · <model> tokens`) and withholds only that total's context bar and window share
 - the first row says `Runtime system prompt` because Pi assembles that prompt at runtime from its base prompt plus tool and extension contributions; expanded view attributes the part it can verify
 - `Skill frontmatter` counts the always-loaded skill index only, not skill bodies, which load on demand

--- a/package.json
+++ b/package.json
@@ -66,7 +66,10 @@
     "extensions/pi-meantime",
     "docs",
     "CHANGELOG.md",
-    "scripts/contextimate",
+    "scripts/contextimate/*.mjs",
+    "scripts/contextimate/*.py",
+    "scripts/contextimate/*.ts",
+    "scripts/contextimate/README.md",
     "LICENSE"
   ],
   "publishConfig": {
@@ -75,6 +78,7 @@
   "bin": {
     "pi-contextimate-probe-prefix": "scripts/contextimate/probe-live-prefix.mjs",
     "pi-contextimate-evaluate-transcripts": "scripts/contextimate/evaluate-transcripts.mjs",
-    "pi-contextimate-check-provider-tokens": "scripts/contextimate/check-provider-tokens.ts"
+    "pi-contextimate-check-provider-tokens": "scripts/contextimate/check-provider-tokens.ts",
+    "pi-contextimate-check-xai-tokenizers": "scripts/contextimate/check-xai-tokenizers.py"
   }
 }

--- a/scripts/contextimate/README.md
+++ b/scripts/contextimate/README.md
@@ -49,8 +49,35 @@ Supported count APIs:
 | Vertex AI | `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` and `GOOGLE_CLOUD_ACCESS_TOKEN` | sections and full request |
 | Amazon Bedrock | standard AWS credentials and `AWS_REGION` | sections and full request for supported models |
 | Kimi | `MOONSHOT_API_KEY` | message sections |
+| Cohere | `COHERE_API_KEY` | raw system text for a named model |
 | Z.AI | `ZAI_API_KEY` | message and tool sections for supported GLM models |
 
-Live calls always require `--provider`, because wire compatibility does not identify the service. Dry runs can infer Anthropic, OpenAI, Gemini or Bedrock from the payload shape.
+Live calls always require `--provider`, because wire compatibility does not identify the service. Dry runs can infer Anthropic, OpenAI, Gemini or Bedrock from the payload shape. Cohere's endpoint counts raw text, not chat roles or tools; pass the direct Cohere model name with `--model` when the capture came through a relay.
 
 With at least 2 tools, the checker removes the shared tool-block overhead before suggesting Contextimate denominators. Tests cover request construction and this calculation. Network execution remains manual.
+
+## Open tokenizer calibration
+
+Reproduce the Kimi, GLM and Cohere raw-text profiles from a source checkout:
+
+```bash
+uv run --with 'huggingface-hub==1.26.0' --with 'tokenizers==0.22.2' \
+  --with 'tiktoken==0.13.0' scripts/contextimate/study-open-tokenizers.py --json
+```
+
+The script pins every model revision and tokenizer hash. It reads a public corpus from git revision `556dd115a77839773e143afc0d982afa59eb7479`. Later code changes cannot move the baseline silently. The script downloads tokenizer artifacts and makes no generation calls. It reads Kimi's pinned rank file and configuration directly. It checks both hashes and executes no repository code.
+
+## xAI tokenizer fingerprints
+
+xAI exposes exact token IDs and bytes through `TokenizeText`. The separate checker keeps its optional Python SDK out of the extension and npm dependency tree:
+
+```bash
+uv run --with 'xai-sdk==1.17.0' \
+  scripts/contextimate/check-xai-tokenizers.py --json
+```
+
+It reads `XAI_API_KEY`, or a fresh xAI OAuth login from Pi. The fixed public corpus covers prose, code, multilingual text, whitespace, control-like strings and deterministic random text. Models join one group only when every token record matches.
+
+Add `--contextimate-corpus` to calculate divisors from the pinned open-tokenizer corpus. Add `--file <path>` for another local corpus, but never send sensitive files. Use repeated `--model` options to inspect aliases. The script reports the resolved model. It never prints credentials or source text.
+
+This is an explicit live diagnostic. It makes no generation calls, and Contextimate never calls it at startup.

--- a/scripts/contextimate/check-provider-tokens.ts
+++ b/scripts/contextimate/check-provider-tokens.ts
@@ -44,7 +44,7 @@ Count a captured Pi request with a provider's token-count endpoint.
 Without --live, print the request plan without making network calls.
 
 Options:
-  --provider <name>  anthropic, openai, google, vertex, bedrock, kimi or zai
+  --provider <name>  anthropic, openai, google, vertex, bedrock, kimi, cohere or zai
   --model <id>       override the captured model
   --tools <a,b>      limit static-section checks to named tools
   --full             count the complete captured request when supported

--- a/scripts/contextimate/check-xai-tokenizers.py
+++ b/scripts/contextimate/check-xai-tokenizers.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Compare exact token streams returned by xAI's TokenizeText API."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import random
+import string
+import subprocess
+import sys
+import time
+from collections.abc import Iterable, Sequence
+from importlib.metadata import version
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Protocol
+
+sys.dont_write_bytecode = True
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from tokenizer_corpus import CORPUS_REVISION, pinned_corpus
+
+DEFAULT_MODELS = [
+    "grok-4.20-0309-reasoning",
+    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-multi-agent",
+    "grok-4.3",
+    "grok-build-0.1",
+    "grok-4.5",
+]
+
+
+def fingerprint_fixtures() -> dict[str, str]:
+    rng = random.Random(20260805)
+    random_ascii = "".join(
+        rng.choice(string.ascii_letters + string.digits + string.punctuation + " \t\n")
+        for _ in range(4096)
+    )
+    return {
+        "ascii": "Pack my box with five dozen liquor jugs. Version 12.003 costs $4.99; HTTP/2 foo_bar-baz.",
+        "code": 'const parseHTTP2=(x:string):Record<string,unknown>=>JSON.parse(`{"snake_case":${x},"emoji":"🦬"}`);\n\treturn parseHTTP2("42");',
+        "controls": "<|im_start|><|im_end|><|endoftext|><think></think>[DONE]<tool_call></tool_call>",
+        "multilingual": "café naïve Straße Ελληνικά русский 中文 日本語 한국어 العربية हिन्दी 👩🏽‍💻🦬 antidisestablishmentarianism",
+        "random-ascii-4096": random_ascii,
+        "whitespace": "a  b   c\td\n\ne\r\nf /usr/local/bin ~/.config foo::bar 00000123456789",
+    }
+
+
+class TokenRecord(Protocol):
+    token_id: int
+    string_token: str
+    token_bytes: bytes
+
+
+def canonical_token_digest(tokens: Iterable[TokenRecord]) -> str:
+    digest = hashlib.sha256()
+    for token in tokens:
+        record = json.dumps(
+            [
+                int(token.token_id),
+                str(token.string_token),
+                base64.b64encode(bytes(token.token_bytes)).decode("ascii"),
+            ],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf8")
+        digest.update(len(record).to_bytes(4, "big"))
+        digest.update(record)
+    return digest.hexdigest()
+
+
+def combined_digest(samples: Sequence[dict[str, object]]) -> str:
+    digest = hashlib.sha256()
+    for sample in samples:
+        record = json.dumps(
+            [sample["fixture"], sample["tokens"], sample["digest"]],
+            separators=(",", ":"),
+        ).encode("utf8")
+        digest.update(len(record).to_bytes(4, "big"))
+        digest.update(record)
+    return digest.hexdigest()
+
+
+def contextimate_profile(
+    samples: Sequence[dict[str, object]],
+) -> dict[str, dict[str, float | int]]:
+    by_name = {str(sample["fixture"]): sample for sample in samples}
+
+    def aggregate(names: list[str]) -> dict[str, float | int]:
+        chars = sum(int(by_name[name]["chars"]) for name in names)
+        tokens = sum(int(by_name[name]["tokens"]) for name in names)
+        return {
+            "chars": chars,
+            "tokens": tokens,
+            "charsPerToken": round(chars / tokens, 4),
+            "recommendedDenominator": round(chars / tokens, 1),
+        }
+
+    return {
+        "text": aggregate(
+            ["contextimate:instructions-core", "contextimate:instructions-design"]
+        ),
+        "session": aggregate(
+            ["contextimate:session-code", "contextimate:session-tests"]
+        ),
+    }
+
+
+def api_key() -> str:
+    if value := os.environ.get("XAI_API_KEY"):
+        return value
+    auth_path = Path.home() / ".pi" / "agent" / "auth.json"
+    try:
+        entry = json.loads(auth_path.read_text()).get("xai")
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError("set XAI_API_KEY or sign in to xAI through Pi") from error
+    if not isinstance(entry, dict) or not isinstance(entry.get("access"), str):
+        raise RuntimeError("set XAI_API_KEY or sign in to xAI through Pi")
+    expires = entry.get("expires")
+    if isinstance(expires, (int, float)) and expires <= time.time() * 1000:
+        raise RuntimeError("the Pi xAI login has expired; refresh it in Pi")
+    return entry["access"]
+
+
+def token_error(error: Exception) -> str:
+    code = getattr(error, "code", None)
+    if callable(code):
+        status = code()
+        return f"{type(error).__name__}: {getattr(status, 'name', str(status))}"
+    return type(error).__name__
+
+
+def tokenize(
+    client: object, model: str, text: str, retries: int
+) -> tuple[str, Sequence[object]]:
+    # The public helper returns only tokens. The pinned SDK's generated stub keeps the
+    # resolved model, which is required to distinguish stable model IDs from aliases.
+    from xai_sdk.proto import tokenize_pb2
+
+    token_client = client.tokenize
+    stub = getattr(token_client, "_stub", None)
+    if stub is None or not hasattr(stub, "TokenizeText"):
+        raise RuntimeError("the pinned xai-sdk TokenizeText contract has changed")
+    for attempt in range(retries + 1):
+        try:
+            response = stub.TokenizeText(
+                tokenize_pb2.TokenizeTextRequest(text=text, model=model)
+            )
+            return response.model, response.tokens
+        except Exception as error:
+            if "RESOURCE_EXHAUSTED" not in str(error) or attempt == retries:
+                raise RuntimeError(token_error(error)) from error
+            time.sleep(15)
+    raise RuntimeError("unreachable TokenizeText retry state")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fingerprint exact xAI token streams. Network calls occur only when this script is run.",
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        dest="models",
+        help="model or alias; repeat for more than one",
+    )
+    parser.add_argument(
+        "--file",
+        action="append",
+        type=Path,
+        default=[],
+        help="additional UTF-8 corpus file",
+    )
+    parser.add_argument("--json", action="store_true", help="emit structured JSON")
+    parser.add_argument(
+        "--contextimate-corpus",
+        action="store_true",
+        help="also count the pinned public corpus used for Contextimate profiles; requires a source checkout",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=4,
+        help="rate-limit retries per call (default: 4)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="test fingerprinting without xAI or xai-sdk",
+    )
+    return parser.parse_args()
+
+
+def self_test() -> None:
+    first = [SimpleNamespace(token_id=1, string_token="a", token_bytes=b"a")]
+    same = [SimpleNamespace(token_id=1, string_token="a", token_bytes=b"a")]
+    changed = [SimpleNamespace(token_id=2, string_token="a", token_bytes=b"a")]
+    assert canonical_token_digest(first) == canonical_token_digest(same)
+    assert canonical_token_digest(first) != canonical_token_digest(changed)
+    assert len(fingerprint_fixtures()["random-ascii-4096"]) == 4096
+    print("xAI tokenizer fingerprint self-test passed")
+
+
+def main() -> None:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return
+    if args.retries < 0:
+        raise RuntimeError("--retries must be non-negative")
+
+    fixtures = fingerprint_fixtures()
+    if args.contextimate_corpus:
+        fixtures.update(
+            {f"contextimate:{name}": text for name, text in pinned_corpus().items()}
+        )
+    for path in args.file:
+        name = f"file:{path.name}"
+        if name in fixtures:
+            raise RuntimeError(f"duplicate corpus name: {name}")
+        fixtures[name] = path.read_text()
+
+    try:
+        from xai_sdk import Client
+    except ImportError as error:
+        raise RuntimeError(
+            "install the pinned SDK with: uv run --with 'xai-sdk==1.17.0'"
+        ) from error
+
+    client = Client(api_key=api_key())
+    rows: list[dict[str, object]] = []
+    for requested_model in args.models or DEFAULT_MODELS:
+        samples: list[dict[str, object]] = []
+        resolved_models: set[str] = set()
+        for fixture, text in fixtures.items():
+            resolved_model, tokens = tokenize(
+                client, requested_model, text, args.retries
+            )
+            resolved_models.add(resolved_model)
+            samples.append(
+                {
+                    "fixture": fixture,
+                    "chars": len(text),
+                    "tokens": len(tokens),
+                    "digest": canonical_token_digest(tokens),
+                }
+            )
+            time.sleep(1)
+        row: dict[str, object] = {
+            "requestedModel": requested_model,
+            "resolvedModels": sorted(resolved_models),
+            "fingerprint": combined_digest(samples),
+            "samples": samples,
+        }
+        if args.contextimate_corpus:
+            row["contextimateProfile"] = contextimate_profile(samples)
+        rows.append(row)
+
+    groups: dict[str, list[str]] = {}
+    for row in rows:
+        groups.setdefault(str(row["fingerprint"]), []).append(
+            str(row["requestedModel"])
+        )
+    result = {
+        "corpusVersion": "2026-08-05.1",
+        "corpus": [
+            {
+                "fixture": name,
+                "chars": len(text),
+                "sha256": hashlib.sha256(text.encode("utf8")).hexdigest(),
+            }
+            for name, text in fixtures.items()
+        ],
+        "contextimateCorpusRevision": CORPUS_REVISION
+        if args.contextimate_corpus
+        else None,
+        "pythonVersion": sys.version.split()[0],
+        "xaiSdkVersion": version("xai-sdk"),
+        "models": rows,
+        "groups": [
+            {"fingerprint": key, "models": models} for key, models in groups.items()
+        ],
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+    for group in result["groups"]:
+        print(f"{str(group['fingerprint'])[:12]}  {', '.join(group['models'])}")
+    if args.contextimate_corpus:
+        for row in rows:
+            profile = row["contextimateProfile"]
+            print(
+                f"{row['requestedModel']:<34} text ÷ {profile['text']['recommendedDenominator']:.1f}"
+                f"  session ÷ {profile['session']['recommendedDenominator']:.1f}"
+            )
+    print("Use --json for resolved models and per-fixture counts.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (
+        OSError,
+        RuntimeError,
+        UnicodeError,
+        subprocess.CalledProcessError,
+    ) as error:
+        print(str(error), file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/contextimate/provider-token-counts.ts
+++ b/scripts/contextimate/provider-token-counts.ts
@@ -78,15 +78,19 @@ function jsonChars(value: JsonValue): number {
   return typeof value === "string" ? value.length : JSON.stringify(value).length;
 }
 
+function visibleText(value: JsonValue): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(visibleText).join("");
+  if (!isJsonObject(value)) return "";
+  if (typeof value.text === "string") return value.text;
+  if (typeof value.content === "string") return value.content;
+  if (Array.isArray(value.content)) return visibleText(value.content);
+  if (Array.isArray(value.parts)) return visibleText(value.parts);
+  return "";
+}
+
 function textChars(value: JsonValue): number {
-  if (typeof value === "string") return value.length;
-  if (Array.isArray(value)) return value.reduce<number>((sum, item) => sum + textChars(item), 0);
-  if (!isJsonObject(value)) return 0;
-  if (typeof value.text === "string") return value.text.length;
-  if (typeof value.content === "string") return value.content.length;
-  if (Array.isArray(value.content)) return textChars(value.content);
-  if (Array.isArray(value.parts)) return textChars(value.parts);
-  return 0;
+  return visibleText(value).length;
 }
 
 function toolRequests(
@@ -326,6 +330,17 @@ export function buildKimiRequests(payload: JsonObject, options: BuildOptions = {
   return requests;
 }
 
+export function buildCohereRequests(payload: JsonObject, options: BuildOptions = {}): CountRequest[] {
+  const text = systemMessages(payload).map(visibleText).filter(Boolean).join("\n");
+  if (!text) throw new Error("payload has no system message text for Cohere to tokenize");
+  return [{
+    id: "system",
+    label: "raw system text",
+    body: { model: modelId(payload, options.model), text },
+    chars: text.length,
+  }];
+}
+
 export function buildZaiRequests(payload: JsonObject, options: BuildOptions = {}): CountRequest[] {
   const model = modelId(payload, options.model);
   const messages = systemMessages(payload);
@@ -520,6 +535,20 @@ export const PROVIDERS: Record<string, Provider> = {
       });
       if (isJsonObject(data) && isJsonObject(data.data) && typeof data.data.total_tokens === "number") return data.data.total_tokens;
       throw new Error("Kimi returned no data.total_tokens");
+    },
+  },
+  cohere: {
+    kinds: ["openai-chat"],
+    method: "Cohere tokenize for raw system text",
+    build: buildCohereRequests,
+    async execute(body) {
+      const data = await postJson("https://api.cohere.com/v1/tokenize", body, {
+        authorization: `Bearer ${requiredEnv("COHERE_API_KEY")}`,
+      });
+      if (isJsonObject(data) && Array.isArray(data.tokens) && data.tokens.every((token) => typeof token === "number")) {
+        return data.tokens.length;
+      }
+      throw new Error("Cohere returned no numeric tokens array");
     },
   },
   zai: {

--- a/scripts/contextimate/study-open-tokenizers.py
+++ b/scripts/contextimate/study-open-tokenizers.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Reproduce Contextimate's pinned open-tokenizer calibration."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from importlib.metadata import version
+from importlib.util import find_spec
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from tokenizer_corpus import CORPUS_FILES, CORPUS_REVISION, pinned_corpus
+
+
+@dataclass(frozen=True)
+class ArtifactSpec:
+    repository: str
+    revision: str
+    filename: str
+    sha256: str
+    core_sha256: str | None = None
+    pattern_sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class TokenizerSpec:
+    label: str
+    representative: ArtifactSpec
+    family_members: tuple[ArtifactSpec, ...] = ()
+
+
+KIMI_HASH = "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103"
+GLM_45_HASH = "9340665016419c825c4bdabbcc9acc43b7ca2c68ce142724afa829abb1be5efd"
+GLM_5_HASH = "19e773648cb4e65de8660ea6365e10acca112d42a854923df93db4a6f333a82d"
+COMMAND_CORE_HASH = "2bcc46184ba3b57d82c76cdeb373c32e65cb570633a7237e1b01c175faf3758e"
+KIMI_CONFIG_HASH = "12fcab43d2b6068f46769f5ff373960bf7c17a94d7abbc50e2491306b2f6cf58"
+KIMI_PATTERN_HASH = "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
+KIMI_PATTERN = "|".join(
+    [
+        r"[\p{Han}]+",
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?",
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?",
+        r"\p{N}{1,3}",
+        r" ?[^\s\p{L}\p{N}]+[\r\n]*",
+        r"\s*[\r\n]+",
+        r"\s+(?!\S)",
+        r"\s+",
+    ]
+)
+
+TOKENIZERS = [
+    TokenizerSpec(
+        "Kimi",
+        ArtifactSpec(
+            "moonshotai/Kimi-K2.5",
+            "4d01dfe0332d63057c186e0b262165819efb6611",
+            "tiktoken.model",
+            KIMI_HASH,
+            pattern_sha256=KIMI_PATTERN_HASH,
+        ),
+        (
+            ArtifactSpec(
+                "moonshotai/Kimi-K2-Instruct",
+                "fd1984e2b7a3350dbf7305fe73a4ede25c14de50",
+                "tiktoken.model",
+                KIMI_HASH,
+                pattern_sha256=KIMI_PATTERN_HASH,
+            ),
+            ArtifactSpec(
+                "moonshotai/Kimi-K2-Instruct-0905",
+                "ac6c49f04883bd0a0598b790693a72061c676629",
+                "tiktoken.model",
+                KIMI_HASH,
+                pattern_sha256=KIMI_PATTERN_HASH,
+            ),
+            ArtifactSpec(
+                "moonshotai/Kimi-K2.6",
+                "7eb5002f6aadc958aed6a9177b7ed26bb94011bb",
+                "tiktoken.model",
+                KIMI_HASH,
+                pattern_sha256=KIMI_PATTERN_HASH,
+            ),
+            ArtifactSpec(
+                "moonshotai/Kimi-K2.7-Code",
+                "74797c9c62378b951a1f6fcf5c4631024e9b8bef",
+                "tiktoken.model",
+                KIMI_HASH,
+                pattern_sha256=KIMI_PATTERN_HASH,
+            ),
+            ArtifactSpec(
+                "moonshotai/Kimi-K3",
+                "9f62e4e9fffbd0a83ddd60e1c209d828994b3569",
+                "tiktoken.model",
+                KIMI_HASH,
+                pattern_sha256=KIMI_PATTERN_HASH,
+            ),
+        ),
+    ),
+    TokenizerSpec(
+        "GLM 4.5",
+        ArtifactSpec(
+            "zai-org/GLM-4.5",
+            "cbb2c7cfb52fa128a9660cb1a7a78e017899e115",
+            "tokenizer.json",
+            GLM_45_HASH,
+        ),
+        (
+            ArtifactSpec(
+                "zai-org/GLM-4.5-Air",
+                "a24ceef6ce4f3536971efe9b778bdaa1bab18daa",
+                "tokenizer.json",
+                GLM_45_HASH,
+            ),
+            ArtifactSpec(
+                "zai-org/GLM-4.5V",
+                "ed47433b37111465ec527affaaddceff371bca04",
+                "tokenizer.json",
+                GLM_45_HASH,
+            ),
+            ArtifactSpec(
+                "zai-org/GLM-4.6",
+                "be72194883d968d7923a07e2f61681ea9a2826d1",
+                "tokenizer.json",
+                GLM_45_HASH,
+            ),
+            ArtifactSpec(
+                "zai-org/GLM-4.6V",
+                "4e2d47eb0b41c5280d8294b17cef9e94fdcfff46",
+                "tokenizer.json",
+                GLM_45_HASH,
+            ),
+            ArtifactSpec(
+                "zai-org/GLM-4.6V-Flash",
+                "411bb4d77144a3f03accbf4b780f5acb8b7cde4e",
+                "tokenizer.json",
+                GLM_45_HASH,
+            ),
+            ArtifactSpec(
+                "zai-org/GLM-4.7",
+                "602d01efcdd332c5238ca4bcede555defbe83eb7",
+                "tokenizer.json",
+                GLM_45_HASH,
+            ),
+        ),
+    ),
+    TokenizerSpec(
+        "GLM 5",
+        ArtifactSpec(
+            "zai-org/GLM-5",
+            "4e6698ba8e85059d749020e3c4d2123719f23926",
+            "tokenizer.json",
+            GLM_5_HASH,
+        ),
+        (
+            ArtifactSpec(
+                "zai-org/GLM-4.7-Flash",
+                "7dd20894a642a0aa287e9827cb1a1f7f91386b67",
+                "tokenizer.json",
+                GLM_5_HASH,
+            ),
+            ArtifactSpec(
+                "zai-org/GLM-5.1",
+                "26e1bd6e011feb778d25ae34b09b07074139d92d",
+                "tokenizer.json",
+                GLM_5_HASH,
+            ),
+            ArtifactSpec(
+                "zai-org/GLM-5.2",
+                "b4734de4facf877f85769a911abafc5283eab3d9",
+                "tokenizer.json",
+                GLM_5_HASH,
+            ),
+        ),
+    ),
+    TokenizerSpec(
+        "Command R",
+        ArtifactSpec(
+            "mlx-community/c4ai-command-r-08-2024-4bit",
+            "563c818b2a8358765f78d30156f6e36f93b57110",
+            "tokenizer.json",
+            "f7e773a231706a3ee5d05050ff27aa122a19df09ee7dd59eafa906b7487035b9",
+            COMMAND_CORE_HASH,
+        ),
+        (
+            ArtifactSpec(
+                "mlx-community/c4ai-command-r-plus-08-2024-4bit",
+                "c1793cf166ecc2e82bca7979d72cc91a95dd4d76",
+                "tokenizer.json",
+                "c69a7ea6c0927dfac8c349186ebcf0466a4723c21cbdb2e850cf559f0bee92b8",
+                COMMAND_CORE_HASH,
+            ),
+        ),
+    ),
+    TokenizerSpec(
+        "North Mini Code",
+        ArtifactSpec(
+            "CohereLabs/North-Mini-Code-1.0",
+            "d11e61a842617a22dc328552fa5bb86231ee4f37",
+            "tokenizer.json",
+            "14bd1c49d7d11874921d324986713df4be21cd06060530c497dacef99919b7a5",
+        ),
+    ),
+]
+
+
+def sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def extract_kimi_pattern(source_path: str) -> str:
+    with open(source_path) as handle:
+        tree = ast.parse(handle.read())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "pat_str"
+            for target in node.targets
+        ):
+            continue
+        value = node.value
+        if (
+            not isinstance(value, ast.Call)
+            or not isinstance(value.func, ast.Attribute)
+            or value.func.attr != "join"
+            or len(value.args) != 1
+        ):
+            break
+        try:
+            parts = ast.literal_eval(value.args[0])
+        except (TypeError, ValueError):
+            break
+        if isinstance(parts, list) and all(isinstance(part, str) for part in parts):
+            return "|".join(parts)
+    raise RuntimeError("Kimi tokenizer source no longer contains a literal pat_str")
+
+
+def check_artifact(
+    spec: ArtifactSpec, hf_hub_download: Callable[..., str]
+) -> dict[str, str]:
+    artifact = hf_hub_download(spec.repository, spec.filename, revision=spec.revision)
+    actual_hash = sha256(artifact)
+    if actual_hash != spec.sha256:
+        raise RuntimeError(f"{spec.repository} artifact hash changed: {actual_hash}")
+    result = {
+        "repository": spec.repository,
+        "revision": spec.revision,
+        "sha256": actual_hash,
+    }
+    if spec.core_sha256 is not None:
+        with open(artifact) as handle:
+            model = json.load(handle)["model"]
+        encoded = json.dumps(
+            model, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode()
+        core_hash = hashlib.sha256(encoded).hexdigest()
+        if core_hash != spec.core_sha256:
+            raise RuntimeError(
+                f"{spec.repository} tokenizer core hash changed: {core_hash}"
+            )
+        result["coreSha256"] = core_hash
+    if spec.pattern_sha256 is not None:
+        source = hf_hub_download(
+            spec.repository, "tokenization_kimi.py", revision=spec.revision
+        )
+        pattern_hash = hashlib.sha256(extract_kimi_pattern(source).encode()).hexdigest()
+        if pattern_hash != spec.pattern_sha256:
+            raise RuntimeError(
+                f"{spec.repository} tokenizer pattern changed: {pattern_hash}"
+            )
+        result["patternSha256"] = pattern_hash
+    return result
+
+
+def load_encoder(
+    spec: TokenizerSpec,
+    hf_hub_download: Callable[..., str],
+) -> Callable[[str], Sequence[int]]:
+    artifact = hf_hub_download(
+        spec.representative.repository,
+        spec.representative.filename,
+        revision=spec.representative.revision,
+    )
+    if spec.representative.filename == "tiktoken.model":
+        local_pattern_hash = hashlib.sha256(KIMI_PATTERN.encode()).hexdigest()
+        if local_pattern_hash != KIMI_PATTERN_HASH:
+            raise RuntimeError(
+                f"local Kimi tokenizer pattern changed: {local_pattern_hash}"
+            )
+        config = hf_hub_download(
+            spec.representative.repository,
+            "tokenizer_config.json",
+            revision=spec.representative.revision,
+        )
+        actual_config_hash = sha256(config)
+        if actual_config_hash != KIMI_CONFIG_HASH:
+            raise RuntimeError(
+                f"Kimi tokenizer config hash changed: {actual_config_hash}"
+            )
+        with open(config) as handle:
+            added = json.load(handle)["added_tokens_decoder"]
+        import tiktoken
+        from tiktoken.load import load_tiktoken_bpe
+
+        ranks = load_tiktoken_bpe(artifact)
+        mapped = {int(token_id): value["content"] for token_id, value in added.items()}
+        special = {
+            mapped.get(token_id, f"<|reserved_token_{token_id}|>"): token_id
+            for token_id in range(len(ranks), len(ranks) + 256)
+        }
+        encoding = tiktoken.Encoding(
+            name="kimi-contextimate-calibration",
+            pat_str=KIMI_PATTERN,
+            mergeable_ranks=ranks,
+            special_tokens=special,
+        )
+        return lambda text: encoding.encode(text, allowed_special="all")
+
+    from tokenizers import Tokenizer
+
+    tokenizer = Tokenizer.from_file(artifact)
+    return lambda text: tokenizer.encode(text, add_special_tokens=False).ids
+
+
+def aggregate(
+    samples: dict[str, dict[str, float | int]], names: list[str]
+) -> dict[str, float | int]:
+    chars = sum(int(samples[name]["chars"]) for name in names)
+    tokens = sum(int(samples[name]["tokens"]) for name in names)
+    return {
+        "chars": chars,
+        "tokens": tokens,
+        "charsPerToken": round(chars / tokens, 4),
+        "recommendedDenominator": round(chars / tokens, 1),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Count the repository's public calibration corpus with pinned open tokenizers.",
+    )
+    parser.add_argument("--json", action="store_true", help="emit structured JSON")
+    parser.add_argument(
+        "--list-corpus",
+        action="store_true",
+        help="list corpus files without downloading tokenizers",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.list_corpus:
+        print(
+            json.dumps({"revision": CORPUS_REVISION, "files": CORPUS_FILES}, indent=2)
+        )
+        return
+    dependencies = ("huggingface_hub", "tiktoken", "tokenizers")
+    if any(find_spec(dependency) is None for dependency in dependencies):
+        raise RuntimeError(
+            "run with: uv run --with 'huggingface-hub==1.26.0' --with 'tokenizers==0.22.2' "
+            "--with 'tiktoken==0.13.0'"
+        )
+    from huggingface_hub import hf_hub_download
+
+    texts = pinned_corpus()
+    rows = []
+    for spec in TOKENIZERS:
+        artifacts = [
+            check_artifact(member, hf_hub_download)
+            for member in (spec.representative, *spec.family_members)
+        ]
+        encode = load_encoder(spec, hf_hub_download)
+        samples = {}
+        for name, text in texts.items():
+            tokens = len(encode(text))
+            samples[name] = {
+                "chars": len(text),
+                "tokens": tokens,
+                "charsPerToken": round(len(text) / tokens, 4),
+            }
+        row = {
+            "profile": spec.label,
+            "familyArtifacts": artifacts,
+            "samples": samples,
+            "text": aggregate(samples, ["instructions-core", "instructions-design"]),
+            "session": aggregate(samples, ["session-code", "session-tests"]),
+        }
+        if spec.representative.filename == "tiktoken.model":
+            row["configurationSha256"] = KIMI_CONFIG_HASH
+        rows.append(row)
+
+    result = {
+        "corpusVersion": "2026-08-05.1",
+        "corpusRevision": CORPUS_REVISION,
+        "corpusFiles": CORPUS_FILES,
+        "pythonVersion": sys.version.split()[0],
+        "dependencies": {
+            "huggingface-hub": version("huggingface-hub"),
+            "tiktoken": version("tiktoken"),
+            "tokenizers": version("tokenizers"),
+        },
+        "profiles": rows,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+    for row in rows:
+        print(
+            f"{row['profile']:<18} text ÷ {row['text']['recommendedDenominator']:.1f}"
+            f"  session ÷ {row['session']['recommendedDenominator']:.1f}"
+        )
+    print("Use --json for artifact hashes and per-corpus counts.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (
+        OSError,
+        RuntimeError,
+        UnicodeError,
+        subprocess.CalledProcessError,
+    ) as error:
+        print(str(error), file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/contextimate/tokenizer_corpus.py
+++ b/scripts/contextimate/tokenizer_corpus.py
@@ -1,0 +1,39 @@
+"""Pinned public corpus shared by manual tokenizer calibration scripts."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CORPUS_REVISION = "556dd115a77839773e143afc0d982afa59eb7479"
+CORPUS_FILES = {
+    "config-json": ["package.json", "tsconfig.json"],
+    "instructions-core": ["AGENTS.md", "docs/agent-coding-standard.md"],
+    "instructions-design": ["docs/design-language.md"],
+    "session-code": [
+        "extensions/_lib/heuristics.ts",
+        "extensions/_lib/tool-payloads.ts",
+    ],
+    "session-tests": [
+        "tests/contextimate/heuristics.test.ts",
+        "tests/contextimate/provider-check.test.ts",
+    ],
+}
+
+
+def pinned_file(path: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "show", f"{CORPUS_REVISION}:{path}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def pinned_corpus() -> dict[str, str]:
+    return {
+        name: "\n".join(pinned_file(path) for path in files)
+        for name, files in CORPUS_FILES.items()
+    }

--- a/tests/contextimate/heuristics.test.ts
+++ b/tests/contextimate/heuristics.test.ts
@@ -87,9 +87,138 @@ test("Claude profiles follow the model through supported routes", () => {
   assert.equal(radius.toolDenominator, 4);
 });
 
+test("measured tokenizer families follow concrete models through serving routes", () => {
+  const cases: Array<[ModelSummary, string, number, number]> = [
+    [model("moonshotai", "kimi-k2-0905-preview", "openai-completions"), "Kimi tokenizer", 4.1, 3.8],
+    [model("fireworks", "accounts/fireworks/routers/kimi-k2p6-fast", "anthropic-messages"), "Kimi tokenizer", 4.1, 3.8],
+    [model("kimi-coding", "k3-256k", "anthropic-messages"), "Kimi tokenizer", 4.1, 3.8],
+    [model("kimi-coding", "kimi-for-coding-highspeed", "anthropic-messages"), "Kimi tokenizer", 4.1, 3.8],
+    [model("amazon-bedrock", "moonshot.kimi-k2-thinking", "bedrock-converse-stream"), "Kimi tokenizer", 4.1, 3.8],
+    [model("openrouter", "z-ai/glm-4.5v", "openai-completions"), "GLM 4.5 tokenizer", 4, 3.9],
+    [model("vercel-ai-gateway", "zai/glm-4.6v-flash", "anthropic-messages"), "GLM 4.5 tokenizer", 4, 3.9],
+    [model("amazon-bedrock", "zai.glm-4.7", "bedrock-converse-stream"), "GLM 4.5 tokenizer", 4, 3.9],
+    [model("openrouter", "z-ai/glm-4.7-flash", "openai-completions"), "GLM 5 tokenizer", 4, 3.9],
+    [model("fireworks", "accounts/fireworks/routers/glm-5p2-fast", "openai-completions"), "GLM 5 tokenizer", 4, 3.9],
+    [model("huggingface", "zai-org/GLM-5.1", "openai-completions"), "GLM 5 tokenizer", 4, 3.9],
+    [model("openrouter", "cohere/command-r-plus-08-2024", "openai-completions"), "Command R tokenizer", 4, 3.4],
+    [model("openrouter", "cohere/north-mini-code:free", "openai-completions"), "North Mini Code tokenizer", 4.2, 3.9],
+    [model("opencode", "north-mini-code-free", "openai-completions"), "North Mini Code tokenizer", 4.2, 3.9],
+    [model("xai", "grok-4.3", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
+    [model("openrouter", "x-ai/grok-4.20", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
+    [model("xai", "grok-4.20-0309-non-reasoning", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
+    [model("vercel-ai-gateway", "xai/grok-4.20-multi-agent", "anthropic-messages"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
+    [model("xai", "grok-4.20-multi-agent-0309", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
+    [model("opencode", "grok-build-0.1", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
+    [model("xai", "grok-4.5", "openai-responses"), "Grok 4.5 tokenizer", 4.1, 3.6],
+  ];
+
+  for (const [current, label, textDenominator, sessionDenominator] of cases) {
+    const heuristic = resolveHeuristic(current, {});
+    assert.equal(heuristic.label, label, `${current.provider}/${current.id}`);
+    assert.equal(heuristic.textDenominator, textDenominator, `${current.provider}/${current.id}`);
+    assert.equal(heuristic.sessionDenominator, sessionDenominator, `${current.provider}/${current.id}`);
+  }
+
+  const relayedKimi = resolveHeuristic(
+    model("fireworks", "accounts/fireworks/routers/kimi-k2p6-fast", "anthropic-messages"),
+    {},
+  );
+  assert.equal(relayedKimi.toolNumerator, "anthropic");
+  assert.equal(relayedKimi.toolDenominator, 4);
+  const bedrockGlm = resolveHeuristic(model("amazon-bedrock", "zai.glm-4.7", "bedrock-converse-stream"), {});
+  assert.equal(bedrockGlm.toolNumerator, "bedrock");
+  const directGrok45 = resolveHeuristic(model("xai", "grok-4.5", "openai-responses"), {});
+  assert.equal(directGrok45.toolNumerator, "openai-responses");
+});
+
+test("published tokenizer siblings stay inside their measured family boundary", () => {
+  const families = [
+    ["Kimi tokenizer", [
+      "moonshotai/kimi-k2",
+      "moonshotai/kimi-k2-0711-preview",
+      "moonshotai/kimi-k2-0905",
+      "moonshotai/kimi-k2-thinking-turbo",
+      "moonshotai/kimi-k2.5",
+      "@cf/moonshotai/kimi-k2.6",
+      "moonshotai/kimi-k2.7-code-highspeed",
+      "accounts/fireworks/models/kimi-k2p6",
+      "accounts/fireworks/routers/kimi-k2p7-code-fast",
+      "moonshotai/kimi-k3-fast",
+    ]],
+    ["GLM 4.5 tokenizer", [
+      "z-ai/glm-4.5",
+      "z-ai/glm-4.5-air",
+      "z-ai/glm-4.5v",
+      "z-ai/glm-4.6",
+      "z-ai/glm-4.6v",
+      "z-ai/glm-4.6v-flash",
+      "zai-glm-4.7",
+    ]],
+    ["GLM 5 tokenizer", [
+      "z-ai/glm-4.7-flash",
+      "z-ai/glm-5",
+      "z-ai/glm-5.1",
+      "zai-org/glm-5.2",
+      "accounts/fireworks/models/glm-5p2",
+      "accounts/fireworks/routers/glm-5p2-fast",
+    ]],
+    ["Command R tokenizer", [
+      "cohere/command-r-08-2024",
+      "cohere/command-r-plus-08-2024",
+    ]],
+    ["North Mini Code tokenizer", [
+      "cohere/north-mini-code:free",
+      "north-mini-code-free",
+      "coherelabs/north-mini-code-1.0",
+    ]],
+    ["Grok 4.20/4.3 tokenizer", [
+      "x-ai/grok-4.20",
+      "xai/grok-4.20-reasoning",
+      "xai/grok-4.20-non-reasoning",
+      "grok-4.20-0309-reasoning",
+      "grok-4.20-multi-agent-0309",
+      "xai.grok-4.3",
+      "grok-build-0.1",
+    ]],
+    ["Grok 4.5 tokenizer", ["x-ai/grok-4.5"]],
+  ] as const;
+
+  for (const [label, ids] of families) {
+    for (const id of ids) {
+      assert.equal(resolveHeuristic(model("relay", id, "openai-completions"), {}).label, label, id);
+    }
+  }
+});
+
+test("dynamic selectors and unverified sibling models keep the fallback tokenizer", () => {
+  for (const current of [
+    model("openrouter", "~moonshotai/kimi-latest", "openai-completions"),
+    model("openrouter", "~x-ai/grok-latest", "openai-completions"),
+    model("radius", "auto", "pi-messages"),
+    model("openrouter", "free", "openai-completions"),
+    model("fireworks", "k3", "anthropic-messages"),
+    model("openrouter", "z-ai/glm-4.7-flashx", "openai-completions"),
+    model("zai", "glm-5-turbo", "openai-completions"),
+    model("zai", "glm-5v-turbo", "openai-completions"),
+    model("openrouter", "z-ai/glm-5.3", "openai-completions"),
+    model("openrouter", "cohere/command-r", "openai-completions"),
+    model("vercel-ai-gateway", "xai/grok-4.20-reasoning-beta", "anthropic-messages"),
+    model("xai", "grok-build-latest", "openai-completions"),
+    model("openrouter", "x-ai/grok-4.6", "openai-completions"),
+  ]) {
+    const heuristic = resolveHeuristic(current, {});
+    assert.equal(heuristic.label, "fallback chars/4", `${current.provider}/${current.id}`);
+    assert.equal(heuristic.textDenominator, 4, `${current.provider}/${current.id}`);
+    assert.equal(heuristic.sessionDenominator, 4, `${current.provider}/${current.id}`);
+  }
+
+  const selector = resolveHeuristic(model("openrouter", "free", "openai-completions"), {});
+  assert.equal(selector.toolNumerator, "openai-chat");
+});
+
 test("wire compatibility does not select a tokenizer family", () => {
   for (const compatible of [
-    model("kimi-coding", "kimi-k3", "anthropic-messages"),
+    model("kimi-coding", "unknown-coding-model", "anthropic-messages"),
     model("minimax", "MiniMax-M2.7", "anthropic-messages"),
     model("vercel-ai-gateway", "alibaba/qwen-3.5-plus", "anthropic-messages"),
   ]) {
@@ -120,7 +249,7 @@ test("precedence: defaults < built-in rule < config rules, in rule order", () =>
   assert.equal(resolveHeuristic(anthropicModel, config).textDenominator, 2.6);
   // ...but defaults apply when no tokenizer profile matches.
   assert.equal(resolveHeuristic(undefined, config).textDenominator, 9);
-  assert.equal(resolveHeuristic(model("kimi-coding", "kimi-k3", "anthropic-messages"), config).textDenominator, 9);
+  assert.equal(resolveHeuristic(model("kimi-coding", "kimi-latest", "anthropic-messages"), config).textDenominator, 9);
   assert.equal(resolveHeuristic(model("ollama", "llama-4", "llama-local-api"), config).textDenominator, 9);
 
   // Config rules override built-in rules; later rules override earlier ones.

--- a/tests/contextimate/provider-check.test.ts
+++ b/tests/contextimate/provider-check.test.ts
@@ -6,6 +6,7 @@ import {
   buildAnthropicRequests,
   buildBedrockFullRequest,
   buildBedrockRequests,
+  buildCohereRequests,
   buildGoogleFullRequest,
   buildGoogleRequests,
   buildKimiRequests,
@@ -16,6 +17,7 @@ import {
   detectPayloadKind,
   geminiCountUrl,
   parsePayloadFile,
+  PROVIDERS,
   summarizeCounts,
   vertexCountRequest,
 } from "../../scripts/contextimate/provider-token-counts.ts";
@@ -150,7 +152,7 @@ test("Google count requests translate Pi SDK parameters", () => {
   assert.match(vertexCountRequest(vertexBody, "project", "eu").url, /^https:\/\/aiplatform\.eu\.rep\.googleapis\.com\//);
 });
 
-test("Bedrock, Kimi and Z.AI builders match their count APIs", () => {
+test("Bedrock, Kimi, Cohere and Z.AI builders match their count APIs", () => {
   const bedrock = {
     modelId: "amazon.nova-2-lite-v1:0",
     messages: [{ role: "user", content: [{ text: "real" }] }],
@@ -182,7 +184,57 @@ test("Bedrock, Kimi and Z.AI builders match their count APIs", () => {
   const kimi = rowsById(buildKimiRequests({ ...chat, model: "kimi-k3" }));
   assert.deepEqual(kimi.system.body.messages, [chat.messages[0], { role: "user", content: "hi" }]);
   assert.equal(kimi.tools, undefined);
+
+  const cohere = buildCohereRequests({
+    ...chat,
+    messages: [
+      { role: "system", content: [{ type: "text", text: "first" }, { type: "text", text: " second" }] },
+      { role: "system", content: "third" },
+      chat.messages[1],
+    ],
+  }, { model: "command-r-08-2024" });
+  assert.deepEqual(cohere, [{
+    id: "system",
+    label: "raw system text",
+    body: { model: "command-r-08-2024", text: "first second\nthird" },
+    chars: 18,
+  }]);
+  assert.throws(
+    () => buildCohereRequests({ model: "command-r-08-2024", messages: [{ role: "user", content: "hi" }] }),
+    /no system message text/,
+  );
+
   assert.deepEqual(rowsById(buildZaiRequests(chat))["tool:ping"].body.tools, chat.tools);
+});
+
+test("Cohere live counting validates the raw tokenizer response", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.COHERE_API_KEY;
+  process.env.COHERE_API_KEY = "fixture-key";
+  let malformed = false;
+  globalThis.fetch = async (input, init) => {
+    assert.equal(String(input), "https://api.cohere.com/v1/tokenize");
+    assert.equal(init?.method, "POST");
+    assert.deepEqual(init?.headers, {
+      "content-type": "application/json",
+      authorization: "Bearer fixture-key",
+    });
+    assert.equal(init?.body, JSON.stringify({ model: "command-r-08-2024", text: "system" }));
+    return Response.json(malformed ? { tokens: [1, "bad"] } : { tokens: [1, 2, 3] });
+  };
+
+  try {
+    assert.equal(await PROVIDERS.cohere.execute({ model: "command-r-08-2024", text: "system" }), 3);
+    malformed = true;
+    await assert.rejects(
+      PROVIDERS.cohere.execute({ model: "command-r-08-2024", text: "system" }),
+      /no numeric tokens array/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.COHERE_API_KEY;
+    else process.env.COHERE_API_KEY = originalKey;
+  }
 });
 
 test("summary removes the shared tool-block overhead", () => {


### PR DESCRIPTION
## Summary

- add conservative raw-text profiles for Kimi K2 to K3, 2 GLM tokenizer generations, Cohere Command R and North Mini Code, and 2 Grok tokenizer generations
- keep tokenizer family independent from provider route and wire/tool serialization
- add Cohere raw-text counting plus reproducible open-tokenizer and xAI token-stream studies
- check in source-free evidence with exact artifact revisions, hashes, token counts, xAI aliases and token-stream digests

Dynamic aliases, GLM Turbo/vision variants without matching artifacts, and beta Grok routes stay on the fallback.

## Evidence

- Kimi K2 to K3 share the same rank and preprocessing hashes
- GLM 4.5-family and GLM 5-family members have exact, distinct tokenizer hashes
- Command R and R+ share the same ordinary-text BPE core; North Mini Code is separate
- xAI `TokenizeText` grouped Grok 4.20 variants, 4.3 and Build 0.1 together; Grok 4.5 is distinct
- 78 exploratory OpenRouter requests across 26 models cost about $0.1215; hosted generation did not define the profiles

## Verification

- `npm run check` (330 tests)
- `npm run test:smoke`
- focused Contextimate tests
- pinned open-tokenizer study reproduced the checked-in profile values
- live xAI default, alias and Contextimate-corpus studies
- packed-package install and xAI offline self-test
