### PR TITLE
Contextimate: trim calibration scaffolding

### DIFF
--- a/docs/contextimate-family-calibration-evidence-2026-08-05.json
+++ b/docs/contextimate-family-calibration-evidence-2026-08-05.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "studyDate": "2026-08-05",
   "purpose": "Evidence behind Contextimate raw-text tokenizer families and divisors. No source text or credentials.",
   "openTokenizers": {
@@ -407,187 +406,54 @@
         "resolvedModels": [
           "grok-4.20-0309-reasoning"
         ],
-        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
-        "samples": [
-          {
-            "fixture": "ascii",
-            "chars": 88,
-            "tokens": 29,
-            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
-          },
-          {
-            "fixture": "code",
-            "chars": 124,
-            "tokens": 38,
-            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
-          },
-          {
-            "fixture": "controls",
-            "chars": 79,
-            "tokens": 29,
-            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
-          },
-          {
-            "fixture": "multilingual",
-            "chars": 95,
-            "tokens": 35,
-            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
-          },
-          {
-            "fixture": "random-ascii-4096",
-            "chars": 4096,
-            "tokens": 2848,
-            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
-          },
-          {
-            "fixture": "whitespace",
-            "chars": 65,
-            "tokens": 25,
-            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
-          }
-        ]
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7"
       },
       {
         "requestedModel": "grok-4.20-0309-non-reasoning",
         "resolvedModels": [
           "grok-4.20-0309-non-reasoning"
         ],
-        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
-        "samples": [
-          {
-            "fixture": "ascii",
-            "chars": 88,
-            "tokens": 29,
-            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
-          },
-          {
-            "fixture": "code",
-            "chars": 124,
-            "tokens": 38,
-            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
-          },
-          {
-            "fixture": "controls",
-            "chars": 79,
-            "tokens": 29,
-            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
-          },
-          {
-            "fixture": "multilingual",
-            "chars": 95,
-            "tokens": 35,
-            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
-          },
-          {
-            "fixture": "random-ascii-4096",
-            "chars": 4096,
-            "tokens": 2848,
-            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
-          },
-          {
-            "fixture": "whitespace",
-            "chars": 65,
-            "tokens": 25,
-            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
-          }
-        ]
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7"
       },
       {
         "requestedModel": "grok-4.20-multi-agent",
         "resolvedModels": [
           "grok-4.20-multi-agent-0309"
         ],
-        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
-        "samples": [
-          {
-            "fixture": "ascii",
-            "chars": 88,
-            "tokens": 29,
-            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
-          },
-          {
-            "fixture": "code",
-            "chars": 124,
-            "tokens": 38,
-            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
-          },
-          {
-            "fixture": "controls",
-            "chars": 79,
-            "tokens": 29,
-            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
-          },
-          {
-            "fixture": "multilingual",
-            "chars": 95,
-            "tokens": 35,
-            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
-          },
-          {
-            "fixture": "random-ascii-4096",
-            "chars": 4096,
-            "tokens": 2848,
-            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
-          },
-          {
-            "fixture": "whitespace",
-            "chars": 65,
-            "tokens": 25,
-            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
-          }
-        ]
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7"
       },
       {
         "requestedModel": "grok-4.3",
         "resolvedModels": [
           "grok-4.3"
         ],
-        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
-        "samples": [
-          {
-            "fixture": "ascii",
-            "chars": 88,
-            "tokens": 29,
-            "digest": "50f7be3af3d98d3681cd2c38abff469b96a3e41e0bafd30a786e742349f99a2b"
-          },
-          {
-            "fixture": "code",
-            "chars": 124,
-            "tokens": 38,
-            "digest": "2116e4b10cac86c8162a1761869afebf77808cd50c39077937acd3b767bb1ad4"
-          },
-          {
-            "fixture": "controls",
-            "chars": 79,
-            "tokens": 29,
-            "digest": "537cec32879bb1d916575b8bd1912b5047b53483c0379e0d7d1e96fb9d1288c9"
-          },
-          {
-            "fixture": "multilingual",
-            "chars": 95,
-            "tokens": 35,
-            "digest": "aaeff9f916380a6a1c8ced749f9a69a6b67ad626aa0c6a7334b020bd6edc18fa"
-          },
-          {
-            "fixture": "random-ascii-4096",
-            "chars": 4096,
-            "tokens": 2848,
-            "digest": "3fb386f7cd57aa74ea0812740bd7e6802f255c12f066945818891fbaafaa582a"
-          },
-          {
-            "fixture": "whitespace",
-            "chars": 65,
-            "tokens": 25,
-            "digest": "20182f7d8b130705deba7bb17df1606521873aeb55098015e1f35b7ea1e28855"
-          }
-        ]
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7"
       },
       {
         "requestedModel": "grok-build-0.1",
         "resolvedModels": [
           "grok-build-0.1"
         ],
+        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7"
+      },
+      {
+        "requestedModel": "grok-4.5",
+        "resolvedModels": [
+          "grok-4.5"
+        ],
+        "fingerprint": "f892196825e9e0e9cb782d8b18502de6e97c561a034a89ad256f0bb2f3b9a6a3"
+      }
+    ],
+    "groups": [
+      {
         "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
+        "models": [
+          "grok-4.20-0309-reasoning",
+          "grok-4.20-0309-non-reasoning",
+          "grok-4.20-multi-agent",
+          "grok-4.3",
+          "grok-build-0.1"
+        ],
         "samples": [
           {
             "fixture": "ascii",
@@ -628,11 +494,10 @@
         ]
       },
       {
-        "requestedModel": "grok-4.5",
-        "resolvedModels": [
+        "fingerprint": "f892196825e9e0e9cb782d8b18502de6e97c561a034a89ad256f0bb2f3b9a6a3",
+        "models": [
           "grok-4.5"
         ],
-        "fingerprint": "f892196825e9e0e9cb782d8b18502de6e97c561a034a89ad256f0bb2f3b9a6a3",
         "samples": [
           {
             "fixture": "ascii",
@@ -670,24 +535,6 @@
             "tokens": 28,
             "digest": "1fce01d76aa14a902c4909de7784fffb55dd547121c2ed24f86ff2b2073da2ed"
           }
-        ]
-      }
-    ],
-    "groups": [
-      {
-        "fingerprint": "6b272011725749c3a0036f41d41febec981f3112ca619793f5a5ba56091f43f7",
-        "models": [
-          "grok-4.20-0309-reasoning",
-          "grok-4.20-0309-non-reasoning",
-          "grok-4.20-multi-agent",
-          "grok-4.3",
-          "grok-build-0.1"
-        ]
-      },
-      {
-        "fingerprint": "f892196825e9e0e9cb782d8b18502de6e97c561a034a89ad256f0bb2f3b9a6a3",
-        "models": [
-          "grok-4.5"
         ]
       }
     ]

--- a/docs/pi-contextimate.md
+++ b/docs/pi-contextimate.md
@@ -47,9 +47,7 @@ A second study on 5 August 2026 covered Kimi, GLM, Cohere and Grok. It counted 5
 | Grok 4.20 variants, 4.3 and Build 0.1 | 4.2 | 3.9 |
 | Grok 4.5 | 4.1 | 3.6 |
 
-These profiles cover visible text only. Kimi versions share one base rank file but use different control vocabularies. GLM has two proven tokenizer generations. Command R and R+ share ordinary-text merges, but some special tokens differ.
-
-Exact xAI fingerprints put Grok 4.20 reasoning, non-reasoning and multi-agent, 4.3 and Build 0.1 together. Grok 4.5 is separate. Dynamic aliases and unverified GLM Turbo variants use the fallback until routing identifies a concrete model. The [tokenizer coverage audit](./contextimate-tokenizer-coverage-audit-2026-08-05.md) contains the full evidence.
+These profiles cover visible text only. Dynamic aliases and unverified GLM Turbo variants use the fallback until routing identifies a concrete model. The [tokenizer coverage audit](./contextimate-tokenizer-coverage-audit-2026-08-05.md) contains the tokenizer hashes, xAI fingerprints and family boundaries.
 
 ## Tool schemas
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -252,21 +252,6 @@ model call required:
   documented manual step in the publish checklist, not a script dependency on provider
   auth.
 
-## Acceptance tests for the queued work
-
-Designed now so the features land with their proofs:
-
-- **#9 (system-prompt row clarity):** golden diff shows the renamed row + method caveat
-  in all three views; unit test that the section id stays `"system"` (config/signature
-  compat) while the title changes.
-- **#8 (provider token check):** the checker is a script (`scripts/contextimate/
-  check-provider-tokens.ts`) whose request builders are pure and unit-tested against current
-  Pi payload shapes and provider count schemas. The Cohere executor is tested with a mocked
-  response. The separate xAI Python checker has an offline fingerprint self-test. Network
-  execution is manual; tests never call providers.
-- **#7 (click UX decision):** resolved by removal; click-to-expand shipped, proved
-  unusable in practice, and was deleted (v0.5.18). Ctrl+T is the whole surface.
-
 ## What "passing" means
 
 `npm test` green on a machine with the current Pi installed means: our assumptions about

--- a/extensions/_lib/heuristics.ts
+++ b/extensions/_lib/heuristics.ts
@@ -98,7 +98,7 @@ const CLAUDE_GENERIC: TokenizerProfile = {
   textDenominator: 3.5,
   sessionDenominator: 3.5,
 };
-const KIMI_RAW: TokenizerProfile = {
+const KIMI: TokenizerProfile = {
   label: "Kimi tokenizer",
   textDenominator: 4.1,
   sessionDenominator: 3.8,
@@ -138,12 +138,6 @@ function isClaudeModel(model: ModelSummary): boolean {
   return model.provider.toLowerCase().includes("anthropic") || model.id.toLowerCase().includes("claude");
 }
 
-function isKimiModel(model: ModelSummary, id: string): boolean {
-  if (KIMI_MODEL.test(id)) return true;
-  if (model.provider.toLowerCase() !== "kimi-coding") return false;
-  return /^(?:k3(?:-256k)?|kimi-for-coding(?:-highspeed)?)$/.test(id);
-}
-
 function tokenizerProfile(model: ModelSummary): TokenizerProfile | undefined {
   const id = model.id.toLowerCase();
   if (isClaudeModel(model)) {
@@ -151,7 +145,9 @@ function tokenizerProfile(model: ModelSummary): TokenizerProfile | undefined {
     if (CLAUDE_45_46_MODEL.test(id)) return CLAUDE_45_46;
     return CLAUDE_GENERIC;
   }
-  if (isKimiModel(model, id)) return KIMI_RAW;
+  const kimiCoding = model.provider.toLowerCase() === "kimi-coding"
+    && /^(?:k3(?:-256k)?|kimi-for-coding(?:-highspeed)?)$/.test(id);
+  if (KIMI_MODEL.test(id) || kimiCoding) return KIMI;
   if (GLM_5_MODEL.test(id)) return GLM_5;
   if (GLM_45_MODEL.test(id)) return GLM_45;
   if (COMMAND_R_MODEL.test(id)) return COMMAND_R;

--- a/scripts/contextimate/check-xai-tokenizers.py
+++ b/scripts/contextimate/check-xai-tokenizers.py
@@ -10,19 +10,14 @@ import json
 import os
 import random
 import string
-import subprocess
 import sys
 import time
 from collections.abc import Iterable, Sequence
 from importlib.metadata import version
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Protocol
 
 sys.dont_write_bytecode = True
-SCRIPT_DIR = Path(__file__).resolve().parent
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
 
 from tokenizer_corpus import CORPUS_REVISION, pinned_corpus
 
@@ -120,44 +115,42 @@ def api_key() -> str:
         entry = json.loads(auth_path.read_text()).get("xai")
     except (OSError, json.JSONDecodeError) as error:
         raise RuntimeError("set XAI_API_KEY or sign in to xAI through Pi") from error
-    if not isinstance(entry, dict) or not isinstance(entry.get("access"), str):
-        raise RuntimeError("set XAI_API_KEY or sign in to xAI through Pi")
-    expires = entry.get("expires")
-    if isinstance(expires, (int, float)) and expires <= time.time() * 1000:
-        raise RuntimeError("the Pi xAI login has expired; refresh it in Pi")
-    return entry["access"]
+    if isinstance(entry, dict) and isinstance(entry.get("access"), str):
+        expires = entry.get("expires")
+        if isinstance(expires, (int, float)) and expires <= time.time() * 1000:
+            raise RuntimeError("the Pi xAI login has expired; refresh it in Pi")
+        return entry["access"]
+    raise RuntimeError("set XAI_API_KEY or sign in to xAI through Pi")
 
 
-def token_error(error: Exception) -> str:
-    code = getattr(error, "code", None)
-    if callable(code):
-        status = code()
-        return f"{type(error).__name__}: {getattr(status, 'name', str(status))}"
-    return type(error).__name__
-
-
-def tokenize(
+def tokenize_with_resolved_model(
     client: object, model: str, text: str, retries: int
-) -> tuple[str, Sequence[object]]:
-    # The public helper returns only tokens. The pinned SDK's generated stub keeps the
-    # resolved model, which is required to distinguish stable model IDs from aliases.
+) -> tuple[str, Sequence[TokenRecord]]:
     from xai_sdk.proto import tokenize_pb2
 
-    token_client = client.tokenize
-    stub = getattr(token_client, "_stub", None)
+    stub = getattr(client.tokenize, "_stub", None)
     if stub is None or not hasattr(stub, "TokenizeText"):
         raise RuntimeError("the pinned xai-sdk TokenizeText contract has changed")
-    for attempt in range(retries + 1):
+    attempts_left = retries
+    while True:
         try:
             response = stub.TokenizeText(
                 tokenize_pb2.TokenizeTextRequest(text=text, model=model)
             )
             return response.model, response.tokens
         except Exception as error:
-            if "RESOURCE_EXHAUSTED" not in str(error) or attempt == retries:
-                raise RuntimeError(token_error(error)) from error
+            if "RESOURCE_EXHAUSTED" not in str(error) or attempts_left == 0:
+                code = getattr(error, "code", None)
+                status = code() if callable(code) else None
+                detail = getattr(status, "name", str(status)) if status else None
+                message = (
+                    f"{type(error).__name__}: {detail}"
+                    if detail
+                    else type(error).__name__
+                )
+                raise RuntimeError(message) from error
+            attempts_left -= 1
             time.sleep(15)
-    raise RuntimeError("unreachable TokenizeText retry state")
 
 
 def parse_args() -> argparse.Namespace:
@@ -189,29 +182,11 @@ def parse_args() -> argparse.Namespace:
         default=4,
         help="rate-limit retries per call (default: 4)",
     )
-    parser.add_argument(
-        "--self-test",
-        action="store_true",
-        help="test fingerprinting without xAI or xai-sdk",
-    )
     return parser.parse_args()
-
-
-def self_test() -> None:
-    first = [SimpleNamespace(token_id=1, string_token="a", token_bytes=b"a")]
-    same = [SimpleNamespace(token_id=1, string_token="a", token_bytes=b"a")]
-    changed = [SimpleNamespace(token_id=2, string_token="a", token_bytes=b"a")]
-    assert canonical_token_digest(first) == canonical_token_digest(same)
-    assert canonical_token_digest(first) != canonical_token_digest(changed)
-    assert len(fingerprint_fixtures()["random-ascii-4096"]) == 4096
-    print("xAI tokenizer fingerprint self-test passed")
 
 
 def main() -> None:
     args = parse_args()
-    if args.self_test:
-        self_test()
-        return
     if args.retries < 0:
         raise RuntimeError("--retries must be non-negative")
 
@@ -235,11 +210,12 @@ def main() -> None:
 
     client = Client(api_key=api_key())
     rows: list[dict[str, object]] = []
+    groups: dict[str, dict[str, object]] = {}
     for requested_model in args.models or DEFAULT_MODELS:
         samples: list[dict[str, object]] = []
         resolved_models: set[str] = set()
         for fixture, text in fixtures.items():
-            resolved_model, tokens = tokenize(
+            resolved_model, tokens = tokenize_with_resolved_model(
                 client, requested_model, text, args.retries
             )
             resolved_models.add(resolved_model)
@@ -256,17 +232,16 @@ def main() -> None:
             "requestedModel": requested_model,
             "resolvedModels": sorted(resolved_models),
             "fingerprint": combined_digest(samples),
-            "samples": samples,
         }
         if args.contextimate_corpus:
             row["contextimateProfile"] = contextimate_profile(samples)
         rows.append(row)
-
-    groups: dict[str, list[str]] = {}
-    for row in rows:
-        groups.setdefault(str(row["fingerprint"]), []).append(
-            str(row["requestedModel"])
+        fingerprint = str(row["fingerprint"])
+        group = groups.setdefault(
+            fingerprint,
+            {"fingerprint": fingerprint, "models": [], "samples": samples},
         )
+        group["models"].append(requested_model)
     result = {
         "corpusVersion": "2026-08-05.1",
         "corpus": [
@@ -283,9 +258,7 @@ def main() -> None:
         "pythonVersion": sys.version.split()[0],
         "xaiSdkVersion": version("xai-sdk"),
         "models": rows,
-        "groups": [
-            {"fingerprint": key, "models": models} for key, models in groups.items()
-        ],
+        "groups": list(groups.values()),
     }
     if args.json:
         print(json.dumps(result, indent=2, ensure_ascii=False))
@@ -305,11 +278,6 @@ def main() -> None:
 if __name__ == "__main__":
     try:
         main()
-    except (
-        OSError,
-        RuntimeError,
-        UnicodeError,
-        subprocess.CalledProcessError,
-    ) as error:
+    except (OSError, RuntimeError, UnicodeError) as error:
         print(str(error), file=sys.stderr)
         raise SystemExit(1)

--- a/scripts/contextimate/study-open-tokenizers.py
+++ b/scripts/contextimate/study-open-tokenizers.py
@@ -13,12 +13,8 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from importlib.metadata import version
 from importlib.util import find_spec
-from pathlib import Path
 
 sys.dont_write_bytecode = True
-SCRIPT_DIR = Path(__file__).resolve().parent
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
 
 from tokenizer_corpus import CORPUS_FILES, CORPUS_REVISION, pinned_corpus
 
@@ -46,18 +42,6 @@ GLM_5_HASH = "19e773648cb4e65de8660ea6365e10acca112d42a854923df93db4a6f333a82d"
 COMMAND_CORE_HASH = "2bcc46184ba3b57d82c76cdeb373c32e65cb570633a7237e1b01c175faf3758e"
 KIMI_CONFIG_HASH = "12fcab43d2b6068f46769f5ff373960bf7c17a94d7abbc50e2491306b2f6cf58"
 KIMI_PATTERN_HASH = "de5781783b193d5ccf5b1b28edfa70fa816ce78d54603fdc422cfd8d4ea4411f"
-KIMI_PATTERN = "|".join(
-    [
-        r"[\p{Han}]+",
-        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?",
-        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?",
-        r"\p{N}{1,3}",
-        r" ?[^\s\p{L}\p{N}]+[\r\n]*",
-        r"\s*[\r\n]+",
-        r"\s+(?!\S)",
-        r"\s+",
-    ]
-)
 
 TOKENIZERS = [
     TokenizerSpec(
@@ -297,11 +281,12 @@ def load_encoder(
         revision=spec.representative.revision,
     )
     if spec.representative.filename == "tiktoken.model":
-        local_pattern_hash = hashlib.sha256(KIMI_PATTERN.encode()).hexdigest()
-        if local_pattern_hash != KIMI_PATTERN_HASH:
-            raise RuntimeError(
-                f"local Kimi tokenizer pattern changed: {local_pattern_hash}"
-            )
+        source = hf_hub_download(
+            spec.representative.repository,
+            "tokenization_kimi.py",
+            revision=spec.representative.revision,
+        )
+        pattern = extract_kimi_pattern(source)
         config = hf_hub_download(
             spec.representative.repository,
             "tokenizer_config.json",
@@ -325,7 +310,7 @@ def load_encoder(
         }
         encoding = tiktoken.Encoding(
             name="kimi-contextimate-calibration",
-            pat_str=KIMI_PATTERN,
+            pat_str=pattern,
             mergeable_ranks=ranks,
             special_tokens=special,
         )

--- a/scripts/contextimate/tokenizer_corpus.py
+++ b/scripts/contextimate/tokenizer_corpus.py
@@ -22,18 +22,16 @@ CORPUS_FILES = {
 }
 
 
-def pinned_file(path: str) -> str:
-    result = subprocess.run(
-        ["git", "-C", str(ROOT), "show", f"{CORPUS_REVISION}:{path}"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout
-
-
 def pinned_corpus() -> dict[str, str]:
+    def read(path: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(ROOT), "show", f"{CORPUS_REVISION}:{path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
     return {
-        name: "\n".join(pinned_file(path) for path in files)
+        name: "\n".join(read(path) for path in files)
         for name, files in CORPUS_FILES.items()
     }

--- a/tests/contextimate/heuristics.test.ts
+++ b/tests/contextimate/heuristics.test.ts
@@ -87,65 +87,19 @@ test("Claude profiles follow the model through supported routes", () => {
   assert.equal(radius.toolDenominator, 4);
 });
 
-test("measured tokenizer families follow concrete models through serving routes", () => {
-  const cases: Array<[ModelSummary, string, number, number]> = [
-    [model("moonshotai", "kimi-k2-0905-preview", "openai-completions"), "Kimi tokenizer", 4.1, 3.8],
-    [model("fireworks", "accounts/fireworks/routers/kimi-k2p6-fast", "anthropic-messages"), "Kimi tokenizer", 4.1, 3.8],
-    [model("kimi-coding", "k3-256k", "anthropic-messages"), "Kimi tokenizer", 4.1, 3.8],
-    [model("kimi-coding", "kimi-for-coding-highspeed", "anthropic-messages"), "Kimi tokenizer", 4.1, 3.8],
-    [model("amazon-bedrock", "moonshot.kimi-k2-thinking", "bedrock-converse-stream"), "Kimi tokenizer", 4.1, 3.8],
-    [model("openrouter", "z-ai/glm-4.5v", "openai-completions"), "GLM 4.5 tokenizer", 4, 3.9],
-    [model("vercel-ai-gateway", "zai/glm-4.6v-flash", "anthropic-messages"), "GLM 4.5 tokenizer", 4, 3.9],
-    [model("amazon-bedrock", "zai.glm-4.7", "bedrock-converse-stream"), "GLM 4.5 tokenizer", 4, 3.9],
-    [model("openrouter", "z-ai/glm-4.7-flash", "openai-completions"), "GLM 5 tokenizer", 4, 3.9],
-    [model("fireworks", "accounts/fireworks/routers/glm-5p2-fast", "openai-completions"), "GLM 5 tokenizer", 4, 3.9],
-    [model("huggingface", "zai-org/GLM-5.1", "openai-completions"), "GLM 5 tokenizer", 4, 3.9],
-    [model("openrouter", "cohere/command-r-plus-08-2024", "openai-completions"), "Command R tokenizer", 4, 3.4],
-    [model("openrouter", "cohere/north-mini-code:free", "openai-completions"), "North Mini Code tokenizer", 4.2, 3.9],
-    [model("opencode", "north-mini-code-free", "openai-completions"), "North Mini Code tokenizer", 4.2, 3.9],
-    [model("xai", "grok-4.3", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
-    [model("openrouter", "x-ai/grok-4.20", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
-    [model("xai", "grok-4.20-0309-non-reasoning", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
-    [model("vercel-ai-gateway", "xai/grok-4.20-multi-agent", "anthropic-messages"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
-    [model("xai", "grok-4.20-multi-agent-0309", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
-    [model("opencode", "grok-build-0.1", "openai-completions"), "Grok 4.20/4.3 tokenizer", 4.2, 3.9],
-    [model("xai", "grok-4.5", "openai-responses"), "Grok 4.5 tokenizer", 4.1, 3.6],
-  ];
-
-  for (const [current, label, textDenominator, sessionDenominator] of cases) {
-    const heuristic = resolveHeuristic(current, {});
-    assert.equal(heuristic.label, label, `${current.provider}/${current.id}`);
-    assert.equal(heuristic.textDenominator, textDenominator, `${current.provider}/${current.id}`);
-    assert.equal(heuristic.sessionDenominator, sessionDenominator, `${current.provider}/${current.id}`);
-  }
-
-  const relayedKimi = resolveHeuristic(
-    model("fireworks", "accounts/fireworks/routers/kimi-k2p6-fast", "anthropic-messages"),
-    {},
-  );
-  assert.equal(relayedKimi.toolNumerator, "anthropic");
-  assert.equal(relayedKimi.toolDenominator, 4);
-  const bedrockGlm = resolveHeuristic(model("amazon-bedrock", "zai.glm-4.7", "bedrock-converse-stream"), {});
-  assert.equal(bedrockGlm.toolNumerator, "bedrock");
-  const directGrok45 = resolveHeuristic(model("xai", "grok-4.5", "openai-responses"), {});
-  assert.equal(directGrok45.toolNumerator, "openai-responses");
-});
-
-test("published tokenizer siblings stay inside their measured family boundary", () => {
+test("measured tokenizer families match their published model IDs", () => {
   const families = [
-    ["Kimi tokenizer", [
+    ["Kimi tokenizer", 4.1, 3.8, [
       "moonshotai/kimi-k2",
-      "moonshotai/kimi-k2-0711-preview",
-      "moonshotai/kimi-k2-0905",
+      "moonshotai/kimi-k2-0905-preview",
       "moonshotai/kimi-k2-thinking-turbo",
       "moonshotai/kimi-k2.5",
       "@cf/moonshotai/kimi-k2.6",
       "moonshotai/kimi-k2.7-code-highspeed",
-      "accounts/fireworks/models/kimi-k2p6",
       "accounts/fireworks/routers/kimi-k2p7-code-fast",
       "moonshotai/kimi-k3-fast",
     ]],
-    ["GLM 4.5 tokenizer", [
+    ["GLM 4.5 tokenizer", 4, 3.9, [
       "z-ai/glm-4.5",
       "z-ai/glm-4.5-air",
       "z-ai/glm-4.5v",
@@ -154,24 +108,23 @@ test("published tokenizer siblings stay inside their measured family boundary", 
       "z-ai/glm-4.6v-flash",
       "zai-glm-4.7",
     ]],
-    ["GLM 5 tokenizer", [
+    ["GLM 5 tokenizer", 4, 3.9, [
       "z-ai/glm-4.7-flash",
       "z-ai/glm-5",
       "z-ai/glm-5.1",
       "zai-org/glm-5.2",
-      "accounts/fireworks/models/glm-5p2",
       "accounts/fireworks/routers/glm-5p2-fast",
     ]],
-    ["Command R tokenizer", [
+    ["Command R tokenizer", 4, 3.4, [
       "cohere/command-r-08-2024",
       "cohere/command-r-plus-08-2024",
     ]],
-    ["North Mini Code tokenizer", [
+    ["North Mini Code tokenizer", 4.2, 3.9, [
       "cohere/north-mini-code:free",
       "north-mini-code-free",
       "coherelabs/north-mini-code-1.0",
     ]],
-    ["Grok 4.20/4.3 tokenizer", [
+    ["Grok 4.20/4.3 tokenizer", 4.2, 3.9, [
       "x-ai/grok-4.20",
       "xai/grok-4.20-reasoning",
       "xai/grok-4.20-non-reasoning",
@@ -180,40 +133,51 @@ test("published tokenizer siblings stay inside their measured family boundary", 
       "xai.grok-4.3",
       "grok-build-0.1",
     ]],
-    ["Grok 4.5 tokenizer", ["x-ai/grok-4.5"]],
+    ["Grok 4.5 tokenizer", 4.1, 3.6, ["x-ai/grok-4.5"]],
   ] as const;
 
-  for (const [label, ids] of families) {
+  for (const [label, textDenominator, sessionDenominator, ids] of families) {
     for (const id of ids) {
-      assert.equal(resolveHeuristic(model("relay", id, "openai-completions"), {}).label, label, id);
+      const heuristic = resolveHeuristic(model("relay", id, "openai-completions"), {});
+      assert.equal(heuristic.label, label, id);
+      assert.equal(heuristic.textDenominator, textDenominator, id);
+      assert.equal(heuristic.sessionDenominator, sessionDenominator, id);
     }
   }
 });
 
-test("dynamic selectors and unverified sibling models keep the fallback tokenizer", () => {
+test("measured tokenizer families remain independent of their wire API", () => {
+  const cases = [
+    [model("kimi-coding", "k3-256k", "anthropic-messages"), "Kimi tokenizer", "anthropic"],
+    [model("amazon-bedrock", "zai.glm-4.7", "bedrock-converse-stream"), "GLM 4.5 tokenizer", "bedrock"],
+    [model("xai", "grok-4.5", "openai-responses"), "Grok 4.5 tokenizer", "openai-responses"],
+  ] as const;
+
+  for (const [current, label, toolNumerator] of cases) {
+    const heuristic = resolveHeuristic(current, {});
+    assert.equal(heuristic.label, label);
+    assert.equal(heuristic.toolNumerator, toolNumerator);
+  }
+});
+
+test("dynamic selectors and unverified variants keep the fallback tokenizer", () => {
   for (const current of [
     model("openrouter", "~moonshotai/kimi-latest", "openai-completions"),
     model("openrouter", "~x-ai/grok-latest", "openai-completions"),
     model("radius", "auto", "pi-messages"),
     model("openrouter", "free", "openai-completions"),
-    model("fireworks", "k3", "anthropic-messages"),
     model("openrouter", "z-ai/glm-4.7-flashx", "openai-completions"),
     model("zai", "glm-5-turbo", "openai-completions"),
     model("zai", "glm-5v-turbo", "openai-completions"),
-    model("openrouter", "z-ai/glm-5.3", "openai-completions"),
-    model("openrouter", "cohere/command-r", "openai-completions"),
     model("vercel-ai-gateway", "xai/grok-4.20-reasoning-beta", "anthropic-messages"),
     model("xai", "grok-build-latest", "openai-completions"),
-    model("openrouter", "x-ai/grok-4.6", "openai-completions"),
   ]) {
-    const heuristic = resolveHeuristic(current, {});
-    assert.equal(heuristic.label, "fallback chars/4", `${current.provider}/${current.id}`);
-    assert.equal(heuristic.textDenominator, 4, `${current.provider}/${current.id}`);
-    assert.equal(heuristic.sessionDenominator, 4, `${current.provider}/${current.id}`);
+    assert.equal(
+      resolveHeuristic(current, {}).label,
+      "fallback chars/4",
+      `${current.provider}/${current.id}`,
+    );
   }
-
-  const selector = resolveHeuristic(model("openrouter", "free", "openai-completions"), {});
-  assert.equal(selector.toolNumerator, "openai-chat");
 });
 
 test("wire compatibility does not select a tokenizer family", () => {

--- a/tests/contextimate/provider-check.test.ts
+++ b/tests/contextimate/provider-check.test.ts
@@ -207,34 +207,20 @@ test("Bedrock, Kimi, Cohere and Z.AI builders match their count APIs", () => {
   assert.deepEqual(rowsById(buildZaiRequests(chat))["tool:ping"].body.tools, chat.tools);
 });
 
-test("Cohere live counting validates the raw tokenizer response", async () => {
-  const originalFetch = globalThis.fetch;
+test("Cohere executor calls the tokenizer API", async (t) => {
   const originalKey = process.env.COHERE_API_KEY;
   process.env.COHERE_API_KEY = "fixture-key";
-  let malformed = false;
-  globalThis.fetch = async (input, init) => {
-    assert.equal(String(input), "https://api.cohere.com/v1/tokenize");
-    assert.equal(init?.method, "POST");
-    assert.deepEqual(init?.headers, {
-      "content-type": "application/json",
-      authorization: "Bearer fixture-key",
-    });
-    assert.equal(init?.body, JSON.stringify({ model: "command-r-08-2024", text: "system" }));
-    return Response.json(malformed ? { tokens: [1, "bad"] } : { tokens: [1, 2, 3] });
-  };
-
-  try {
-    assert.equal(await PROVIDERS.cohere.execute({ model: "command-r-08-2024", text: "system" }), 3);
-    malformed = true;
-    await assert.rejects(
-      PROVIDERS.cohere.execute({ model: "command-r-08-2024", text: "system" }),
-      /no numeric tokens array/,
-    );
-  } finally {
-    globalThis.fetch = originalFetch;
+  t.after(() => {
     if (originalKey === undefined) delete process.env.COHERE_API_KEY;
     else process.env.COHERE_API_KEY = originalKey;
-  }
+  });
+  t.mock.method(globalThis, "fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    assert.equal(String(input), "https://api.cohere.com/v1/tokenize");
+    assert.equal(init?.body, JSON.stringify({ model: "command-r-08-2024", text: "system" }));
+    return Response.json({ tokens: [1, 2, 3] });
+  });
+
+  assert.equal(await PROVIDERS.cohere.execute({ model: "command-r-08-2024", text: "system" }), 3);
 });
 
 test("summary removes the shared tool-block overhead", () => {


### PR DESCRIPTION
## Summary

- inline the one-use Kimi matcher and remove duplicated tokenizer-pattern data
- collapse overlapping model-route tests and remove speculative future-model cases
- remove the tautological xAI self-test and stale queued-work documentation
- store shared xAI samples once per fingerprint instead of once per model
- keep the real Cohere request contract test and all artifact, route and API-boundary checks

This removes 273 lines without changing Contextimate's runtime profiles or routing.

## Verification

- `npm run check` (330 tests)
- focused Contextimate tests
- pinned open-tokenizer evidence reproduced exactly
- live xAI same-family grouping reproduced fingerprint `6b2720117257…`
- Python format, lint, compilation and CLI help
- npm package contents checked
