### PR TITLE
Fix Traceline startup on Pi 0.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.10.1 (2026-08-06)
+
+- Traceline works with Pi 0.84's stable TUI reference. Its delayed render hook now
+  wraps the shared renderer prototype instead of assigning through Pi's proxy, avoiding
+  a recursive `requestRender` call that crashed Pi at startup. The hook follows runtime
+  switches between regular and fullscreen mode.
 - Contextimate adds measured visible-text profiles for Gemini, Kimi, GLM, Cohere,
   Grok, DeepSeek and Qwen. Explicit, verified model IDs use the new profiles; dynamic
   and unverified variants keep the generic estimate or fallback.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -75,6 +75,7 @@ it. When `pi update` breaks one, the failure message says exactly which seam mov
 | A real Pi-built system prompt (constructed via Pi's own prompt assembly against a fixture project dir with an AGENTS.md and one skill) matches `PROJECT_INSTRUCTIONS_RE`, `AVAILABLE_SKILLS_RE`, `SKILL_RE`, and `getPromptRemainder` strips both blocks | contextimate section parsing; it silently renders wrong buckets if the prompt format drifts |
 | `[Context]`/`[Skills]`/… resource headers still render in the startup transcript shape matched by `RESOURCE_HEADER_RE` | contextimate block insertion point |
 | `ToolExecutionComponent` (or successor) instances satisfy `isToolRow`: `render`, `setExpanded`, `toolName` in instance; prototype is patchable | traceline prototype patch |
+| Pi's extension-visible stable TUI reference resolves `requestRender` through a writable shared prototype across regular/fullscreen renderer replacement | traceline delayed row patching and Ctrl+T status suppression |
 | A successful silent built-in bash call returns exactly `(no output)` | traceline's terminal `gh pr merge` evidence rule |
 | Assistant message component satisfies `isAssistantRow`: `setHideThinkingBlock` fn + `hideThinkingBlock` boolean | traceline collapse-state source of truth |
 | A collapsed `AssistantMessageComponent` skips empty thinking blocks, emits one label per adjacent thinking run, and keeps native spacers across tool and text boundaries | traceline grouped thinking previews |

--- a/extensions/_lib/chat.ts
+++ b/extensions/_lib/chat.ts
@@ -92,8 +92,6 @@ export interface AssistantRowPrototypeLike extends Partial<AssistantRowLike> {
 
 export interface TracelineTuiLike {
   requestRender: (force?: boolean) => unknown;
-  __tracelineRRWrapVersion?: number;
-  __tracelineOriginalRequestRender?: (force?: boolean) => unknown;
 }
 
 /** Total text chars across a result's text blocks; undefined before a result exists. */

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -55,6 +55,7 @@ import {
   type DiffStats,
 } from "./write-diff.ts";
 import { dedupeThinkingLabels } from "./thinking-preview.ts";
+import { patchRequestRender } from "./request-render.ts";
 import { handleThinkingToggleTerminalInput } from "./thinking-toggle.ts";
 
 /**
@@ -160,7 +161,7 @@ const TOOL_PREFIX_VISIBLE_WIDTH = TOOL_INDENT.length + 2 + 1 + TOOL_AFTER_BULLET
 // gutter, so the suffix column never touches the terminal edge.
 const TOOL_RIGHT_MARGIN = 2;
 const ONE_LINE_CAPTURE_WIDTH = 10_000;
-const TRACELINE_PATCH_VERSION = 28;
+const TRACELINE_PATCH_VERSION = 29;
 const TRACELINE_ASSISTANT_PATCH_VERSION = 4;
 
 // --- theme-derived ink (design language §3) --------------------------------------------
@@ -1714,9 +1715,10 @@ export default function piTraceline(pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
-    // Capture the real TUI (passed synchronously to the widget factory), then patch only
-    // extension-visible seams: requestRender for delayed tool-row patching, and raw
-    // terminal input for Ctrl+T expansion coordination plus release/repeat handling.
+    // Capture Pi's extension-visible TUI handle (passed synchronously to the widget
+    // factory), then patch only extension-visible seams: requestRender for delayed
+    // tool-row patching, and raw terminal input for Ctrl+T expansion coordination plus
+    // release/repeat handling.
     g.__tracelineGetTheme = () => {
       try {
         return (ctx.ui as ExtensionUiWithTheme).theme;
@@ -1728,20 +1730,14 @@ export default function piTraceline(pi: ExtensionAPI) {
     captureTui(ctx.ui, "__pi_traceline_capture", (tui) => {
       const t = tui as TracelineTuiLike;
       g.__tracelineTui = t;
-      if (t.__tracelineRRWrapVersion !== TRACELINE_PATCH_VERSION) {
-        const orig = t.__tracelineOriginalRequestRender ?? t.requestRender.bind(t);
-        t.__tracelineOriginalRequestRender = orig;
-        t.requestRender = (force?: boolean) => {
-          tryPatch();
-          try {
-            suppressThinkingToggleStatus();
-          } catch {
-            /* never let pi-traceline break a render */
-          }
-          return orig(force);
-        };
-        t.__tracelineRRWrapVersion = TRACELINE_PATCH_VERSION;
-      }
+      patchRequestRender(t, TRACELINE_PATCH_VERSION, () => {
+        tryPatch();
+        try {
+          suppressThinkingToggleStatus();
+        } catch {
+          /* never let pi-traceline break a render */
+        }
+      });
       tryPatch();
     });
 

