### PR TITLE
Contextimate: verify relay tokenizer aliases

### DIFF
--- a/docs/contextimate-family-calibration-evidence-2026-08-05.json
+++ b/docs/contextimate-family-calibration-evidence-2026-08-05.json
@@ -1855,5 +1855,287 @@
         ]
       }
     ]
+  },
+  "relayAliasResolutions": {
+    "checkedAt": "2026-08-05",
+    "catalogs": [
+      {
+        "provider": "openrouter",
+        "endpoint": "https://openrouter.ai/api/v1/models",
+        "routes": [
+          {
+            "id": "deepseek/deepseek-chat-v3-0324",
+            "canonicalSlug": "deepseek/deepseek-chat-v3-0324",
+            "huggingFaceId": "deepseek-ai/DeepSeek-V3-0324"
+          },
+          {
+            "id": "deepseek/deepseek-chat-v3.1",
+            "canonicalSlug": "deepseek/deepseek-chat-v3.1",
+            "huggingFaceId": "deepseek-ai/DeepSeek-V3.1"
+          },
+          {
+            "id": "deepseek/deepseek-r1",
+            "canonicalSlug": "deepseek/deepseek-r1",
+            "huggingFaceId": "deepseek-ai/DeepSeek-R1"
+          },
+          {
+            "id": "deepseek/deepseek-r1-0528",
+            "canonicalSlug": "deepseek/deepseek-r1-0528",
+            "huggingFaceId": "deepseek-ai/DeepSeek-R1-0528"
+          },
+          {
+            "id": "deepseek/deepseek-v3.1-terminus",
+            "canonicalSlug": "deepseek/deepseek-v3.1-terminus",
+            "huggingFaceId": "deepseek-ai/DeepSeek-V3.1-Terminus"
+          },
+          {
+            "id": "deepseek/deepseek-v3.2",
+            "canonicalSlug": "deepseek/deepseek-v3.2-20251201",
+            "huggingFaceId": "deepseek-ai/DeepSeek-V3.2"
+          },
+          {
+            "id": "deepseek/deepseek-v3.2-exp",
+            "canonicalSlug": "deepseek/deepseek-v3.2-exp",
+            "huggingFaceId": "deepseek-ai/DeepSeek-V3.2-Exp"
+          },
+          {
+            "id": "deepseek/deepseek-v4-flash",
+            "canonicalSlug": "deepseek/deepseek-v4-flash-20260423",
+            "huggingFaceId": "deepseek-ai/DeepSeek-V4-Flash"
+          },
+          {
+            "id": "deepseek/deepseek-v4-pro",
+            "canonicalSlug": "deepseek/deepseek-v4-pro-20260423",
+            "huggingFaceId": "deepseek-ai/DeepSeek-V4-Pro"
+          },
+          {
+            "id": "qwen/qwen-2.5-72b-instruct",
+            "canonicalSlug": "qwen/qwen-2.5-72b-instruct",
+            "huggingFaceId": "Qwen/Qwen2.5-72B-Instruct"
+          },
+          {
+            "id": "qwen/qwen-2.5-7b-instruct",
+            "canonicalSlug": "qwen/qwen-2.5-7b-instruct",
+            "huggingFaceId": "Qwen/Qwen2.5-7B-Instruct"
+          },
+          {
+            "id": "qwen/qwen3-14b",
+            "canonicalSlug": "qwen/qwen3-14b-04-28",
+            "huggingFaceId": "Qwen/Qwen3-14B"
+          },
+          {
+            "id": "qwen/qwen3-235b-a22b",
+            "canonicalSlug": "qwen/qwen3-235b-a22b-04-28",
+            "huggingFaceId": "Qwen/Qwen3-235B-A22B"
+          },
+          {
+            "id": "qwen/qwen3-235b-a22b-2507",
+            "canonicalSlug": "qwen/qwen3-235b-a22b-07-25",
+            "huggingFaceId": "Qwen/Qwen3-235B-A22B-Instruct-2507"
+          },
+          {
+            "id": "qwen/qwen3-235b-a22b-thinking-2507",
+            "canonicalSlug": "qwen/qwen3-235b-a22b-thinking-2507",
+            "huggingFaceId": "Qwen/Qwen3-235B-A22B-Thinking-2507"
+          },
+          {
+            "id": "qwen/qwen3-30b-a3b",
+            "canonicalSlug": "qwen/qwen3-30b-a3b-04-28",
+            "huggingFaceId": "Qwen/Qwen3-30B-A3B"
+          },
+          {
+            "id": "qwen/qwen3-30b-a3b-instruct-2507",
+            "canonicalSlug": "qwen/qwen3-30b-a3b-instruct-2507",
+            "huggingFaceId": "Qwen/Qwen3-30B-A3B-Instruct-2507"
+          },
+          {
+            "id": "qwen/qwen3-30b-a3b-thinking-2507",
+            "canonicalSlug": "qwen/qwen3-30b-a3b-thinking-2507",
+            "huggingFaceId": "Qwen/Qwen3-30B-A3B-Thinking-2507"
+          },
+          {
+            "id": "qwen/qwen3-32b",
+            "canonicalSlug": "qwen/qwen3-32b-04-28",
+            "huggingFaceId": "Qwen/Qwen3-32B"
+          },
+          {
+            "id": "qwen/qwen3-8b",
+            "canonicalSlug": "qwen/qwen3-8b-04-28",
+            "huggingFaceId": "Qwen/Qwen3-8B"
+          },
+          {
+            "id": "qwen/qwen3-coder-30b-a3b-instruct",
+            "canonicalSlug": "qwen/qwen3-coder-30b-a3b-instruct",
+            "huggingFaceId": "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+          },
+          {
+            "id": "qwen/qwen3-coder-next",
+            "canonicalSlug": "qwen/qwen3-coder-next-2025-02-03",
+            "huggingFaceId": "Qwen/Qwen3-Coder-Next"
+          },
+          {
+            "id": "qwen/qwen3-next-80b-a3b-instruct",
+            "canonicalSlug": "qwen/qwen3-next-80b-a3b-instruct-2509",
+            "huggingFaceId": "Qwen/Qwen3-Next-80B-A3B-Instruct"
+          },
+          {
+            "id": "qwen/qwen3-next-80b-a3b-thinking",
+            "canonicalSlug": "qwen/qwen3-next-80b-a3b-thinking-2509",
+            "huggingFaceId": "Qwen/Qwen3-Next-80B-A3B-Thinking"
+          },
+          {
+            "id": "qwen/qwen3-vl-235b-a22b-instruct",
+            "canonicalSlug": "qwen/qwen3-vl-235b-a22b-instruct",
+            "huggingFaceId": "Qwen/Qwen3-VL-235B-A22B-Instruct"
+          },
+          {
+            "id": "qwen/qwen3-vl-235b-a22b-thinking",
+            "canonicalSlug": "qwen/qwen3-vl-235b-a22b-thinking",
+            "huggingFaceId": "Qwen/Qwen3-VL-235B-A22B-Thinking"
+          },
+          {
+            "id": "qwen/qwen3-vl-30b-a3b-instruct",
+            "canonicalSlug": "qwen/qwen3-vl-30b-a3b-instruct",
+            "huggingFaceId": "Qwen/Qwen3-VL-30B-A3B-Instruct"
+          },
+          {
+            "id": "qwen/qwen3-vl-30b-a3b-thinking",
+            "canonicalSlug": "qwen/qwen3-vl-30b-a3b-thinking",
+            "huggingFaceId": "Qwen/Qwen3-VL-30B-A3B-Thinking"
+          },
+          {
+            "id": "qwen/qwen3-vl-32b-instruct",
+            "canonicalSlug": "qwen/qwen3-vl-32b-instruct",
+            "huggingFaceId": "Qwen/Qwen3-VL-32B-Instruct"
+          },
+          {
+            "id": "qwen/qwen3-vl-8b-instruct",
+            "canonicalSlug": "qwen/qwen3-vl-8b-instruct",
+            "huggingFaceId": "Qwen/Qwen3-VL-8B-Instruct"
+          },
+          {
+            "id": "qwen/qwen3-vl-8b-thinking",
+            "canonicalSlug": "qwen/qwen3-vl-8b-thinking",
+            "huggingFaceId": "Qwen/Qwen3-VL-8B-Thinking"
+          },
+          {
+            "id": "qwen/qwen3.5-122b-a10b",
+            "canonicalSlug": "qwen/qwen3.5-122b-a10b-20260224",
+            "huggingFaceId": "Qwen/Qwen3.5-122B-A10B"
+          },
+          {
+            "id": "qwen/qwen3.5-27b",
+            "canonicalSlug": "qwen/qwen3.5-27b-20260224",
+            "huggingFaceId": "Qwen/Qwen3.5-27B"
+          },
+          {
+            "id": "qwen/qwen3.5-35b-a3b",
+            "canonicalSlug": "qwen/qwen3.5-35b-a3b-20260224",
+            "huggingFaceId": "Qwen/Qwen3.5-35B-A3B"
+          },
+          {
+            "id": "qwen/qwen3.5-397b-a17b",
+            "canonicalSlug": "qwen/qwen3.5-397b-a17b-20260216",
+            "huggingFaceId": "Qwen/Qwen3.5-397B-A17B"
+          },
+          {
+            "id": "qwen/qwen3.5-9b",
+            "canonicalSlug": "qwen/qwen3.5-9b-20260310",
+            "huggingFaceId": "Qwen/Qwen3.5-9B"
+          }
+        ]
+      },
+      {
+        "provider": "vercel-ai-gateway",
+        "endpoint": "https://ai-gateway.vercel.sh/v1/models",
+        "routes": [
+          {
+            "id": "alibaba/qwen-3-14b",
+            "name": "Qwen3-14B",
+            "artifact": "Qwen/Qwen3-14B"
+          },
+          {
+            "id": "alibaba/qwen-3-235b",
+            "name": "Qwen3 235B A22B",
+            "artifact": "Qwen/Qwen3-235B-A22B"
+          },
+          {
+            "id": "alibaba/qwen-3-30b",
+            "name": "Qwen3-30B-A3B",
+            "artifact": "Qwen/Qwen3-30B-A3B"
+          },
+          {
+            "id": "alibaba/qwen-3-32b",
+            "name": "Qwen 3 32B",
+            "artifact": "Qwen/Qwen3-32B"
+          },
+          {
+            "id": "alibaba/qwen3-coder-30b-a3b",
+            "name": "Qwen 3 Coder 30B A3B Instruct",
+            "artifact": "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+          },
+          {
+            "id": "alibaba/qwen3-coder-next",
+            "name": "Qwen3 Coder Next",
+            "artifact": "Qwen/Qwen3-Coder-Next"
+          },
+          {
+            "id": "alibaba/qwen3-next-80b-a3b-instruct",
+            "name": "Qwen3 Next 80B A3B Instruct",
+            "artifact": "Qwen/Qwen3-Next-80B-A3B-Instruct"
+          },
+          {
+            "id": "alibaba/qwen3-next-80b-a3b-thinking",
+            "name": "Qwen3 Next 80B A3B Thinking",
+            "artifact": "Qwen/Qwen3-Next-80B-A3B-Thinking"
+          },
+          {
+            "id": "alibaba/qwen3-vl-235b-a22b-instruct",
+            "name": "Qwen3 VL 235B A22B Instruct",
+            "artifact": "Qwen/Qwen3-VL-235B-A22B-Instruct"
+          },
+          {
+            "id": "deepseek/deepseek-r1",
+            "name": "DeepSeek-R1",
+            "artifact": "deepseek-ai/DeepSeek-R1"
+          },
+          {
+            "id": "deepseek/deepseek-v3",
+            "name": "DeepSeek V3 0324",
+            "artifact": "deepseek-ai/DeepSeek-V3-0324"
+          },
+          {
+            "id": "deepseek/deepseek-v3.1",
+            "name": "DeepSeek V3.1",
+            "artifact": "deepseek-ai/DeepSeek-V3.1"
+          },
+          {
+            "id": "deepseek/deepseek-v3.1-terminus",
+            "name": "DeepSeek V3.1 Terminus",
+            "artifact": "deepseek-ai/DeepSeek-V3.1-Terminus"
+          },
+          {
+            "id": "deepseek/deepseek-v3.2",
+            "name": "DeepSeek V3.2",
+            "artifact": "deepseek-ai/DeepSeek-V3.2"
+          },
+          {
+            "id": "deepseek/deepseek-v3.2-thinking",
+            "name": "DeepSeek V3.2 Thinking",
+            "artifact": "deepseek-ai/DeepSeek-V3.2"
+          },
+          {
+            "id": "deepseek/deepseek-v4-flash",
+            "name": "DeepSeek V4 Flash",
+            "artifact": "deepseek-ai/DeepSeek-V4-Flash"
+          },
+          {
+            "id": "deepseek/deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro",
+            "artifact": "deepseek-ai/DeepSeek-V4-Pro"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/contextimate-tokenizer-coverage-audit-2026-08-05.md
+++ b/docs/contextimate-tokenizer-coverage-audit-2026-08-05.md
@@ -199,6 +199,8 @@ The DeepSeek and Qwen study checked every pinned artifact before counting. Full 
 
 The resulting rules cover 42 of the 43 DeepSeek route entries in Pi AI 0.83.0. Only the moving `deepseek-chat` alias keeps the fallback. They also cover 49 Qwen 2.5/3 entries and 11 Qwen 3.5 entries. The other 55 Qwen entries are unpinned proprietary aliases or later model generations, so they keep the fallback.
 
+The public relay catalogs resolved the abbreviated serving IDs. OpenRouter linked all 36 profiled routes to an exact pinned Hugging Face artifact. Vercel's full names resolved all 17 profiled routes unambiguously to pinned artifacts, including architecture and instruction suffixes omitted from serving IDs. `DeepSeek V3.2 Thinking` resolves to the pinned V3.2 artifact; thinking is a serving mode here, not a tokenizer claim. The checked route remains separate from its wire API.
+
 GLM 5 Turbo, GLM 5V Turbo, GLM 4.7 FlashX, beta Grok aliases, `deepseek-chat` and proprietary Qwen aliases remain unknown. Retired Gemini previews, `gemini-3-flash`, `gemini-3.1-pro` and Gemini Live also keep the existing generic estimate because the official endpoint did not count them. The same rule applies to `auto`, `free`, fusion and picker routes.
 
 The hosted sweep made 78 tiny requests across 26 routes and cost about $0.1215. One GLM request produced 38,918 hidden reasoning tokens despite `max_tokens: 1`. Future studies should prefer count or tokenizer endpoints because some models require generation reasoning.
@@ -274,6 +276,8 @@ The family follow-up used about $0.1215 of paid OpenRouter generation. Direct xA
 - [DeepSeek V3 tokenizer artifacts](https://huggingface.co/deepseek-ai/DeepSeek-V3/tree/e815299b0bcbac849fa540c768ef21845365c9eb)
 - [Qwen 3 tokenizer artifacts](https://huggingface.co/Qwen/Qwen3-8B/tree/b968826d9c46dd6066d109eabc6255188de91218)
 - [Qwen 3.5 tokenizer artifacts](https://huggingface.co/Qwen/Qwen3.5-9B/tree/c202236235762e1c871ad0ccb60c8ee5ba337b9a)
+- [OpenRouter model catalog](https://openrouter.ai/api/v1/models)
+- [Vercel AI Gateway model catalog](https://ai-gateway.vercel.sh/v1/models)
 - [Gemini `countTokens`](https://ai.google.dev/api/tokens#method:-models.counttokens)
 - [Google local tokenizer](https://github.com/googleapis/python-genai/blob/main/google/genai/local_tokenizer.py)
 - [Mistral common](https://github.com/mistralai/mistral-common)

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "pi-contextimate-evaluate-transcripts": "scripts/contextimate/evaluate-transcripts.mjs",
     "pi-contextimate-check-provider-tokens": "scripts/contextimate/check-provider-tokens.ts",
     "pi-contextimate-check-gemini-tokenizers": "scripts/contextimate/check-gemini-tokenizers.py",
+    "pi-contextimate-check-relay-tokenizer-routes": "scripts/contextimate/check-relay-tokenizer-routes.py",
     "pi-contextimate-check-xai-tokenizers": "scripts/contextimate/check-xai-tokenizers.py"
   }
 }

--- a/scripts/contextimate/README.md
+++ b/scripts/contextimate/README.md
@@ -79,6 +79,17 @@ The checker sends each public corpus fixture as one user text part. Its 17 defau
 
 This is a live, date-stamped check. Google can retire preview model IDs, so the checked-in evidence remains the record for the measured revisions.
 
+## Relay alias verification
+
+OpenRouter and Vercel publish the concrete model behind each relay ID. Verify the profiled DeepSeek and Qwen routes against those public catalogs:
+
+```bash
+npm run link-pi
+scripts/contextimate/check-relay-tokenizer-routes.py
+```
+
+The checker reads model IDs from the installed Pi AI catalog and the checked-in route evidence. It compares OpenRouter's canonical and Hugging Face IDs and Vercel's full model names. It needs no API key, makes no generation calls and runs only when invoked.
+
 ## xAI tokenizer fingerprints
 
 xAI exposes exact token IDs and bytes through `TokenizeText`. The separate checker keeps its optional Python SDK out of the extension and npm dependency tree:

--- a/scripts/contextimate/check-relay-tokenizer-routes.py
+++ b/scripts/contextimate/check-relay-tokenizer-routes.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Verify profiled OpenRouter and Vercel routes against their public catalogs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+sys.dont_write_bytecode = True
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_EVIDENCE = (
+    PROJECT_ROOT / "docs/contextimate-family-calibration-evidence-2026-08-05.json"
+)
+PI_AI_DATA = (
+    PROJECT_ROOT
+    / "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/providers/data"
+)
+CATALOGS = (
+    ("openrouter", "https://openrouter.ai/api/v1/models"),
+    ("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1/models"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check profiled relay IDs against public model catalogs.",
+    )
+    parser.add_argument(
+        "--evidence",
+        type=Path,
+        default=DEFAULT_EVIDENCE,
+        help="checked-in calibration evidence to verify",
+    )
+    parser.add_argument("--json", action="store_true", help="emit current mappings")
+    return parser.parse_args()
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    try:
+        payload: Any = json.loads(path.read_text())
+    except FileNotFoundError:
+        raise RuntimeError(f"missing {path}; run npm run link-pi if needed") from None
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"expected a JSON object in {path}")
+    return payload
+
+
+def model_records(value: Any) -> list[dict[str, str]]:
+    if isinstance(value, list):
+        return [record for item in value for record in model_records(item)]
+    if not isinstance(value, dict):
+        return []
+    if all(isinstance(value.get(key), str) for key in ("provider", "id", "api")):
+        return [
+            {
+                "provider": value["provider"],
+                "id": value["id"],
+                "api": value["api"],
+            }
+        ]
+    return [record for item in value.values() for record in model_records(item)]
+
+
+def profiled_model_ids(evidence: dict[str, Any]) -> set[str]:
+    route_evidence = evidence.get("openFamilyPiRoutes")
+    if not isinstance(route_evidence, dict):
+        raise RuntimeError("evidence omitted openFamilyPiRoutes")
+    families = route_evidence.get("families")
+    if not isinstance(families, list):
+        raise RuntimeError("route evidence omitted families")
+    result: set[str] = set()
+    for family in families:
+        if not isinstance(family, dict) or not isinstance(family.get("groups"), list):
+            raise RuntimeError("route evidence contains a malformed family")
+        for group in family["groups"]:
+            if not isinstance(group, dict) or not isinstance(group.get("label"), str):
+                raise RuntimeError("route evidence contains a malformed group")
+            ids = group.get("modelIds")
+            if not isinstance(ids, list) or not all(
+                isinstance(item, str) for item in ids
+            ):
+                raise RuntimeError("route evidence contains malformed model IDs")
+            if group["label"] != "fallback chars/4":
+                result.update(ids)
+    return result
+
+
+def pinned_repositories(evidence: dict[str, Any]) -> set[str]:
+    tokenizers = evidence.get("openTokenizers")
+    if not isinstance(tokenizers, dict) or not isinstance(
+        tokenizers.get("profiles"), list
+    ):
+        raise RuntimeError("evidence omitted open tokenizer profiles")
+    repositories: set[str] = set()
+    for profile in tokenizers["profiles"]:
+        if not isinstance(profile, dict) or not isinstance(
+            profile.get("familyArtifacts"), list
+        ):
+            raise RuntimeError("evidence contains malformed tokenizer artifacts")
+        for artifact in profile["familyArtifacts"]:
+            if not isinstance(artifact, dict) or not isinstance(
+                artifact.get("repository"), str
+            ):
+                raise RuntimeError("evidence contains a malformed tokenizer artifact")
+            repositories.add(artifact["repository"])
+    return repositories
+
+
+def normalized_model_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def artifact_for_name(name: str, repositories: set[str]) -> str:
+    normalized = normalized_model_name(name)
+    candidates = [
+        repository
+        for repository in repositories
+        if normalized_model_name(repository.rsplit("/", 1)[-1])
+        in (normalized, normalized.removesuffix("thinking"))
+    ]
+    if len(candidates) != 1:
+        raise RuntimeError(
+            f"could not resolve relay model name to one artifact: {name}"
+        )
+    return candidates[0]
+
+
+def fetch_models(endpoint: str) -> dict[str, dict[str, Any]]:
+    request = urllib.request.Request(
+        endpoint,
+        headers={"User-Agent": "pine-of-glass-contextimate-calibration"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload: Any = json.load(response)
+    except urllib.error.HTTPError as error:
+        raise RuntimeError(f"{endpoint} returned HTTP {error.code}") from None
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"{endpoint} request failed: {error.reason}") from None
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        raise RuntimeError(f"{endpoint} returned malformed JSON")
+    models: dict[str, dict[str, Any]] = {}
+    for model in payload["data"]:
+        if isinstance(model, dict) and isinstance(model.get("id"), str):
+            models[model["id"]] = model
+    return models
+
+
+def current_resolutions(evidence: dict[str, Any]) -> dict[str, Any]:
+    profiled_ids = profiled_model_ids(evidence)
+    repositories = pinned_repositories(evidence)
+    repositories_by_lower = {repository.lower() for repository in repositories}
+    catalogs = []
+    for provider, endpoint in CATALOGS:
+        records = model_records(load_object(PI_AI_DATA / f"{provider}.json"))
+        route_ids = sorted(
+            {record["id"] for record in records if record["id"] in profiled_ids}
+        )
+        live = fetch_models(endpoint)
+        missing = [model_id for model_id in route_ids if model_id not in live]
+        if missing:
+            raise RuntimeError(
+                f"{provider} omitted profiled routes: {', '.join(missing)}"
+            )
+        if provider == "openrouter":
+            routes = [
+                {
+                    "id": model_id,
+                    "canonicalSlug": live[model_id].get("canonical_slug"),
+                    "huggingFaceId": live[model_id].get("hugging_face_id"),
+                }
+                for model_id in route_ids
+            ]
+            if any(
+                not isinstance(route["huggingFaceId"], str)
+                or route["huggingFaceId"].lower() not in repositories_by_lower
+                for route in routes
+            ):
+                raise RuntimeError("OpenRouter did not resolve to a pinned artifact")
+        else:
+            routes = []
+            for model_id in route_ids:
+                name = live[model_id].get("name")
+                if not isinstance(name, str):
+                    raise RuntimeError("Vercel omitted a profiled model name")
+                routes.append(
+                    {
+                        "id": model_id,
+                        "name": name,
+                        "artifact": artifact_for_name(name, repositories),
+                    }
+                )
+        catalogs.append({"provider": provider, "endpoint": endpoint, "routes": routes})
+    return {"checkedAt": date.today().isoformat(), "catalogs": catalogs}
+
+
+def main() -> None:
+    args = parse_args()
+    evidence = load_object(args.evidence)
+    current = current_resolutions(evidence)
+    if args.json:
+        print(json.dumps(current, indent=2))
+        return
+    expected = evidence.get("relayAliasResolutions")
+    if (
+        not isinstance(expected, dict)
+        or expected.get("catalogs") != current["catalogs"]
+    ):
+        raise RuntimeError("relay alias resolutions differ; inspect --json output")
+    counts = ", ".join(
+        f"{catalog['provider']} {len(catalog['routes'])}"
+        for catalog in current["catalogs"]
+    )
+    print(f"relay alias resolutions match checked evidence: {counts}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, RuntimeError, UnicodeError) as error:
+        print(str(error), file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

- resolve every profiled OpenRouter route to its pinned Hugging Face artifact
- resolve abbreviated Vercel route names to the matching pinned artifact
- add a manual, key-free checker for relay catalog drift

## Verification

- `scripts/contextimate/check-relay-tokenizer-routes.py`
- `npm run check`
- Python Ruff and compilation checks
- `npm pack --dry-run --json`

No runtime dependency, startup network call, release or version bump.