### PR TITLE
Contextimate: simplify tokenizer calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,8 @@
 ## Unreleased
 
 - Contextimate adds measured visible-text profiles for Gemini, Kimi, GLM, Cohere,
-  Grok, DeepSeek and Qwen. Official counts, pinned tokenizer artifacts, exact corpus
-  token streams or xAI token streams define conservative groups across concrete relay
-  IDs. Dynamic and unverified variants keep the generic estimate or fallback. Manual
-  count and tokenizer scripts add no runtime dependencies or startup network calls.
+  Grok, DeepSeek and Qwen. Explicit, verified model IDs use the new profiles; dynamic
+  and unverified variants keep the generic estimate or fallback.
 
 ## 0.10.0 (2026-08-05)
 

--- a/docs/contextimate-family-calibration-evidence-2026-08-05.json
+++ b/docs/contextimate-family-calibration-evidence-2026-08-05.json
@@ -367,68 +367,57 @@
           {
             "repository": "deepseek-ai/DeepSeek-V3",
             "revision": "e815299b0bcbac849fa540c768ef21845365c9eb",
-            "sha256": "621ac2e32d0dba658404412318818aaa8ce8cda492e59830109d8da6b517fb41",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "621ac2e32d0dba658404412318818aaa8ce8cda492e59830109d8da6b517fb41"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V3-0324",
             "revision": "e9b33add76883f293d6bf61f6bd89b497e80e335",
-            "sha256": "621ac2e32d0dba658404412318818aaa8ce8cda492e59830109d8da6b517fb41",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "621ac2e32d0dba658404412318818aaa8ce8cda492e59830109d8da6b517fb41"
           },
           {
             "repository": "deepseek-ai/DeepSeek-R1",
             "revision": "56d4cbbb4d29f4355bab4b9a39ccb717a14ad5ad",
-            "sha256": "ecb6f9fc369894346f0511f4074ca75cee5cd5f3b06d02f1ba35fcd39f8e121d",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "ecb6f9fc369894346f0511f4074ca75cee5cd5f3b06d02f1ba35fcd39f8e121d"
           },
           {
             "repository": "deepseek-ai/DeepSeek-R1-0528",
             "revision": "4236a6af538feda4548eca9ab308586007567f52",
-            "sha256": "ecb6f9fc369894346f0511f4074ca75cee5cd5f3b06d02f1ba35fcd39f8e121d",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "ecb6f9fc369894346f0511f4074ca75cee5cd5f3b06d02f1ba35fcd39f8e121d"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V3.1",
             "revision": "c0781d039fb7a1ba2abc4add0bdc293e92d2b8db",
-            "sha256": "32b34a41212e92f62e859cbbea121ae705a1fabbf157d9acf22d134ecd8dcf70",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "32b34a41212e92f62e859cbbea121ae705a1fabbf157d9acf22d134ecd8dcf70"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V3.1-Terminus",
             "revision": "19510d6dc61f79dbd925bd51ee8a9081c509a4b6",
-            "sha256": "32b34a41212e92f62e859cbbea121ae705a1fabbf157d9acf22d134ecd8dcf70",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "32b34a41212e92f62e859cbbea121ae705a1fabbf157d9acf22d134ecd8dcf70"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V3.2-Exp",
             "revision": "194c67e12b1b0d6df0ef373ddcf215bc84027409",
-            "sha256": "32b34a41212e92f62e859cbbea121ae705a1fabbf157d9acf22d134ecd8dcf70",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "32b34a41212e92f62e859cbbea121ae705a1fabbf157d9acf22d134ecd8dcf70"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V3.2",
             "revision": "a7e62ac04ecb2c0a54d736dc46601c5606cf10a6",
-            "sha256": "cd050be35cae877f8f0aa847f45aa87e23835a56ca32b29b28545597852784e5",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "cd050be35cae877f8f0aa847f45aa87e23835a56ca32b29b28545597852784e5"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V4-Flash",
             "revision": "60d8d70770c6776ff598c94bb586a859a38244f1",
-            "sha256": "8f9f37ca37fdc4f5fd36d5cf4d3b0e8392edb4e894fd10cc0d70b4957c8633cf",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "8f9f37ca37fdc4f5fd36d5cf4d3b0e8392edb4e894fd10cc0d70b4957c8633cf"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V4-Flash-0731",
             "revision": "7872f01b1d1fe23eabc4c98b48bffcef5a386062",
-            "sha256": "8f9f37ca37fdc4f5fd36d5cf4d3b0e8392edb4e894fd10cc0d70b4957c8633cf",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "8f9f37ca37fdc4f5fd36d5cf4d3b0e8392edb4e894fd10cc0d70b4957c8633cf"
           },
           {
             "repository": "deepseek-ai/DeepSeek-V4-Pro",
             "revision": "b5968e9190ef611bbf34a7229255be88a0e937c1",
-            "sha256": "8f9f37ca37fdc4f5fd36d5cf4d3b0e8392edb4e894fd10cc0d70b4957c8633cf",
-            "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
+            "sha256": "8f9f37ca37fdc4f5fd36d5cf4d3b0e8392edb4e894fd10cc0d70b4957c8633cf"
           }
         ],
         "samples": {
@@ -470,7 +459,8 @@
           "charsPerToken": 3.6208,
           "recommendedDenominator": 3.6
         },