--- a/extensions/pi-traceline/request-render.ts
+++ b/extensions/pi-traceline/request-render.ts
@@ -1,0 +1,41 @@
+import type { TracelineTuiLike } from "../_lib/chat.ts";
+
+interface TracelineTuiPrototypeLike extends TracelineTuiLike {
+  __tracelineRRWrapVersion?: number;
+  __tracelineOriginalRequestRender?: (force?: boolean) => unknown;
+}
+
+// Pi 0.84 made the extension-visible TUI a stable Proxy so regular/fullscreen mode
+// switches can replace its renderer. Assigning requestRender on that Proxy writes to the
+// current renderer; a previously captured proxy method then resolves the assignment again
+// and recurses. Patch the prototype that owns the native method instead. Both renderer
+// classes inherit it, and the same route also works with Pi <=0.83's direct TUI object.
+export function findRequestRenderPrototype(tui: TracelineTuiLike): TracelineTuiPrototypeLike | undefined {
+  // SAFETY: requestRender's prototype ownership is a private Pi TUI seam. The installed-
+  // Pi contract test exercises this walk through Pi's real stable TUI reference.
+  let candidate: object | null = Object.getPrototypeOf(tui);
+  while (candidate) {
+    const proto = candidate as Partial<TracelineTuiPrototypeLike>;
+    if (Object.prototype.hasOwnProperty.call(proto, "requestRender") && typeof proto.requestRender === "function") {
+      return proto as TracelineTuiPrototypeLike;
+    }
+    candidate = Object.getPrototypeOf(candidate);
+  }
+  return undefined;
+}
+
+export function patchRequestRender(
+  tui: TracelineTuiLike,
+  version: number,
+  beforeRender: () => void,
+): void {
+  const proto = findRequestRenderPrototype(tui);
+  if (!proto || proto.__tracelineRRWrapVersion === version) return;
+  const original = proto.__tracelineOriginalRequestRender ?? proto.requestRender;
+  proto.__tracelineOriginalRequestRender = original;
+  proto.requestRender = function (this: TracelineTuiLike, force?: boolean) {
+    beforeRender();
+    return original.call(this, force);
+  };
+  proto.__tracelineRRWrapVersion = version;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-of-glass",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Observability extensions for the Pi coding agent",
   "license": "MIT",
   "type": "module",

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,7 +7,7 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 859,
       "extensions/pi-contextimate/index.ts": 1568,
-      "extensions/pi-traceline/index.ts": 1766,
+      "extensions/pi-traceline/index.ts": 1762,
       "tests/contract/pi-internals.test.ts": 432,
       "tests/traceline/one-line.test.ts": 775
     }

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -253,15 +253,15 @@ test("chat-rebuild surface family line persistence depends on", () => {
   const container = new piTui.Container();
   assert.equal(typeof container.clear, "function", "Container.clear gone — clear hook cannot install");
 
-  // Pre-rows chat detection: pi now renders the startup resource listing into a
-  // loadedResourcesContainer sibling immediately before chatContainer. _lib/findChatContainer
-  // uses that sibling ordering as the fresh-session fallback anchor; the section headers
-  // must keep their names for resource-container detection.
-  assert.ok(source.includes("this.ui.addChild(this.loadedResourcesContainer);"), "loadedResourcesContainer no longer in root layout");
-  assert.ok(source.includes("this.ui.addChild(this.chatContainer);"), "chatContainer no longer in root layout");
+  // Pre-rows chat detection: Pi 0.84 nests loadedResourcesContainer immediately before
+  // chatContainer under the mounted documentContainer. _lib/findChatContainer walks
+  // recursively, then uses that sibling ordering as the fresh-session fallback anchor.
+  assert.ok(source.includes("this.documentContainer.addChild(this.loadedResourcesContainer);"), "loadedResourcesContainer no longer in transcript tree");
+  assert.ok(source.includes("this.documentContainer.addChild(this.chatContainer);"), "chatContainer no longer in transcript tree");
+  assert.ok(source.includes("this.documentContainer,"), "documentContainer no longer mounted in the TUI");
   assert.ok(
-    source.indexOf("this.ui.addChild(this.loadedResourcesContainer);") <
-      source.indexOf("this.ui.addChild(this.chatContainer);"),
+    source.indexOf("this.documentContainer.addChild(this.loadedResourcesContainer);") <
+      source.indexOf("this.documentContainer.addChild(this.chatContainer);"),
     "loadedResourcesContainer no longer sits before chatContainer — fresh-session detection needs rework",
   );
   assert.ok(

--- a/tests/contract/traceline-request-render.test.ts
+++ b/tests/contract/traceline-request-render.test.ts
@@ -1,0 +1,80 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import type { Terminal, TUI } from "@earendil-works/pi-tui";
+
+import { findRequestRenderPrototype, patchRequestRender } from "../../extensions/pi-traceline/request-render.ts";
+
+const piRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"))), "..");
+
+test("pi's stable TUI reference keeps traceline requestRender wrapping non-recursive", async () => {
+  const interactive = await import(pathToFileURL(join(piRoot, "dist/modes/interactive/interactive-mode.js")).href) as {
+    createInteractiveTui: (options: {
+      tuiMode: "regular" | "fullscreen";
+      showHardwareCursor: boolean;
+      logDirectory: string;
+      terminal: Terminal;
+    }) => TUI;
+    createInteractiveTuiReference: (getTui: () => TUI) => TUI;
+  };
+  const terminal: Terminal = {
+    columns: 100,
+    rows: 30,
+    kittyProtocolActive: false,
+    start() {},
+    stop() {},
+    async drainInput() {},
+    write() {},
+    moveBy() {},
+    hideCursor() {},
+    showCursor() {},
+    clearLine() {},
+    clearFromCursor() {},
+    clearScreen() {},
+    setTitle() {},
+    setProgress() {},
+  };
+  let renderer = interactive.createInteractiveTui({
+    tuiMode: "regular",
+    showHardwareCursor: false,
+    logDirectory: tmpdir(),
+    terminal,
+  });
+  const stableTui = interactive.createInteractiveTuiReference(() => renderer);
+  const owner = findRequestRenderPrototype(stableTui);
+  assert.ok(owner, "requestRender no longer has a writable prototype owner, traceline cannot install its delayed patch hook");
+
+  const patchedProperties = ["requestRender", "__tracelineOriginalRequestRender", "__tracelineRRWrapVersion"] as const;
+  const originalDescriptors = patchedProperties.map((name) => [name, Object.getOwnPropertyDescriptor(owner, name)] as const);
+  let beforeRenders = 0;
+  try {
+    patchRequestRender(stableTui, 1, () => { beforeRenders += 1; });
+    assert.doesNotThrow(
+      () => stableTui.requestRender(),
+      "stable-proxy requestRender recursed, do not assign the wrapper onto Pi's proxy/current renderer",
+    );
+    assert.equal(beforeRenders, 1, "regular renderer bypassed the traceline hook");
+    renderer.stop();
+
+    renderer = interactive.createInteractiveTui({
+      tuiMode: "fullscreen",
+      showHardwareCursor: false,
+      logDirectory: tmpdir(),
+      terminal,
+    });
+    assert.doesNotThrow(
+      () => stableTui.requestRender(),
+      "requestRender wrapper did not survive Pi's regular/fullscreen renderer replacement",
+    );
+    assert.equal(beforeRenders, 2, "fullscreen renderer bypassed the shared prototype hook");
+  } finally {
+    renderer.stop();
+    for (const [name, descriptor] of originalDescriptors) {
+      if (descriptor) Object.defineProperty(owner, name, descriptor);
+      else Reflect.deleteProperty(owner, name);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- wrap Pi 0.84's stable TUI reference at the shared `requestRender` prototype instead of assigning through its proxy
- add a real-runtime contract test covering recursion and regular/fullscreen renderer replacement
- update the Pi 0.84 transcript-tree contract and prepare the `v0.10.1` patch release

## Validation
- `npm run check` (332 tests)
- `npm run test:smoke` (all real-Pi TUI smokes)