### PR TITLE
Simplify Traceline's Pi 0.84 compatibility patch

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -75,7 +75,7 @@ it. When `pi update` breaks one, the failure message says exactly which seam mov
 | A real Pi-built system prompt (constructed via Pi's own prompt assembly against a fixture project dir with an AGENTS.md and one skill) matches `PROJECT_INSTRUCTIONS_RE`, `AVAILABLE_SKILLS_RE`, `SKILL_RE`, and `getPromptRemainder` strips both blocks | contextimate section parsing; it silently renders wrong buckets if the prompt format drifts |
 | `[Context]`/`[Skills]`/… resource headers still render in the startup transcript shape matched by `RESOURCE_HEADER_RE` | contextimate block insertion point |
 | `ToolExecutionComponent` (or successor) instances satisfy `isToolRow`: `render`, `setExpanded`, `toolName` in instance; prototype is patchable | traceline prototype patch |
-| Pi's extension-visible stable TUI reference resolves `requestRender` through a writable shared prototype across regular/fullscreen renderer replacement | traceline delayed row patching and Ctrl+T status suppression |
+| Pi's stable TUI reference keeps one `requestRender` prototype across regular and fullscreen modes | traceline delayed row patching and Ctrl+T status suppression |
 | A successful silent built-in bash call returns exactly `(no output)` | traceline's terminal `gh pr merge` evidence rule |
 | Assistant message component satisfies `isAssistantRow`: `setHideThinkingBlock` fn + `hideThinkingBlock` boolean | traceline collapse-state source of truth |
 | A collapsed `AssistantMessageComponent` skips empty thinking blocks, emits one label per adjacent thinking run, and keeps native spacers across tool and text boundaries | traceline grouped thinking previews |

--- a/extensions/_lib/capture.ts
+++ b/extensions/_lib/capture.ts
@@ -1,14 +1,10 @@
-// Shared one-shot TUI capture: pi passes the live TUI synchronously to a widget
-// factory; grab it, then remove the throwaway widget so nothing is rendered.
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { TUI } from "@earendil-works/pi-tui";
 
-interface WidgetHost {
-  setWidget(key: string, factory: unknown): void;
-}
-
-export function captureTui(ui: WidgetHost, key: string, onCapture: (tui: unknown) => void): void {
-  ui.setWidget(key, (tui: unknown) => {
+export function captureTui(ui: ExtensionUIContext, key: string, onCapture: (tui: TUI) => void): void {
+  ui.setWidget(key, (tui) => {
     onCapture(tui);
-    return { render: () => [] as string[], invalidate: () => {} };
+    return { render: () => [], invalidate() {} };
   });
   ui.setWidget(key, undefined);
 }

--- a/extensions/_lib/chat.ts
+++ b/extensions/_lib/chat.ts
@@ -90,10 +90,6 @@ export interface AssistantRowPrototypeLike extends Partial<AssistantRowLike> {
   __tracelineOriginalAssistantRender?: (width: number) => unknown;
 }
 
-export interface TracelineTuiLike {
-  requestRender: (force?: boolean) => unknown;
-}
-
 /** Total text chars across a result's text blocks; undefined before a result exists. */
 export function resultTextCharCount(comp: ToolRowDataLike | undefined): number | undefined {
   const content = comp?.result?.content;

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -511,7 +511,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     s.ui = ctx.ui;
     s.theme = ctx.ui.theme;
     captureTui(ctx.ui, "__pi_cachemire_capture", (tui) => {
-      s.tui = tui as CachemireState["tui"];
+      s.tui = tui;
     });
     cacheWidget.lastText = undefined;
     updateWidget();

--- a/extensions/pi-meantime/index.ts
+++ b/extensions/pi-meantime/index.ts
@@ -217,7 +217,7 @@ export function registerMeantime(pi: ExtensionAPI, config: MeantimeConfig): void
     s.ui = ctx.ui;
     s.theme = ctx.ui.theme;
     captureTui(ctx.ui, "__pi_meantime_capture", (tui) => {
-      s.tui = tui as MeantimeState["tui"];
+      s.tui = tui;
     });
     if (g.__piMeantimeTimer) clearInterval(g.__piMeantimeTimer);
     g.__piMeantimeTimer = s.config.widget ? setInterval(() => updateWidget(), 1000) : undefined;

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth, type KeyId } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, type KeyId, type TUI } from "@earendil-works/pi-tui";
 import { rawIndexAtVisibleIndex, rawIndexBeforeVisibleIndex, stripAnsi } from "../_lib/ansi.ts";
 import { booleanValue, positiveNumberValue, isJsonObject, stringValue } from "../_lib/boundary.ts";
 import { captureTui } from "../_lib/capture.ts";
@@ -16,7 +16,6 @@ import {
   type ToolRowDataLike,
   type ToolRowLike,
   type ToolRowPrototypeLike,
-  type TracelineTuiLike,
 } from "../_lib/chat.ts";
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount } from "../_lib/fmt.ts";
@@ -129,21 +128,19 @@ import { handleThinkingToggleTerminalInput } from "./thinking-toggle.ts";
  * Spacing: one blank line before a tool group (restoring the spacer pi drops), none
  * between consecutive tools.
  *
- * Nothing in pi's node_modules is modified, so this survives `pi update`.
  */
 
 type ToolDisplayMode = "native" | "oneLine";
 
 type TracelineGlobal = typeof globalThis & {
   __tracelinePatchVersion?: number;
-  __tracelineTui?: TracelineTuiLike;
+  __tracelineTui?: TUI;
   __tracelineChat?: ContainerLike;
   __tracelineInputUnsubscribe?: () => void;
   __tracelineGetTheme?: () => Theme | undefined;
   __tracelineAssistantPatchVersion?: number;
 };
 const g = globalThis as TracelineGlobal;
-type ExtensionUiWithTheme = { theme?: Theme };
 function setTracelineChat(chat: ContainerLike | undefined): void { g.__tracelineChat = chat; }
 function getTracelineChat(): ContainerLike | undefined { return g.__tracelineChat; }
 function setTracelineThemeGetter(getTheme: (() => Theme | undefined) | undefined): void { g.__tracelineGetTheme = getTheme; }
@@ -161,13 +158,11 @@ const TOOL_PREFIX_VISIBLE_WIDTH = TOOL_INDENT.length + 2 + 1 + TOOL_AFTER_BULLET
 // gutter, so the suffix column never touches the terminal edge.
 const TOOL_RIGHT_MARGIN = 2;
 const ONE_LINE_CAPTURE_WIDTH = 10_000;
-const TRACELINE_PATCH_VERSION = 29;
-const TRACELINE_ASSISTANT_PATCH_VERSION = 4;
+const TOOL_ROW_PATCH_VERSION = 28;
+const ASSISTANT_ROW_PATCH_VERSION = 4;
 
 // --- theme-derived ink (design language §3) --------------------------------------------
-// The live Theme handle is captured at session_start; before that (and in unit tests
-// without one) ink() falls back to basic raw ANSI. The registered getter guards its
-// own property access, so the hottest call in the file stays bare.
+// Before session_start (and in unit tests without a UI), ink falls back to basic ANSI.
 
 function currentTheme(): Theme | undefined {
   return g.__tracelineGetTheme?.();
@@ -1490,7 +1485,7 @@ function renderTraceRow(comp: ToolRowLike, width: number): string[] {
 
 function patchAssistantRowPrototype(proto: AssistantRowPrototypeLike): void {
   if (!proto || typeof proto.render !== "function") return;
-  if (proto.__tracelineAssistantPatchVersion === TRACELINE_ASSISTANT_PATCH_VERSION) return;
+  if (proto.__tracelineAssistantPatchVersion === ASSISTANT_ROW_PATCH_VERSION) return;
   const original = proto.__tracelineOriginalAssistantRender ?? proto.render;
   proto.__tracelineOriginalAssistantRender = original;
   proto.render = function (this: AssistantRowDataLike, width: number) {
@@ -1504,14 +1499,14 @@ function patchAssistantRowPrototype(proto: AssistantRowPrototypeLike): void {
     }
     return lines;
   };
-  proto.__tracelineAssistantPatchVersion = TRACELINE_ASSISTANT_PATCH_VERSION;
-  g.__tracelineAssistantPatchVersion = TRACELINE_ASSISTANT_PATCH_VERSION;
+  proto.__tracelineAssistantPatchVersion = ASSISTANT_ROW_PATCH_VERSION;
+  g.__tracelineAssistantPatchVersion = ASSISTANT_ROW_PATCH_VERSION;
 }
 
 // --- prototype patch (shared by every current + future tool row, applied once) --------
 
 function currentPatchInstalled(): boolean {
-  return g.__tracelinePatchVersion === TRACELINE_PATCH_VERSION;
+  return g.__tracelinePatchVersion === TOOL_ROW_PATCH_VERSION;
 }
 
 // The write pre-image is captured at three seams, deduped by sameWriteInput: on
@@ -1521,7 +1516,7 @@ function currentPatchInstalled(): boolean {
 // session's first write is what installs the prototype patch, from its own
 // requestRender tick.
 function patchWriteSnapshotHooks(proto: ToolRowPrototypeLike): void {
-  if (!proto || proto.__tracelineWriteSnapshotPatchVersion === TRACELINE_PATCH_VERSION) return;
+  if (!proto || proto.__tracelineWriteSnapshotPatchVersion === TOOL_ROW_PATCH_VERSION) return;
 
   const originalSetArgsComplete = proto.__tracelineOriginalSetArgsComplete ?? proto.setArgsComplete;
   if (typeof originalSetArgsComplete === "function") {
@@ -1549,7 +1544,7 @@ function patchWriteSnapshotHooks(proto: ToolRowPrototypeLike): void {
     };
   }
 
-  proto.__tracelineWriteSnapshotPatchVersion = TRACELINE_PATCH_VERSION;
+  proto.__tracelineWriteSnapshotPatchVersion = TOOL_ROW_PATCH_VERSION;
 }
 
 function patchToolRowPrototype(proto: ToolRowPrototypeLike): void {
@@ -1572,11 +1567,11 @@ function patchToolRowPrototype(proto: ToolRowPrototypeLike): void {
       return original.call(this, width);
     }
   };
-  g.__tracelinePatchVersion = TRACELINE_PATCH_VERSION;
+  g.__tracelinePatchVersion = TOOL_ROW_PATCH_VERSION;
 }
 
 function assistantPatchInstalled(): boolean {
-  return g.__tracelineAssistantPatchVersion === TRACELINE_ASSISTANT_PATCH_VERSION;
+  return g.__tracelineAssistantPatchVersion === ASSISTANT_ROW_PATCH_VERSION;
 }
 
 function tryPatch(): void {
@@ -1675,13 +1670,7 @@ export default function piTraceline(pi: ExtensionAPI) {
     ui,
     theme: currentTheme,
     chatChildren,
-    requestRender: () => {
-      try {
-        g.__tracelineTui?.requestRender();
-      } catch {
-        /* never let drill mode break a render */
-      }
-    },
+    requestRender: () => g.__tracelineTui?.requestRender(),
     traceLines: (comp, width) => {
       const read = readRun(comp);
       if (read?.index === 0) return foldedReadLines(read.rows, width);
@@ -1714,29 +1703,14 @@ export default function piTraceline(pi: ExtensionAPI) {
     handler: async (_args, ctx) => startDrill(ctx),
   });
 
-  pi.on("session_start", async (_event, ctx) => {
-    // Capture Pi's extension-visible TUI handle (passed synchronously to the widget
-    // factory), then patch only extension-visible seams: requestRender for delayed
-    // tool-row patching, and raw terminal input for Ctrl+T expansion coordination plus
-    // release/repeat handling.
-    g.__tracelineGetTheme = () => {
-      try {
-        return (ctx.ui as ExtensionUiWithTheme).theme;
-      } catch {
-        return undefined;
-      }
-    };
+  pi.on("session_start", (_event, ctx) => {
+    g.__tracelineGetTheme = () => ctx.ui.theme;
     configureSizeThresholds(config);
     captureTui(ctx.ui, "__pi_traceline_capture", (tui) => {
-      const t = tui as TracelineTuiLike;
-      g.__tracelineTui = t;
-      patchRequestRender(t, TRACELINE_PATCH_VERSION, () => {
+      g.__tracelineTui = tui;
+      patchRequestRender(tui, () => {
         tryPatch();
-        try {
-          suppressThinkingToggleStatus();
-        } catch {
-          /* never let pi-traceline break a render */
-        }
+        suppressThinkingToggleStatus();
       });
       tryPatch();
     });
@@ -1753,7 +1727,7 @@ export default function piTraceline(pi: ExtensionAPI) {
     });
   });
 
-  pi.on("session_shutdown", async () => {
+  pi.on("session_shutdown", () => {
     exitDrillMode(); // restores the editor and turns mouse reporting off
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = undefined;

--- a/extensions/pi-traceline/request-render.ts
+++ b/extensions/pi-traceline/request-render.ts
@@ -1,41 +1,25 @@
-import type { TracelineTuiLike } from "../_lib/chat.ts";
+import type { TUI } from "@earendil-works/pi-tui";
 
-interface TracelineTuiPrototypeLike extends TracelineTuiLike {
+const PATCH_VERSION = 29;
+
+interface RequestRenderPrototype {
+  requestRender(force?: boolean): void;
   __tracelineRRWrapVersion?: number;
-  __tracelineOriginalRequestRender?: (force?: boolean) => unknown;
+  __tracelineOriginalRequestRender?: (force?: boolean) => void;
 }
 
-// Pi 0.84 made the extension-visible TUI a stable Proxy so regular/fullscreen mode
-// switches can replace its renderer. Assigning requestRender on that Proxy writes to the
-// current renderer; a previously captured proxy method then resolves the assignment again
-// and recurses. Patch the prototype that owns the native method instead. Both renderer
-// classes inherit it, and the same route also works with Pi <=0.83's direct TUI object.
-export function findRequestRenderPrototype(tui: TracelineTuiLike): TracelineTuiPrototypeLike | undefined {
-  // SAFETY: requestRender's prototype ownership is a private Pi TUI seam. The installed-
-  // Pi contract test exercises this walk through Pi's real stable TUI reference.
-  let candidate: object | null = Object.getPrototypeOf(tui);
-  while (candidate) {
-    const proto = candidate as Partial<TracelineTuiPrototypeLike>;
-    if (Object.prototype.hasOwnProperty.call(proto, "requestRender") && typeof proto.requestRender === "function") {
-      return proto as TracelineTuiPrototypeLike;
-    }
-    candidate = Object.getPrototypeOf(candidate);
-  }
-  return undefined;
-}
+export function patchRequestRender(tui: TUI, beforeRender: () => void): void {
+  // Writing through Pi's stable TUI proxy patches only the current renderer.
+  let prototype: object = Object.getPrototypeOf(tui);
+  while (!Object.hasOwn(prototype, "requestRender")) prototype = Object.getPrototypeOf(prototype);
+  const owner = prototype as RequestRenderPrototype;
+  if (owner.__tracelineRRWrapVersion === PATCH_VERSION) return;
 
-export function patchRequestRender(
-  tui: TracelineTuiLike,
-  version: number,
-  beforeRender: () => void,
-): void {
-  const proto = findRequestRenderPrototype(tui);
-  if (!proto || proto.__tracelineRRWrapVersion === version) return;
-  const original = proto.__tracelineOriginalRequestRender ?? proto.requestRender;
-  proto.__tracelineOriginalRequestRender = original;
-  proto.requestRender = function (this: TracelineTuiLike, force?: boolean) {
+  const original = owner.__tracelineOriginalRequestRender ?? owner.requestRender;
+  owner.__tracelineOriginalRequestRender = original;
+  owner.requestRender = function (this: TUI, force?: boolean) {
     beforeRender();
-    return original.call(this, force);
+    original.call(this, force);
   };
-  proto.__tracelineRRWrapVersion = version;
+  owner.__tracelineRRWrapVersion = PATCH_VERSION;
 }

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,8 +7,8 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 859,
       "extensions/pi-contextimate/index.ts": 1568,
-      "extensions/pi-traceline/index.ts": 1762,
-      "tests/contract/pi-internals.test.ts": 432,
+      "extensions/pi-traceline/index.ts": 1736,
+      "tests/contract/pi-internals.test.ts": 430,
       "tests/traceline/one-line.test.ts": 775
     }
   }

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -253,9 +253,7 @@ test("chat-rebuild surface family line persistence depends on", () => {
   const container = new piTui.Container();
   assert.equal(typeof container.clear, "function", "Container.clear gone — clear hook cannot install");
 
-  // Pre-rows chat detection: Pi 0.84 nests loadedResourcesContainer immediately before
-  // chatContainer under the mounted documentContainer. _lib/findChatContainer walks
-  // recursively, then uses that sibling ordering as the fresh-session fallback anchor.
+  // Fresh-session chat detection relies on these siblings inside the mounted transcript tree.
   assert.ok(source.includes("this.documentContainer.addChild(this.loadedResourcesContainer);"), "loadedResourcesContainer no longer in transcript tree");
   assert.ok(source.includes("this.documentContainer.addChild(this.chatContainer);"), "chatContainer no longer in transcript tree");
   assert.ok(source.includes("this.documentContainer,"), "documentContainer no longer mounted in the TUI");

--- a/tests/contract/traceline-request-render.test.ts
+++ b/tests/contract/traceline-request-render.test.ts
@@ -4,22 +4,16 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import type { Terminal, TUI } from "@earendil-works/pi-tui";
+import { TuiAltScreen, TuiMainScreen, type Terminal, type TUI } from "@earendil-works/pi-tui";
 
-import { findRequestRenderPrototype, patchRequestRender } from "../../extensions/pi-traceline/request-render.ts";
+import { patchRequestRender } from "../../extensions/pi-traceline/request-render.ts";
 
 const piRoot = resolve(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"))), "..");
 
-test("pi's stable TUI reference keeps traceline requestRender wrapping non-recursive", async () => {
-  const interactive = await import(pathToFileURL(join(piRoot, "dist/modes/interactive/interactive-mode.js")).href) as {
-    createInteractiveTui: (options: {
-      tuiMode: "regular" | "fullscreen";
-      showHardwareCursor: boolean;
-      logDirectory: string;
-      terminal: Terminal;
-    }) => TUI;
-    createInteractiveTuiReference: (getTui: () => TUI) => TUI;
-  };
+test("traceline's render hook follows Pi's stable TUI reference across modes", async () => {
+  const { createInteractiveTuiReference } = await import(
+    pathToFileURL(join(piRoot, "dist/modes/interactive/interactive-mode.js")).href
+  ) as { createInteractiveTuiReference: (getTui: () => TUI) => TUI };
   const terminal: Terminal = {
     columns: 100,
     rows: 30,
@@ -37,44 +31,20 @@ test("pi's stable TUI reference keeps traceline requestRender wrapping non-recur
     setTitle() {},
     setProgress() {},
   };
-  let renderer = interactive.createInteractiveTui({
-    tuiMode: "regular",
-    showHardwareCursor: false,
-    logDirectory: tmpdir(),
-    terminal,
-  });
-  const stableTui = interactive.createInteractiveTuiReference(() => renderer);
-  const owner = findRequestRenderPrototype(stableTui);
-  assert.ok(owner, "requestRender no longer has a writable prototype owner, traceline cannot install its delayed patch hook");
+  let renderer: TUI = new TuiMainScreen(terminal, false, tmpdir());
+  const stableTui = createInteractiveTuiReference(() => renderer);
+  let renders = 0;
 
-  const patchedProperties = ["requestRender", "__tracelineOriginalRequestRender", "__tracelineRRWrapVersion"] as const;
-  const originalDescriptors = patchedProperties.map((name) => [name, Object.getOwnPropertyDescriptor(owner, name)] as const);
-  let beforeRenders = 0;
+  patchRequestRender(stableTui, () => { renders += 1; });
   try {
-    patchRequestRender(stableTui, 1, () => { beforeRenders += 1; });
-    assert.doesNotThrow(
-      () => stableTui.requestRender(),
-      "stable-proxy requestRender recursed, do not assign the wrapper onto Pi's proxy/current renderer",
-    );
-    assert.equal(beforeRenders, 1, "regular renderer bypassed the traceline hook");
+    stableTui.requestRender();
+    assert.equal(renders, 1);
     renderer.stop();
 
-    renderer = interactive.createInteractiveTui({
-      tuiMode: "fullscreen",
-      showHardwareCursor: false,
-      logDirectory: tmpdir(),
-      terminal,
-    });
-    assert.doesNotThrow(
-      () => stableTui.requestRender(),
-      "requestRender wrapper did not survive Pi's regular/fullscreen renderer replacement",
-    );
-    assert.equal(beforeRenders, 2, "fullscreen renderer bypassed the shared prototype hook");
+    renderer = new TuiAltScreen(terminal, false, tmpdir());
+    stableTui.requestRender();
+    assert.equal(renders, 2);
   } finally {
     renderer.stop();
-    for (const [name, descriptor] of originalDescriptors) {
-      if (descriptor) Object.defineProperty(owner, name, descriptor);
-      else Reflect.deleteProperty(owner, name);
-    }
   }
 });


### PR DESCRIPTION
## Summary
- replace defensive TUI duck types and casts with Pi's public `TUI` types
- inline the one-use prototype lookup and remove redundant catch-and-ignore paths
- keep request-render versioning separate from tool-row patching
- reduce the regression test to observable regular/fullscreen behaviour
- remove stale comments and shrink the lint budgets

Net change: 82 fewer lines.

## Validation
- `npm run check` (332 tests)
- `npm run test:smoke` (all real-Pi TUI smokes)