-        "tokenStreamSha256": "fc92ce91342c67f51ff9f576b966759714efe91fe088124cd386c17eb51b2abd"
+        "tokenStreamSha256": "fc92ce91342c67f51ff9f576b966759714efe91fe088124cd386c17eb51b2abd",
+        "bpeSha256": "22acf98589f19423735aafc33361a4d1d0273a05fd8b9b8be74023afb6b8c882"
       },
       {
         "profile": "Qwen 2.5/3",
@@ -478,152 +468,127 @@
           {
             "repository": "Qwen/Qwen2.5-7B-Instruct",
             "revision": "a09a35458c702b33eeacc393d103063234e8bc28",
-            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539"
           },
           {
             "repository": "Qwen/Qwen2.5-72B-Instruct",
             "revision": "495f39366efef23836d0cfae4fbe635880d2be31",
-            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539"
           },
           {
             "repository": "Qwen/Qwen2.5-Coder-7B-Instruct",
             "revision": "c03e6d358207e414f1eca0bb1891e29f1db0e242",
-            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539"
           },
           {
             "repository": "Qwen/Qwen2.5-VL-7B-Instruct",
             "revision": "cc594898137f460bfe9f0759e9844b3ce807cfb5",
-            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539"
           },
           {
             "repository": "Qwen/Qwen3-8B",
             "revision": "b968826d9c46dd6066d109eabc6255188de91218",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-14B",
             "revision": "40c069824f4251a91eefaf281ebe4c544efd3e18",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-30B-A3B",
             "revision": "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-32B",
             "revision": "9216db5781bf21249d130ec9da846c4624c16137",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-235B-A22B",
             "revision": "8efa61729e24bd65b1d152b5ab5409052aa80e65",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "revision": "0d7cf23991f47feeb3a57ecb4c9cee8ea4a17bfe",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-235B-A22B-Instruct-2507",
             "revision": "ac9c66cc9b46af7306746a9250f23d47083d689e",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-Next-80B-A3B-Instruct",
             "revision": "9c7f2fbe84465e40164a94cc16cd30b6999b0cc7",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-Next-80B-A3B-Thinking",
             "revision": "e502dd4100cc68c0de57643fd4317ec93a128670",
-            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
           },
           {
             "repository": "Qwen/Qwen3-30B-A3B-Thinking-2507",
             "revision": "144afc2f379b542fdd4e85a1fcd5e1f79112d95d",
-            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d"
           },
           {
             "repository": "Qwen/Qwen3-235B-A22B-Thinking-2507",
             "revision": "6cbffae6d8e28b986a6b17bd36f42f9fa0f1f0a5",
-            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d"
           },
           {
             "repository": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
             "revision": "b2cff646eb4bb1d68355c01b18ae02e7cf42d120",
-            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d"
           },
           {
             "repository": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
             "revision": "9d90cf8fca1bf7b7acca42d3fc9ae694a2194069",
-            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d"
           },
           {
             "repository": "Qwen/Qwen3-Coder-Next",
             "revision": "a7fbcb5c0e12d62a448eaa0e260346bf5dcc0feb",
-            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "19564a48c4f71a2a1b937cce34c737a1e662b171c5f5d7edf641a15cd896f07d"
           },
           {
             "repository": "Qwen/Qwen3-VL-8B-Instruct",
             "revision": "0c351dd01ed87e9c1b53cbc748cba10e6187ff3b",
-            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
           },
           {
             "repository": "Qwen/Qwen3-VL-8B-Thinking",
             "revision": "92f3c4b4feadd3a016ef468d103bb5f58b2a2c6b",
-            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
           },
           {
             "repository": "Qwen/Qwen3-VL-30B-A3B-Instruct",
             "revision": "9c4b90e1e4ba969fd3b5378b57d966d725f1b86c",
-            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
           },
           {
             "repository": "Qwen/Qwen3-VL-30B-A3B-Thinking",
             "revision": "d0ed0380729be07a546fdefafbb4fe411f341e92",
-            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
           },
           {
             "repository": "Qwen/Qwen3-VL-32B-Instruct",
             "revision": "0cfaf48183f594c314753d30a4c4974bc75f3ccb",
-            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
           },
           {
             "repository": "Qwen/Qwen3-VL-235B-A22B-Instruct",
             "revision": "710c13861be6c466e66de3f484069440b8f31389",
-            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
           },
           {
             "repository": "Qwen/Qwen3-VL-235B-A22B-Thinking",
             "revision": "6664affde68449468deb7527186455c7450c13c0",
-            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
-            "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
+            "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
           }
         ],
         "samples": {
@@ -665,7 +630,8 @@
           "charsPerToken": 3.8214,
           "recommendedDenominator": 3.8
         },
-        "tokenStreamSha256": "0cbd8118040023d731f5ccc639adb182bc553575a5d13c86e1c49929a59fb0ea"
+        "tokenStreamSha256": "0cbd8118040023d731f5ccc639adb182bc553575a5d13c86e1c49929a59fb0ea",
+        "bpeSha256": "6e2c42439170bc898d8412d52f3c47361ec4bd134c1cc008fbdd86ac99259a8b"
       },
       {
         "profile": "Qwen 3.5",
@@ -673,32 +639,27 @@
           {
             "repository": "Qwen/Qwen3.5-9B",
             "revision": "c202236235762e1c871ad0ccb60c8ee5ba337b9a",
-            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42",
-            "bpeSha256": "e23b06565b8e5ec64f5ab300b6c2a2c3ed3f5f8acb16b02f5f03bd811bbb8317"
+            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42"
           },
           {
             "repository": "Qwen/Qwen3.5-27B",
             "revision": "fc05daec18b0a78c049392ed2e771dde82bdf654",
-            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42",
-            "bpeSha256": "e23b06565b8e5ec64f5ab300b6c2a2c3ed3f5f8acb16b02f5f03bd811bbb8317"
+            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42"
           },
           {
             "repository": "Qwen/Qwen3.5-35B-A3B",
             "revision": "59d61f3ce65a6d9863b86d2e96597125219dc754",
-            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42",
-            "bpeSha256": "e23b06565b8e5ec64f5ab300b6c2a2c3ed3f5f8acb16b02f5f03bd811bbb8317"
+            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42"
           },
           {
             "repository": "Qwen/Qwen3.5-122B-A10B",
             "revision": "dc4d348443bc740c68e2d77492492c11606384d5",
-            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42",
-            "bpeSha256": "e23b06565b8e5ec64f5ab300b6c2a2c3ed3f5f8acb16b02f5f03bd811bbb8317"
+            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42"
           },
           {
             "repository": "Qwen/Qwen3.5-397B-A17B",
             "revision": "8472618112abcbd45acbcdc58436aff4233c23f7",
-            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42",
-            "bpeSha256": "e23b06565b8e5ec64f5ab300b6c2a2c3ed3f5f8acb16b02f5f03bd811bbb8317"
+            "sha256": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42"
           }
         ],
         "samples": {
@@ -740,7 +701,8 @@
           "charsPerToken": 3.5317,
           "recommendedDenominator": 3.5
         },
-        "tokenStreamSha256": "1b9ddcbd8e88d46091ec9398b4dc9e71e52369581c9701c17f527ad80ee943a1"
+        "tokenStreamSha256": "1b9ddcbd8e88d46091ec9398b4dc9e71e52369581c9701c17f527ad80ee943a1",
+        "bpeSha256": "e23b06565b8e5ec64f5ab300b6c2a2c3ed3f5f8acb16b02f5f03bd811bbb8317"
       }
     ]
   },
@@ -1042,45 +1004,31 @@
       {
         "family": "MiniMax",
         "catalogEntries": 41,
-        "providerCatalogs": 13,
-        "modelChanges30Days": 0,
-        "modelChanges90Days": 0,
-        "decision": "exclude"
+        "providerCatalogs": 13
       },
       {
         "family": "Mistral",
         "catalogEntries": 73,
-        "providerCatalogs": 6,
-        "modelChanges30Days": 0,
-        "modelChanges90Days": 0,
-        "decision": "exclude"
+        "providerCatalogs": 6
       },
       {
         "family": "Llama",
         "catalogEntries": 36,
-        "providerCatalogs": 8,
-        "modelChanges30Days": 0,
-        "modelChanges90Days": 0,
-        "decision": "exclude"
+        "providerCatalogs": 8
       },
       {
         "family": "Gemma",
         "catalogEntries": 19,
-        "providerCatalogs": 9,
-        "modelChanges30Days": 0,
-        "modelChanges90Days": 0,
-        "decision": "exclude"
+        "providerCatalogs": 9
       },
       {
         "family": "MiMo",
         "catalogEntries": 25,
-        "providerCatalogs": 9,
-        "modelChanges30Days": 0,
-        "modelChanges90Days": 0,
-        "decision": "exclude"
+        "providerCatalogs": 9
       }
     ],
-    "conclusion": "Catalog availability alone did not justify new profiles without any recent local use."
+    "matchingModelChanges": 0,
+    "decision": "Keep these families on the fallback until use justifies calibration."
   },
   "geminiCountTokens": {
     "corpusVersion": "2026-08-05.1",
@@ -1108,76 +1056,6 @@
     },
     "endpoint": "https://generativelanguage.googleapis.com/v1beta/models/{model}:countTokens",
     "requestCoverage": "one user text part per corpus fixture",
-    "models": [
-      {
-        "model": "gemini-2.0-flash",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-2.0-flash-lite",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-2.5-flash",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-2.5-flash-lite",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-2.5-pro",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-2.5-computer-use-preview-10-2025",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3-flash-preview",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3-pro-preview",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3-pro-image",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.1-flash-lite",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.1-flash-lite-preview",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.1-flash-lite-image",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.1-pro-preview",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.1-pro-preview-customtools",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.5-flash",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.5-flash-lite",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      },
-      {
-        "model": "gemini-3.6-flash",
-        "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e"
-      }
-    ],
     "groups": [
       {
         "countFingerprint": "e739e7b896931133d016a86325761fbfc61dbff2dce557f406e3d0a41151253e",
@@ -1244,32 +1122,14 @@
   },
   "geminiUnsupportedCountAttempts": {
     "endpoint": "https://generativelanguage.googleapis.com/v1beta/models/{model}:countTokens",
-    "models": [
-      {
-        "model": "gemini-2.5-pro-preview",
-        "status": 404,
-        "reason": "not listed or not supported for countTokens by the official Developer API"
-      },
-      {
-        "model": "gemini-2.5-pro-preview-05-06",
-        "status": 404,
-        "reason": "not listed or not supported for countTokens by the official Developer API"
-      },
-      {
-        "model": "gemini-3-flash",
-        "status": 404,
-        "reason": "not listed or not supported for countTokens by the official Developer API"
-      },
-      {
-        "model": "gemini-3.1-pro",
-        "status": 404,
-        "reason": "not listed or not supported for countTokens by the official Developer API"
-      },
-      {
-        "model": "gemini-3.1-flash-live-preview",
-        "status": 404,
-        "reason": "not listed or not supported for countTokens by the official Developer API"
-      }
+    "status": 404,
+    "reason": "not listed or not supported for countTokens by the official Developer API",
+    "modelIds": [
+      "gemini-2.5-pro-preview",
+      "gemini-2.5-pro-preview-05-06",
+      "gemini-3-flash",
+      "gemini-3.1-pro",
+      "gemini-3.1-flash-live-preview"
     ]
   },
   "geminiPiRoutes": {
@@ -1865,27 +1725,22 @@
         "routes": [
           {
             "id": "deepseek/deepseek-chat-v3-0324",
-            "canonicalSlug": "deepseek/deepseek-chat-v3-0324",
             "huggingFaceId": "deepseek-ai/DeepSeek-V3-0324"
           },
           {
             "id": "deepseek/deepseek-chat-v3.1",
-            "canonicalSlug": "deepseek/deepseek-chat-v3.1",
             "huggingFaceId": "deepseek-ai/DeepSeek-V3.1"
           },
           {
             "id": "deepseek/deepseek-r1",
-            "canonicalSlug": "deepseek/deepseek-r1",
             "huggingFaceId": "deepseek-ai/DeepSeek-R1"
           },
           {
             "id": "deepseek/deepseek-r1-0528",
-            "canonicalSlug": "deepseek/deepseek-r1-0528",
             "huggingFaceId": "deepseek-ai/DeepSeek-R1-0528"
           },
           {
             "id": "deepseek/deepseek-v3.1-terminus",
-            "canonicalSlug": "deepseek/deepseek-v3.1-terminus",
             "huggingFaceId": "deepseek-ai/DeepSeek-V3.1-Terminus"
           },
           {
@@ -1895,7 +1750,6 @@
           },
           {
             "id": "deepseek/deepseek-v3.2-exp",
-            "canonicalSlug": "deepseek/deepseek-v3.2-exp",
             "huggingFaceId": "deepseek-ai/DeepSeek-V3.2-Exp"
           },
           {
@@ -1910,12 +1764,10 @@
           },
           {
             "id": "qwen/qwen-2.5-72b-instruct",
-            "canonicalSlug": "qwen/qwen-2.5-72b-instruct",
             "huggingFaceId": "Qwen/Qwen2.5-72B-Instruct"
           },
           {
             "id": "qwen/qwen-2.5-7b-instruct",
-            "canonicalSlug": "qwen/qwen-2.5-7b-instruct",
             "huggingFaceId": "Qwen/Qwen2.5-7B-Instruct"
           },
           {
@@ -1935,7 +1787,6 @@
           },
           {
             "id": "qwen/qwen3-235b-a22b-thinking-2507",
-            "canonicalSlug": "qwen/qwen3-235b-a22b-thinking-2507",
             "huggingFaceId": "Qwen/Qwen3-235B-A22B-Thinking-2507"
           },
           {
@@ -1945,12 +1796,10 @@
           },
           {
             "id": "qwen/qwen3-30b-a3b-instruct-2507",
-            "canonicalSlug": "qwen/qwen3-30b-a3b-instruct-2507",
             "huggingFaceId": "Qwen/Qwen3-30B-A3B-Instruct-2507"
           },
           {
             "id": "qwen/qwen3-30b-a3b-thinking-2507",
-            "canonicalSlug": "qwen/qwen3-30b-a3b-thinking-2507",
             "huggingFaceId": "Qwen/Qwen3-30B-A3B-Thinking-2507"
           },
           {
@@ -1965,7 +1814,6 @@
           },
           {
             "id": "qwen/qwen3-coder-30b-a3b-instruct",
-            "canonicalSlug": "qwen/qwen3-coder-30b-a3b-instruct",
             "huggingFaceId": "Qwen/Qwen3-Coder-30B-A3B-Instruct"
           },
           {
@@ -1985,37 +1833,30 @@
           },
           {
             "id": "qwen/qwen3-vl-235b-a22b-instruct",
-            "canonicalSlug": "qwen/qwen3-vl-235b-a22b-instruct",
             "huggingFaceId": "Qwen/Qwen3-VL-235B-A22B-Instruct"
           },
           {
             "id": "qwen/qwen3-vl-235b-a22b-thinking",
-            "canonicalSlug": "qwen/qwen3-vl-235b-a22b-thinking",
             "huggingFaceId": "Qwen/Qwen3-VL-235B-A22B-Thinking"
           },
           {
             "id": "qwen/qwen3-vl-30b-a3b-instruct",
-            "canonicalSlug": "qwen/qwen3-vl-30b-a3b-instruct",
             "huggingFaceId": "Qwen/Qwen3-VL-30B-A3B-Instruct"
           },
           {
             "id": "qwen/qwen3-vl-30b-a3b-thinking",
-            "canonicalSlug": "qwen/qwen3-vl-30b-a3b-thinking",
             "huggingFaceId": "Qwen/Qwen3-VL-30B-A3B-Thinking"
           },
           {
             "id": "qwen/qwen3-vl-32b-instruct",
-            "canonicalSlug": "qwen/qwen3-vl-32b-instruct",
             "huggingFaceId": "Qwen/Qwen3-VL-32B-Instruct"
           },
           {
             "id": "qwen/qwen3-vl-8b-instruct",
-            "canonicalSlug": "qwen/qwen3-vl-8b-instruct",
             "huggingFaceId": "Qwen/Qwen3-VL-8B-Instruct"
           },
           {
             "id": "qwen/qwen3-vl-8b-thinking",
-            "canonicalSlug": "qwen/qwen3-vl-8b-thinking",
             "huggingFaceId": "Qwen/Qwen3-VL-8B-Thinking"
           },
           {

--- a/docs/contextimate-tokenizer-coverage-audit-2026-08-05.md
+++ b/docs/contextimate-tokenizer-coverage-audit-2026-08-05.md
@@ -184,7 +184,7 @@ The [machine-readable evidence](./contextimate-family-calibration-evidence-2026-
 | North Mini Code | 4.2 | 3.9 | separate tokenizer hash `14bd1c49d7d1…` |
 | Grok 4.20/4.3 | 4.2 | 3.9 | Grok 4.20 reasoning, non-reasoning and multi-agent, 4.3 and Build 0.1 returned identical token IDs, strings and bytes |
 | Grok 4.5 | 4.1 | 3.6 | a distinct xAI token stream; `grok-build-latest` currently resolves here |
-| Gemini 2.x and 3.x | 3.9 | 3.4 | 17 exact Developer API model IDs returned count fingerprint `e739e7b89693…` |
+| 17 counted Gemini model IDs | 3.9 | 3.4 | exact Developer API IDs returned count fingerprint `e739e7b89693…` |
 | DeepSeek V3, R1 and V4 | 4.0 | 3.6 | 11 pinned artifacts share BPE hash `22acf98589f1…` and corpus token-stream hash `fc92ce91342c…` |
 | Qwen 2.5 and 3 | 4.0 | 3.8 | 25 pinned artifacts share BPE hash `6e2c42439170…` and corpus token-stream hash `0cbd81180400…` |
 | Qwen 3.5 | 3.9 | 3.5 | 5 pinned artifacts share BPE hash `e23b06565b8e…` and corpus token-stream hash `1b9ddcbd8e88…` |
@@ -193,15 +193,15 @@ The xAI fingerprint used six fixtures covering prose, code, multilingual text, w
 
 At measurement time, `grok-4.20` resolved to `grok-4.20-0309-reasoning`. `grok-latest` resolved to `grok-4.3`, while `grok-build-latest` resolved to `grok-4.5`. Contextimate leaves `latest` aliases unknown before routing because their targets can change.
 
-The Gemini Developer API counted each corpus fixture as one user text part. All 17 exact model IDs returned the same five counts. They cover 62 of the 68 Gemini 2.x and 3.x route entries in Pi AI 0.83.0, including batch, computer-use and image variants. Six routes keep the generic estimate: 2 retired 2.5 Pro previews, 2 `gemini-3-flash` aliases, `gemini-3.1-pro` and Gemini 3.1 Live. The official endpoint returned no count for those IDs. Tool conversion and route overhead stay separate.
+The Gemini Developer API counted each fixture as one user text part. All 17 model IDs returned the same five counts. They cover 62 of 68 matching Pi routes. The route IDs include batch, computer-use and image-capable models, but the evidence covers text only. Two retired 2.5 Pro previews, 2 `gemini-3-flash` aliases, `gemini-3.1-pro` and Gemini 3.1 Live keep the generic estimate because the endpoint did not count them.
 
 The DeepSeek and Qwen study checked every pinned artifact before counting. Full tokenizer JSON hashes vary where models add special tokens or chat configuration. The ordinary-text BPE content and every token ID across the pinned corpus matched within each shipped group. Qwen 3.5 remained separate from Qwen 2.5 and 3.
 
 The resulting rules cover 42 of the 43 DeepSeek route entries in Pi AI 0.83.0. Only the moving `deepseek-chat` alias keeps the fallback. They also cover 49 Qwen 2.5/3 entries and 11 Qwen 3.5 entries. The other 55 Qwen entries are unpinned proprietary aliases or later model generations, so they keep the fallback.
 
-The public relay catalogs resolved the abbreviated serving IDs. OpenRouter linked all 36 profiled routes to an exact pinned Hugging Face artifact. Vercel's full names resolved all 17 profiled routes unambiguously to pinned artifacts, including architecture and instruction suffixes omitted from serving IDs. `DeepSeek V3.2 Thinking` resolves to the pinned V3.2 artifact; thinking is a serving mode here, not a tokenizer claim. The checked route remains separate from its wire API.
+OpenRouter linked all 36 profiled relay routes to pinned Hugging Face artifacts. Vercel's full names linked all 17 profiled routes to pinned artifacts. `DeepSeek V3.2 Thinking` names the V3.2 artifact and a serving mode. These checks verify tokenizer family, not request serialization.
 
-GLM 5 Turbo, GLM 5V Turbo, GLM 4.7 FlashX, beta Grok aliases, `deepseek-chat` and proprietary Qwen aliases remain unknown. Retired Gemini previews, `gemini-3-flash`, `gemini-3.1-pro` and Gemini Live also keep the existing generic estimate because the official endpoint did not count them. The same rule applies to `auto`, `free`, fusion and picker routes.
+GLM 5 Turbo, GLM 5V Turbo, GLM 4.7 FlashX, beta Grok aliases, `deepseek-chat`, proprietary Qwen aliases and dynamic selectors remain unknown.
 
 The hosted sweep made 78 tiny requests across 26 routes and cost about $0.1215. One GLM request produced 38,918 hidden reasoning tokens despite `max_tokens: 1`. Future studies should prefer count or tokenizer endpoints because some models require generation reasoning.
 
@@ -215,45 +215,21 @@ Resolve these facts independently:
 - wire API shape, for system and tool serialization
 - tokenizer family and revision, for token density
 
-Measured profiles now cover:
-
-- Claude 4.5 and 4.6
-- Claude 4.7 and later
-- OpenAI Codex and Responses
-- Gemini 2.x and 3.x visible text for 17 exact countable model IDs
-- Kimi K2 through K3 raw text
-- GLM 4.5-generation and GLM 5-generation raw text
-- Cohere Command R/R+ 08-2024 and North Mini Code raw text
-- Grok 4.20/4.3/Build 0.1 and Grok 4.5 raw text
-- DeepSeek V3, R1 and V4 raw text
-- Qwen 2.5, 3 and 3.5 raw text for pinned, explicit model IDs
-
-Bedrock and unidentified families remain estimates at characters divided by 4 until calibration data supports a better profile. API compatibility alone does not change that denominator.
+The family calibration table defines the measured raw-text profiles. Contextimate also has measured Claude and OpenAI profiles documented in [How pi-contextimate counts context](./pi-contextimate.md). Bedrock and unidentified families remain at characters divided by 4. API compatibility alone does not select a tokenizer profile.
 
 Use `scripts/contextimate/check-provider-tokens.ts` to measure captured Pi payloads. Add profiles only after checking several Pi-shaped text and schema fixtures, plus returned provider usage where available.
 
-## Usage did not justify 5 more families
+## Five families remain unmeasured
 
-We checked local `model_change` metadata for the previous 30 and 90 days. This inspected model IDs and providers only. It did not inspect prompts or messages.
+MiniMax, Mistral, Llama, Gemma and MiMo did not appear in local `model_change` metadata over 30 or 90 days. The check covered 3,206 and 7,444 model changes respectively, without reading prompts or messages. Contextimate keeps the fallback until use justifies calibration.
 
-Pi's catalog had 41 MiniMax entries, 73 Mistral-family entries, 36 Llama entries, 19 Gemma entries and 25 MiMo entries. None appeared in 3,206 model changes over 30 days or 7,444 over 90 days. Contextimate keeps the fallback for those families until local use or another practical need justifies calibration.
-
-## Remaining work
-
-Prioritise measured profiles in this order:
-
-1. newly used model families with pinned or provider evidence
-2. existing profiles after tokenizer or alias changes
-
-Still requiring a capability check:
+## Remaining checks
 
 - Kimi Coding membership keys against the public Moonshot endpoint
 - Z.AI Coding Plan keys against the tokenizer endpoint
 - GLM model IDs newer than the published tokenizer enum, including 5 Turbo and 5V Turbo
 - whether DashScope still documents a Qwen tokenization service and which plans can use it
 - Azure support for OpenAI's Responses input-token endpoint
-
-The family follow-up used about $0.1215 of paid OpenRouter generation. Direct xAI checks used `TokenizeText`, not generation.
 
 ## Sources
 
@@ -278,7 +254,6 @@ The family follow-up used about $0.1215 of paid OpenRouter generation. Direct xA
 - [Qwen 3.5 tokenizer artifacts](https://huggingface.co/Qwen/Qwen3.5-9B/tree/c202236235762e1c871ad0ccb60c8ee5ba337b9a)
 - [OpenRouter model catalog](https://openrouter.ai/api/v1/models)
 - [Vercel AI Gateway model catalog](https://ai-gateway.vercel.sh/v1/models)
-- [Gemini `countTokens`](https://ai.google.dev/api/tokens#method:-models.counttokens)
 - [Google local tokenizer](https://github.com/googleapis/python-genai/blob/main/google/genai/local_tokenizer.py)
 - [Mistral common](https://github.com/mistralai/mistral-common)
 - [OpenAI Harmony](https://github.com/openai/harmony)

--- a/docs/pi-contextimate.md
+++ b/docs/pi-contextimate.md
@@ -51,7 +51,7 @@ A second study on 5 August 2026 covered Gemini, Kimi, GLM, Cohere, Grok, DeepSee
 | Qwen 2.5 and 3 | 4.0 | 3.8 |
 | Qwen 3.5 | 3.9 | 3.5 |
 
-These profiles cover visible text only. Dynamic aliases and unverified Gemini, GLM Turbo, DeepSeek and Qwen variants use the existing generic estimate or fallback until routing identifies a counted model. The [tokenizer coverage audit](./contextimate-tokenizer-coverage-audit-2026-08-05.md) contains the count fingerprints, tokenizer hashes, token-stream fingerprints, xAI fingerprints and family boundaries.
+These profiles cover visible text only. Dynamic aliases and unverified variants keep the generic estimate or fallback. The [tokenizer coverage audit](./contextimate-tokenizer-coverage-audit-2026-08-05.md) records the evidence and family boundaries.
 
 ## Tool schemas
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -124,14 +124,9 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   earlier. `parseContextimateConfig` drops non-positive JSON denominators before
   resolution; `cleanDenominator` remains the defensive pure boundary for direct patches.
   This is user-configurable surface; precedence bugs misprice every row.
-- **Built-in rule matching**: boundary table: `claude-opus-4-8`, Fable 5 and Opus 5
-  → Claude 4.7+ rule; explicit Radius/OpenRouter relays keep
-  that tokenizer while Bedrock keeps its payload shape; `claude-sonnet-4-5` → 4.5/4.6
-  rule; other Anthropic → generic; counted Gemini and pinned Kimi, GLM, Cohere, Grok,
-  DeepSeek and Qwen IDs → their measured raw-text profiles through each supported
-  route; dynamic and unverified aliases → fallback; `openai-codex` vs `openai` vs
-  `mistral` vs `gemini`
-  vs `bedrock` routing by provider/API.
+- **Built-in rule matching**: boundary tables map explicit model IDs to measured
+  families and leave dynamic or unverified aliases on the fallback. Separate cases pin
+  Claude family boundaries and tool payload routing by provider and API.
 - **Tool payload shaping**: for one frozen `ToolSummary` fixture, the exact JSON emitted
   per shape (`anthropic`, `openai-responses`, `openai-chat`, `bedrock`, `raw-schema`),
   the *aggregated* gemini `functionDeclarations` form, and the unknown-shape fallback to

--- a/scripts/contextimate/README.md
+++ b/scripts/contextimate/README.md
@@ -56,6 +56,8 @@ Live calls always require `--provider`, because wire compatibility does not iden
 
 With at least 2 tools, the checker removes the shared tool-block overhead before suggesting Contextimate denominators. Tests cover request construction and this calculation. Network execution remains manual.
 
+The calibration checks below are manual. They add no runtime dependencies or startup network calls, and make no generation requests.
+
 ## Open tokenizer calibration
 
 Reproduce the Kimi, GLM, Cohere, DeepSeek and Qwen raw-text profiles from a source checkout:
@@ -65,7 +67,7 @@ uv run --with 'huggingface-hub==1.26.0' --with 'tokenizers==0.22.2' \
   --with 'tiktoken==0.13.0' scripts/contextimate/study-open-tokenizers.py --json
 ```
 
-The script pins every model revision and tokenizer hash. It reads a public corpus from git revision `556dd115a77839773e143afc0d982afa59eb7479`. Later code changes cannot move the baseline silently. The script downloads tokenizer artifacts and makes no generation calls. It reads Kimi's pinned rank file and configuration directly. For DeepSeek and Qwen, it also checks the ordinary-text BPE content and exact corpus token stream for every grouped artifact. It executes no repository code.
+The script pins each revision and tokenizer hash. It reads the public corpus at git revision `556dd115a77839773e143afc0d982afa59eb7479`, so later changes cannot move the baseline. It verifies Kimi's rank file and configuration directly. For DeepSeek and Qwen, it checks the BPE content and corpus token stream of every artifact. It does not execute downloaded code.
 
 ## Gemini count fingerprints
 
@@ -75,20 +77,18 @@ Gemini exposes counts through the official `countTokens` endpoint. Reproduce the
 GEMINI_API_KEY=... scripts/contextimate/check-gemini-tokenizers.py --json
 ```
 
-The checker sends each public corpus fixture as one user text part. Its 17 default IDs are the countable Gemini 2.x and 3.x models represented in Pi's current catalog. It groups models only when all returned counts match. Use repeated `--model` options to check another exact model ID. The script makes no generation calls and never prints the key or source text.
-
-This is a live, date-stamped check. Google can retire preview model IDs, so the checked-in evidence remains the record for the measured revisions.
+The checker sends each fixture as one user text part. It groups its 17 default model IDs only when all counts match. Repeat `--model` to check another exact ID. It never prints the key or source text. Google can retire preview IDs, so the checked-in evidence preserves the measured result.
 
 ## Relay alias verification
 
-OpenRouter and Vercel publish the concrete model behind each relay ID. Verify the profiled DeepSeek and Qwen routes against those public catalogs:
+Verify profiled DeepSeek and Qwen routes against OpenRouter and Vercel's public catalogs:
 
 ```bash
 npm run link-pi
 scripts/contextimate/check-relay-tokenizer-routes.py
 ```
 
-The checker reads model IDs from the installed Pi AI catalog and the checked-in route evidence. It compares OpenRouter's canonical and Hugging Face IDs and Vercel's full model names. It needs no API key, makes no generation calls and runs only when invoked.
+The checker compares installed Pi routes with OpenRouter's Hugging Face IDs and Vercel's full model names. It needs no API key.
 
 ## xAI tokenizer fingerprints
 
@@ -102,5 +102,3 @@ uv run --with 'xai-sdk==1.17.0' \
 It reads `XAI_API_KEY`, or a fresh xAI OAuth login from Pi. The fixed public corpus covers prose, code, multilingual text, whitespace, control-like strings and deterministic random text. Models join one group only when every token record matches.
 
 Add `--contextimate-corpus` to calculate divisors from the pinned open-tokenizer corpus. Add `--file <path>` for another local corpus, but never send sensitive files. Use repeated `--model` options to inspect aliases. The script reports the resolved model. It never prints credentials or source text.
-
-This is an explicit live diagnostic. It makes no generation calls, and Contextimate never calls it at startup.

--- a/scripts/contextimate/check-gemini-tokenizers.py
+++ b/scripts/contextimate/check-gemini-tokenizers.py
@@ -13,9 +13,7 @@ import urllib.parse
 import urllib.request
 from collections import defaultdict
 
-sys.dont_write_bytecode = True
-
-from tokenizer_corpus import CORPUS_FILES, CORPUS_REVISION, pinned_corpus
+from tokenizer_corpus import CORPUS_FILES, CORPUS_REVISION, count_summary, pinned_corpus
 
 DEFAULT_MODELS = (
     "gemini-2.0-flash",
@@ -81,26 +79,6 @@ def count_tokens(model: str, text: str, api_key: str) -> int:
     return total
 
 
-def aggregate(
-    samples: dict[str, dict[str, float | int]], names: list[str]
-) -> dict[str, float | int]:
-    chars = sum(int(samples[name]["chars"]) for name in names)
-    tokens = sum(int(samples[name]["tokens"]) for name in names)
-    return {
-        "chars": chars,
-        "tokens": tokens,
-        "charsPerToken": round(chars / tokens, 4),
-        "recommendedDenominator": round(chars / tokens, 1),
-    }
-
-
-def count_fingerprint(samples: dict[str, dict[str, float | int]]) -> str:
-    counts = [[name, samples[name]["tokens"]] for name in sorted(samples)]
-    return hashlib.sha256(
-        json.dumps(counts, separators=(",", ":")).encode()
-    ).hexdigest()
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Count the repository's public calibration corpus with Gemini countTokens.",
@@ -142,15 +120,18 @@ def main() -> None:
                 "tokens": tokens,
                 "charsPerToken": round(len(text) / tokens, 4),
             }
+        counts = [[name, samples[name]["tokens"]] for name in sorted(samples)]
         rows.append(
             {
                 "model": model,
-                "countFingerprint": count_fingerprint(samples),
+                "countFingerprint": hashlib.sha256(
+                    json.dumps(counts, separators=(",", ":")).encode()
+                ).hexdigest(),
                 "samples": samples,
-                "text": aggregate(
+                "text": count_summary(
                     samples, ["instructions-core", "instructions-design"]
                 ),
-                "session": aggregate(samples, ["session-code", "session-tests"]),
+                "session": count_summary(samples, ["session-code", "session-tests"]),
             }
         )
 
@@ -163,13 +144,6 @@ def main() -> None:
         "corpusFiles": CORPUS_FILES,
         "endpoint": f"{ENDPOINT}/{{model}}:countTokens",
         "requestCoverage": "one user text part per corpus fixture",
-        "models": [
-            {
-                "model": row["model"],
-                "countFingerprint": row["countFingerprint"],
-            }
-            for row in rows
-        ],
         "groups": [
             {
                 "countFingerprint": fingerprint,

--- a/scripts/contextimate/check-relay-tokenizer-routes.py
+++ b/scripts/contextimate/check-relay-tokenizer-routes.py
@@ -7,13 +7,10 @@ import argparse
 import json
 import re
 import sys
-import urllib.error
 import urllib.request
 from datetime import date
 from pathlib import Path
 from typing import Any
-
-sys.dont_write_bytecode = True
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_EVIDENCE = (
@@ -43,94 +40,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_object(path: Path) -> dict[str, Any]:
-    try:
-        payload: Any = json.loads(path.read_text())
-    except FileNotFoundError:
-        raise RuntimeError(f"missing {path}; run npm run link-pi if needed") from None
-    if not isinstance(payload, dict):
-        raise RuntimeError(f"expected a JSON object in {path}")
-    return payload
-
-
-def model_records(value: Any) -> list[dict[str, str]]:
-    if isinstance(value, list):
-        return [record for item in value for record in model_records(item)]
-    if not isinstance(value, dict):
-        return []
-    if all(isinstance(value.get(key), str) for key in ("provider", "id", "api")):
-        return [
-            {
-                "provider": value["provider"],
-                "id": value["id"],
-                "api": value["api"],
-            }
-        ]
-    return [record for item in value.values() for record in model_records(item)]
-
-
-def profiled_model_ids(evidence: dict[str, Any]) -> set[str]:
-    route_evidence = evidence.get("openFamilyPiRoutes")
-    if not isinstance(route_evidence, dict):
-        raise RuntimeError("evidence omitted openFamilyPiRoutes")
-    families = route_evidence.get("families")
-    if not isinstance(families, list):
-        raise RuntimeError("route evidence omitted families")
-    result: set[str] = set()
-    for family in families:
-        if not isinstance(family, dict) or not isinstance(family.get("groups"), list):
-            raise RuntimeError("route evidence contains a malformed family")
-        for group in family["groups"]:
-            if not isinstance(group, dict) or not isinstance(group.get("label"), str):
-                raise RuntimeError("route evidence contains a malformed group")
-            ids = group.get("modelIds")
-            if not isinstance(ids, list) or not all(
-                isinstance(item, str) for item in ids
-            ):
-                raise RuntimeError("route evidence contains malformed model IDs")
-            if group["label"] != "fallback chars/4":
-                result.update(ids)
-    return result
-
-
-def pinned_repositories(evidence: dict[str, Any]) -> set[str]:
-    tokenizers = evidence.get("openTokenizers")
-    if not isinstance(tokenizers, dict) or not isinstance(
-        tokenizers.get("profiles"), list
-    ):
-        raise RuntimeError("evidence omitted open tokenizer profiles")
-    repositories: set[str] = set()
-    for profile in tokenizers["profiles"]:
-        if not isinstance(profile, dict) or not isinstance(
-            profile.get("familyArtifacts"), list
-        ):
-            raise RuntimeError("evidence contains malformed tokenizer artifacts")
-        for artifact in profile["familyArtifacts"]:
-            if not isinstance(artifact, dict) or not isinstance(
-                artifact.get("repository"), str
-            ):
-                raise RuntimeError("evidence contains a malformed tokenizer artifact")
-            repositories.add(artifact["repository"])
-    return repositories
-
-
-def normalized_model_name(value: str) -> str:
-    return re.sub(r"[^a-z0-9]", "", value.lower())
-
-
-def artifact_for_name(name: str, repositories: set[str]) -> str:
-    normalized = normalized_model_name(name)
-    candidates = [
-        repository
-        for repository in repositories
-        if normalized_model_name(repository.rsplit("/", 1)[-1])
-        in (normalized, normalized.removesuffix("thinking"))
-    ]
-    if len(candidates) != 1:
-        raise RuntimeError(
-            f"could not resolve relay model name to one artifact: {name}"
-        )
-    return candidates[0]
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text())
 
 
 def fetch_models(endpoint: str) -> dict[str, dict[str, Any]]:
@@ -138,31 +49,52 @@ def fetch_models(endpoint: str) -> dict[str, dict[str, Any]]:
         endpoint,
         headers={"User-Agent": "pine-of-glass-contextimate-calibration"},
     )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            payload: Any = json.load(response)
-    except urllib.error.HTTPError as error:
-        raise RuntimeError(f"{endpoint} returned HTTP {error.code}") from None
-    except urllib.error.URLError as error:
-        raise RuntimeError(f"{endpoint} request failed: {error.reason}") from None
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload: Any = json.load(response)
     if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
         raise RuntimeError(f"{endpoint} returned malformed JSON")
-    models: dict[str, dict[str, Any]] = {}
-    for model in payload["data"]:
-        if isinstance(model, dict) and isinstance(model.get("id"), str):
-            models[model["id"]] = model
-    return models
+    return {
+        model["id"]: model
+        for model in payload["data"]
+        if isinstance(model, dict) and isinstance(model.get("id"), str)
+    }
 
 
-def current_resolutions(evidence: dict[str, Any]) -> dict[str, Any]:
-    profiled_ids = profiled_model_ids(evidence)
-    repositories = pinned_repositories(evidence)
+def model_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def main() -> None:
+    args = parse_args()
+    evidence = read_json(args.evidence)
+    profiled_ids = {
+        model_id
+        for family in evidence["openFamilyPiRoutes"]["families"]
+        for group in family["groups"]
+        if group["label"] != "fallback chars/4"
+        for model_id in group["modelIds"]
+    }
+    repositories = {
+        artifact["repository"]
+        for profile in evidence["openTokenizers"]["profiles"]
+        for artifact in profile["familyArtifacts"]
+    }
     repositories_by_lower = {repository.lower() for repository in repositories}
+    repositories_by_key = {
+        model_key(repository.rsplit("/", 1)[-1]): repository
+        for repository in repositories
+    }
+
     catalogs = []
     for provider, endpoint in CATALOGS:
-        records = model_records(load_object(PI_AI_DATA / f"{provider}.json"))
+        installed = read_json(PI_AI_DATA / f"{provider}.json")
         route_ids = sorted(
-            {record["id"] for record in records if record["id"] in profiled_ids}
+            {
+                model_id
+                for models in installed.values()
+                for model_id in models
+                if model_id in profiled_ids
+            }
         )
         live = fetch_models(endpoint)
         missing = [model_id for model_id in route_ids if model_id not in live]
@@ -170,56 +102,53 @@ def current_resolutions(evidence: dict[str, Any]) -> dict[str, Any]:
             raise RuntimeError(
                 f"{provider} omitted profiled routes: {', '.join(missing)}"
             )
-        if provider == "openrouter":
-            routes = [
-                {
-                    "id": model_id,
-                    "canonicalSlug": live[model_id].get("canonical_slug"),
-                    "huggingFaceId": live[model_id].get("hugging_face_id"),
-                }
-                for model_id in route_ids
-            ]
-            if any(
-                not isinstance(route["huggingFaceId"], str)
-                or route["huggingFaceId"].lower() not in repositories_by_lower
-                for route in routes
-            ):
-                raise RuntimeError("OpenRouter did not resolve to a pinned artifact")
-        else:
-            routes = []
-            for model_id in route_ids:
-                name = live[model_id].get("name")
+
+        routes = []
+        for model_id in route_ids:
+            model = live[model_id]
+            if provider == "openrouter":
+                artifact = model.get("hugging_face_id")
+                if (
+                    not isinstance(artifact, str)
+                    or artifact.lower() not in repositories_by_lower
+                ):
+                    raise RuntimeError(
+                        f"OpenRouter did not resolve {model_id} to a pinned artifact"
+                    )
+                route = {"id": model_id, "huggingFaceId": artifact}
+                canonical_slug = model.get("canonical_slug")
+                if canonical_slug != model_id:
+                    if not isinstance(canonical_slug, str):
+                        raise RuntimeError(
+                            f"OpenRouter omitted the canonical slug for {model_id}"
+                        )
+                    route["canonicalSlug"] = canonical_slug
+            else:
+                name = model.get("name")
                 if not isinstance(name, str):
-                    raise RuntimeError("Vercel omitted a profiled model name")
-                routes.append(
-                    {
-                        "id": model_id,
-                        "name": name,
-                        "artifact": artifact_for_name(name, repositories),
-                    }
-                )
+                    raise RuntimeError(f"Vercel omitted the name for {model_id}")
+                key = model_key(name)
+                if model_id == "deepseek/deepseek-v3.2-thinking":
+                    key = key.removesuffix("thinking")
+                artifact = repositories_by_key.get(key)
+                if artifact is None:
+                    raise RuntimeError(
+                        f"Vercel model name did not match a pinned artifact: {name}"
+                    )
+                route = {"id": model_id, "name": name, "artifact": artifact}
+            routes.append(route)
         catalogs.append({"provider": provider, "endpoint": endpoint, "routes": routes})
-    return {"checkedAt": date.today().isoformat(), "catalogs": catalogs}
 
-
-def main() -> None:
-    args = parse_args()
-    evidence = load_object(args.evidence)
-    current = current_resolutions(evidence)
+    current = {"checkedAt": date.today().isoformat(), "catalogs": catalogs}
     if args.json:
         print(json.dumps(current, indent=2))
-        return
-    expected = evidence.get("relayAliasResolutions")
-    if (
-        not isinstance(expected, dict)
-        or expected.get("catalogs") != current["catalogs"]
-    ):
+    elif evidence.get("relayAliasResolutions", {}).get("catalogs") != catalogs:
         raise RuntimeError("relay alias resolutions differ; inspect --json output")
-    counts = ", ".join(
-        f"{catalog['provider']} {len(catalog['routes'])}"
-        for catalog in current["catalogs"]
-    )
-    print(f"relay alias resolutions match checked evidence: {counts}")
+    else:
+        counts = ", ".join(
+            f"{catalog['provider']} {len(catalog['routes'])}" for catalog in catalogs
+        )
+        print(f"relay alias resolutions match checked evidence: {counts}")
 
 
 if __name__ == "__main__":

--- a/scripts/contextimate/check-xai-tokenizers.py
+++ b/scripts/contextimate/check-xai-tokenizers.py
@@ -17,8 +17,6 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Protocol
 
-sys.dont_write_bytecode = True
-
 from tokenizer_corpus import CORPUS_REVISION, pinned_corpus
 
 DEFAULT_MODELS = [

--- a/scripts/contextimate/study-open-tokenizers.py
+++ b/scripts/contextimate/study-open-tokenizers.py
@@ -14,9 +14,7 @@ from dataclasses import dataclass
 from importlib.metadata import version
 from importlib.util import find_spec
 
-sys.dont_write_bytecode = True
-
-from tokenizer_corpus import CORPUS_FILES, CORPUS_REVISION, pinned_corpus
+from tokenizer_corpus import CORPUS_FILES, CORPUS_REVISION, count_summary, pinned_corpus
 
 
 @dataclass(frozen=True)
@@ -524,7 +522,6 @@ def check_artifact(
             raise RuntimeError(
                 f"{spec.repository} tokenizer BPE hash changed: {bpe_hash}"
             )
-        result["bpeSha256"] = bpe_hash
     if spec.pattern_sha256 is not None:
         source = hf_hub_download(
             spec.repository, "tokenization_kimi.py", revision=spec.revision
@@ -597,19 +594,6 @@ def token_stream_sha256(
     return hashlib.sha256(encoded).hexdigest()
 
 
-def aggregate(
-    samples: dict[str, dict[str, float | int]], names: list[str]
-) -> dict[str, float | int]:
-    chars = sum(int(samples[name]["chars"]) for name in names)
-    tokens = sum(int(samples[name]["tokens"]) for name in names)
-    return {
-        "chars": chars,
-        "tokens": tokens,
-        "charsPerToken": round(chars / tokens, 4),
-        "recommendedDenominator": round(chars / tokens, 1),
-    }
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Count the repository's public calibration corpus with pinned open tokenizers.",
@@ -673,11 +657,15 @@ def main() -> None:
             "profile": spec.label,
             "familyArtifacts": artifacts,
             "samples": samples,
-            "text": aggregate(samples, ["instructions-core", "instructions-design"]),
-            "session": aggregate(samples, ["session-code", "session-tests"]),
+            "text": count_summary(
+                samples, ["instructions-core", "instructions-design"]
+            ),
+            "session": count_summary(samples, ["session-code", "session-tests"]),
         }
         if spec.representative.filename == "tiktoken.model":
             row["configurationSha256"] = KIMI_CONFIG_HASH
+        if spec.representative.bpe_sha256 is not None:
+            row["bpeSha256"] = spec.representative.bpe_sha256
         if spec.token_stream_sha256 is not None:
             row["tokenStreamSha256"] = spec.token_stream_sha256
         rows.append(row)

--- a/scripts/contextimate/tokenizer_corpus.py
+++ b/scripts/contextimate/tokenizer_corpus.py
@@ -22,6 +22,19 @@ CORPUS_FILES = {
 }
 
 
+def count_summary(
+    samples: dict[str, dict[str, float | int]], names: list[str]
+) -> dict[str, float | int]:
+    chars = sum(int(samples[name]["chars"]) for name in names)
+    tokens = sum(int(samples[name]["tokens"]) for name in names)
+    return {
+        "chars": chars,
+        "tokens": tokens,
+        "charsPerToken": round(chars / tokens, 4),
+        "recommendedDenominator": round(chars / tokens, 1),
+    }
+
+
 def pinned_corpus() -> dict[str, str]:
     def read(path: str) -> str:
         return subprocess.run(

--- a/tests/contextimate/heuristics.test.ts
+++ b/tests/contextimate/heuristics.test.ts
@@ -104,9 +104,6 @@ test("measured tokenizer families remain independent of their wire API", () => {
     [model("kimi-coding", "k3-256k", "anthropic-messages"), "Kimi tokenizer", "anthropic"],
     [model("amazon-bedrock", "zai.glm-4.7", "bedrock-converse-stream"), "GLM 4.5 tokenizer", "bedrock"],
     [model("xai", "grok-4.5", "openai-responses"), "Grok 4.5 tokenizer", "openai-responses"],
-    [model("vercel-ai-gateway", "google/gemini-3.5-flash", "anthropic-messages"), "Gemini 2/3 countTokens", "anthropic"],
-    [model("vercel-ai-gateway", "deepseek/deepseek-v3.2", "anthropic-messages"), "DeepSeek tokenizer", "anthropic"],
-    [model("amazon-bedrock", "qwen.qwen3-coder-next", "bedrock-converse-stream"), "Qwen 2.5/3 tokenizer", "bedrock"],
   ] as const;
 
   for (const [current, label, toolNumerator] of cases) {


### PR DESCRIPTION
## Summary

- replace broad relay parsing and one-use helpers with direct catalog handling
- remove duplicate machine evidence and repeated policy prose
- drop redundant wire-independence cases while keeping realistic family and fallback coverage

The cleanup removes 294 net lines without changing runtime tokenizer routing.

## Verification

- `npm run check` (331 tests)
- full open-tokenizer evidence reproduction (8 profiles, 61 artifacts)
- Gemini evidence rendering reproduced from checked counts (17 models)
- live relay catalog check (36 OpenRouter, 17 Vercel routes)
- Ruff, Python compilation and `npm pack --dry-run --json`

No release or version bump.