### PR TITLE
fix(traceline): remove terminal mouse ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Traceline no longer replaces the TUI's `requestRender` method. It discovers new rows
   after Pi lifecycle events, captures write pre-images through `tool_call`, and uses
   Pi's stable TUI reference only to request redraws.
+- Traceline no longer enables or parses terminal mouse reporting in drill mode.
+  Drill remains keyboard-only, while Pi and the terminal retain control of
+  scrolling, selection, links and fullscreen mouse handling.
 
 ## 0.10.1 (2026-08-06)
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -686,23 +686,19 @@ The peek pager:
   a partially scrolled image shows its dim fact line in place (`scroll to
   view`), never a clipped or overdrawn image. Images are sized to fit the
   viewport so full visibility is always reachable
-- kitty image ids allocated by the pager are deleted when it closes, the same
-  bounded lifecycle as drill-mode mouse reporting: the mode cleans up every
-  terminal-state side effect it created, on exit and on shutdown
+- kitty image ids allocated by the pager are deleted when it closes. The pager
+  cleans up every terminal-state side effect it created, on exit and on shutdown
 - `j`/`k`, the arrows, page keys and `g`/`G` scroll; `h`/`l` and left/right
   move to the neighbouring numbered target without closing; `p` toggles
   expansion; digits jump; esc, enter or `q` closes back to drill mode
 
 Mouse:
 
-- the live transcript never owns mouse reporting: enabling it breaks terminal
-  text selection for the whole session, so z0 stays keyboard-and-scrollback
-  native. This is a hard rule, not a phasing decision
-- drill mode is a bounded exception: SGR mouse reporting is enabled on entry
-  and disabled on exit, on session shutdown and on process exit. The wheel
-  moves the selection (wheel up walks older rows); inside the pager it
-  scrolls. Every other mouse event is swallowed, never leaked to the editor.
-  `"drillMouse": false` in the family config opts out
+- Traceline never enables, disables, parses or consumes terminal mouse
+  reporting. Pi and the terminal own scrolling, selection and links in every
+  mode
+- drill mode stays keyboard-only. Future row clicking must use a public Pi
+  component-click API, never a render-wide hit map or raw terminal mouse input
 
 ## 10. Tempo facts
 

--- a/extensions/pi-traceline/README.md
+++ b/extensions/pi-traceline/README.md
@@ -56,7 +56,7 @@ Traceline follows Pi's reasoning visibility setting. The full view reuses Pi's o
 
 The tool view reads its state from the live assistant row. It cannot get out of sync with the reasoning view. Traceline hides Pi's `Thinking blocks: hidden/visible` caption because the changing tool rows already show the state.
 
-Outside drill mode, Traceline does not enable mouse reporting or change terminal scrolling.
+Traceline never enables, disables or reads terminal mouse reporting. Pi and the terminal keep full control of scrolling, selection and links.
 
 ## Drill into one row
 
@@ -81,15 +81,13 @@ Scroll with `j`/`k`, the arrow keys, the page keys or `g`/`G`. Press `h`/`l` to 
 
 The most common case takes two keys: `Alt+T`, then `1` for the latest call.
 
-Inside drill mode the mouse wheel works: it moves the selection, or scrolls the pager. Traceline turns mouse reporting on only while drill mode is open and turns it off again on exit, so normal terminal text selection is never affected.
-
-Configure drill mode in the same config file as the size thresholds:
+Configure the drill shortcut in the same config file as the size thresholds:
 
 ```json
-{ "drillKey": "alt+d", "drillMouse": false }
+{ "drillKey": "alt+d" }
 ```
 
-`drillKey` changes the shortcut. `drillMouse: false` keeps mouse reporting off even inside drill mode.
+`drillKey` changes the shortcut. Drill mode stays keyboard-only.
 
 On macOS, an Alt-letter shortcut works only when the terminal sends Option as Alt. In Ghostty, set `macos-option-as-alt = left` in the active config. cmux users can set the same value in Terminal settings or in `~/Library/Application Support/com.cmuxterm.app/config.ghostty`, then run `cmux reload-config`. This leaves right Option available for character composition. The `/drill` command works without Option-as-Alt.
 

--- a/extensions/pi-traceline/drill-input.ts
+++ b/extensions/pi-traceline/drill-input.ts
@@ -1,45 +1,13 @@
-// Drill mode's raw terminal-input hook (design language §9.13), fed by traceline's
-// onTerminalInput listener in index.ts. While the mode is active every mouse report is
-// consumed: the wheel scrolls the pager when open, else walks the selection (wheel up =
-// older); clicks and drags are swallowed so they never reach pi's editor as garbage
-// input. A foreign modifier chord ends the mode instead of dying in it: the exit is
-// synchronous (pi restores the editor inline in `close`) and the chord is deliberately
-// NOT consumed, so the very same keystroke lands in the restored editor and does what
-// it always does — option+up edits a queue, ctrl+c aborts, the entry chord re-freezes
-// the numbering through its own shortcut.
+// Drill mode's raw terminal-input hook (design language §9.13), fed by Traceline's
+// onTerminalInput listener in index.ts. A foreign modifier chord ends the mode instead
+// of dying in it: the exit is synchronous (Pi restores the editor inline in `close`)
+// and the chord is not consumed, so the same keystroke lands in the restored editor.
 
 import { isKeyRelease, parseKey } from "@earendil-works/pi-tui";
-import { drillState, exitDrillMode, setSelected } from "./drill.ts";
+import { drillState, exitDrillMode } from "./drill.ts";
 
-const SGR_MOUSE_EVENT = /\x1b\[<(\d+);\d+;\d+([Mm])/g;
-
-/** Net wheel movement across a chunk of SGR mouse events: negative = wheel up. */
-export function wheelDelta(data: string): number {
-  let wheel = 0;
-  SGR_MOUSE_EVENT.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = SGR_MOUSE_EVENT.exec(data))) {
-    if (match[2] !== "M") continue; // presses only; SGR release events end in lowercase m
-    const cb = Number(match[1]);
-    if ((cb & 64) === 0) continue; // not a wheel event
-    const dir = cb & 3; // 0 = wheel up, 1 = wheel down; 2/3 are horizontal, ignored
-    if (dir === 0 || dir === 1) wheel += dir === 0 ? -1 : 1;
-  }
-  return wheel;
-}
-
-export function handleDrillTerminalInput(data: string): { consume: true } | undefined {
-  const st = drillState();
-  if (!st) return undefined;
-  if (data.startsWith("\x1b[<") || data.startsWith("\x1b[M")) {
-    const wheel = wheelDelta(data);
-    if (wheel !== 0) {
-      if (st.pager) st.pager.scrollBy(wheel * 3);
-      else setSelected(st, st.selected - wheel);
-    }
-    return { consume: true };
-  }
-  if (isForeignChord(data)) exitDrillMode();
+export function handleDrillTerminalInput(data: string): undefined {
+  if (drillState() && isForeignChord(data)) exitDrillMode();
   return undefined;
 }
 

--- a/extensions/pi-traceline/drill-pager.ts
+++ b/extensions/pi-traceline/drill-pager.ts
@@ -50,7 +50,7 @@ type PagerBody = { lines: string[]; images: PagerImage[] };
 type CachedImage = { data: string; comp: Image };
 
 // A crash mid-peek must not leave transmitted kitty images behind in the terminal:
-// the same bounded lifecycle as drill-mode mouse reporting (§9.13).
+// pager-owned terminal state has the same bounded lifecycle as the pager (§9.13).
 const livePagers = new Set<DrillPager>();
 let exitGuardInstalled = false;
 

--- a/extensions/pi-traceline/drill.ts
+++ b/extensions/pi-traceline/drill.ts
@@ -5,11 +5,9 @@
 // opens the peek pager (drill-pager.ts); `p` toggles the selected row's native
 // expansion (§9.12 z1) in place; esc restores the editor and its draft. A modifier
 // chord the mode does not own (option+up, ctrl+c, …) exits the same way without being
-// consumed, so the keystroke lands in the restored editor. SGR mouse
-// reporting, never enabled for the plain transcript, turns on only inside the mode and
-// off at exit/shutdown/process-exit, with every mouse event consumed. State lives on
-// globalThis so that after /reload the previously patched tool-row renderer and the
-// freshly loaded controller share it, exactly like traceline's other seam globals.
+// consumed, so the keystroke lands in the restored editor. State lives on globalThis
+// so that after /reload the previously patched tool-row renderer and the freshly loaded
+// controller share it, exactly like traceline's other seam globals.
 
 import type { ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth, type Component, type KeyId } from "@earendil-works/pi-tui";
@@ -35,7 +33,6 @@ export type DrillHost = {
   /** True when the row renders nothing because an earlier row carries its fold. */
   hiddenByFold(comp: ToolRowLike): boolean;
   statusTone(comp: ToolRowLike): Tone;
-  mouse: boolean;
 };
 
 export type DrillState = {
@@ -48,12 +45,10 @@ export type DrillState = {
   pager?: DrillPager;
   closeHint?: () => void;
   closePager?: () => void;
-  mouseOn: boolean;
 };
 
 type DrillGlobal = typeof globalThis & {
   __tracelineDrill?: DrillState;
-  __tracelineDrillMouseGuard?: boolean;
 };
 const g = globalThis as DrillGlobal;
 
@@ -118,10 +113,8 @@ export function enterDrillMode(host: DrillHost): void {
     numbers: new Map(rows.map((row, i) => [row as unknown, i + 1])),
     selected: 0,
     digits: "",
-    mouseOn: false,
   };
   g.__tracelineDrill = st;
-  if (host.mouse) enableMouse(st);
   void host.ui
     .custom<undefined>((_tui, _theme, _kb, done) => {
       st.closeHint = () => done(undefined);
@@ -137,12 +130,11 @@ export function exitDrillMode(): void {
   const st = g.__tracelineDrill;
   if (!st) return;
   g.__tracelineDrill = undefined;
-  disableMouse(st);
   try {
     st.closePager?.();
     st.closeHint?.();
   } catch {
-    // Pi seam: a dispose-time close may throw during shutdown; state and mouse are already restored.
+    // Pi seam: a dispose-time close may throw during shutdown; state is already cleared.
   }
   st.host.requestRender();
 }
@@ -282,41 +274,5 @@ class DrillHintBar implements Component {
   invalidate(): void {}
 }
 
-// --- mouse (bounded to the mode; never active in the plain transcript) -----------------
-
-const MOUSE_ENABLE = "\x1b[?1000h\x1b[?1006h";
-const MOUSE_DISABLE = "\x1b[?1006l\x1b[?1000l";
-
-function enableMouse(st: DrillState): void {
-  if (st.mouseOn) return;
-  try {
-    process.stdout.write(MOUSE_ENABLE);
-  } catch {
-    return; // no mouse rather than a broken mode
-  }
-  st.mouseOn = true;
-  if (!g.__tracelineDrillMouseGuard) {
-    g.__tracelineDrillMouseGuard = true;
-    process.on("exit", () => {
-      // A crash mid-mode must not leave the terminal reporting mouse events.
-      if (g.__tracelineDrill?.mouseOn) writeIgnoringErrors(MOUSE_DISABLE);
-    });
-  }
-}
-
-function disableMouse(st: DrillState): void {
-  if (!st.mouseOn) return;
-  st.mouseOn = false;
-  writeIgnoringErrors(MOUSE_DISABLE);
-}
-
-function writeIgnoringErrors(sequence: string): void {
-  try {
-    process.stdout.write(sequence);
-  } catch {
-    // terminal already gone; nothing to restore
-  }
-}
-
-// The raw terminal-input hook (mouse consumption + foreign-chord exit) lives in
-// drill-input.ts; index.ts feeds it traceline's onTerminalInput listener.
+// The raw terminal-input hook for foreign-chord exit lives in drill-input.ts;
+// index.ts feeds it traceline's onTerminalInput listener.

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth, type KeyId, type TUI } from "@earendil-works/pi-tui";
 import { rawIndexAtVisibleIndex, rawIndexBeforeVisibleIndex, stripAnsi } from "../_lib/ansi.ts";
-import { booleanValue, positiveNumberValue, isJsonObject, stringValue } from "../_lib/boundary.ts";
+import { positiveNumberValue, isJsonObject, stringValue } from "../_lib/boundary.ts";
 import { captureTui } from "../_lib/capture.ts";
 import {
   findChatContainer,
@@ -306,7 +306,6 @@ type TracelineConfig = {
   sizeWarningChars?: number;
   sizeErrorChars?: number;
   drillKey?: string;
-  drillMouse?: boolean;
 };
 
 function parseTracelineConfig(value: unknown): TracelineConfig {
@@ -314,12 +313,10 @@ function parseTracelineConfig(value: unknown): TracelineConfig {
   const sizeWarningChars = positiveNumberValue(value.sizeWarningChars);
   const sizeErrorChars = positiveNumberValue(value.sizeErrorChars);
   const drillKey = stringValue(value.drillKey);
-  const drillMouse = booleanValue(value.drillMouse);
   return {
     ...(sizeWarningChars !== undefined ? { sizeWarningChars: Math.floor(sizeWarningChars) } : {}),
     ...(sizeErrorChars !== undefined ? { sizeErrorChars: Math.floor(sizeErrorChars) } : {}),
     ...(drillKey !== undefined && drillKey.length > 0 ? { drillKey } : {}),
-    ...(drillMouse !== undefined ? { drillMouse } : {}),
   };
 }
 
@@ -1665,7 +1662,6 @@ export default function piTraceline(pi: ExtensionAPI) {
     hiddenByFold: (comp) =>
       displayMode() === "oneLine" && ((readRun(comp)?.index ?? 0) > 0 || (repetitionRun(comp)?.index ?? 0) > 0),
     statusTone,
-    mouse: config.drillMouse !== false,
   });
   const startDrill = (ctx: { ui: ExtensionUIContext; hasUI: boolean }) => {
     if (!ctx.hasUI) return;
@@ -1714,9 +1710,8 @@ export default function piTraceline(pi: ExtensionAPI) {
     // Ctrl+O expansion first, then lets the same keypress continue to Pi (§9.12).
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = ctx.ui.onTerminalInput((data) => {
-      // Drill mode owns mouse reports; a foreign chord exits it un-consumed (§9.13).
-      const drill = handleDrillTerminalInput(data);
-      if (drill) return drill;
+      // A foreign chord exits drill mode before the same input reaches Pi (§9.13).
+      handleDrillTerminalInput(data);
       return handleThinkingToggleTerminalInput(data, ctx.ui, afterThinkingToggle);
     });
   });
@@ -1724,7 +1719,7 @@ export default function piTraceline(pi: ExtensionAPI) {
   pi.on("session_shutdown", () => {
     clearPatchTimer();
     clearWriteCallSnapshots();
-    exitDrillMode(); // restores the editor and turns mouse reporting off
+    exitDrillMode(); // restores the editor when shutdown interrupts drill mode
     g.__tracelineInputUnsubscribe?.();
     g.__tracelineInputUnsubscribe = undefined;
     g.__tracelineTui = undefined;

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,7 +7,7 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 859,
       "extensions/pi-contextimate/index.ts": 1568,
-      "extensions/pi-traceline/index.ts": 1735,
+      "extensions/pi-traceline/index.ts": 1730,
       "tests/contract/pi-internals.test.ts": 430,
       "tests/traceline/one-line.test.ts": 775
     }

--- a/tests/contract/pi-internals.test.ts
+++ b/tests/contract/pi-internals.test.ts
@@ -341,7 +341,7 @@ test("showExtensionCustom seam: editor swap/restore + overlay close drill mode r
 
   const declarations = readFileSync(join(piRoot, "dist/core/extensions/types.d.ts"), "utf8");
   assert.ok(declarations.includes("registerShortcut(shortcut: KeyId"), "registerShortcut signature drifted — the alt+t entry point dies");
-  assert.ok(declarations.includes("onTerminalInput(handler: TerminalInputHandler)"), "onTerminalInput gone — drill's mouse routing dies");
+  assert.ok(declarations.includes("onTerminalInput(handler: TerminalInputHandler)"), "onTerminalInput gone — drill's foreign-chord exit dies");
   assert.ok(declarations.includes("custom<T>(factory: (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: T) => void)"), "custom factory signature drifted — hint bar and pager factories break");
 });
 

--- a/tests/traceline/drill-pager.test.ts
+++ b/tests/traceline/drill-pager.test.ts
@@ -56,9 +56,8 @@ function pagerFor(rows: ToolRowLike[], terminalRows = 16): DrillPager {
     runRows: () => undefined,
     hiddenByFold: () => false,
     statusTone: () => "success",
-    mouse: false,
   };
-  const st: DrillState = { host, rows, numbers: new Map(), selected: 0, digits: "", mouseOn: false };
+  const st: DrillState = { host, rows, numbers: new Map(), selected: 0, digits: "" };
   const pager = new DrillPager(st);
   pager.attach({ terminal: { rows: terminalRows } } as unknown as TUI);
   return pager;

--- a/tests/traceline/drill.test.ts
+++ b/tests/traceline/drill.test.ts
@@ -18,7 +18,7 @@ import {
   stepDigits,
   type DrillHost,
 } from "../../extensions/pi-traceline/drill.ts";
-import { handleDrillTerminalInput, isForeignChord, wheelDelta } from "../../extensions/pi-traceline/drill-input.ts";
+import { handleDrillTerminalInput, isForeignChord } from "../../extensions/pi-traceline/drill-input.ts";
 import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
 
 const { foldedReadLines, isExpandedToolRow, leadingBlank, oneLine, readRun, renderTraceRow, setTracelineChat, statusTone, stripAnsi } = internals;
@@ -76,7 +76,6 @@ function makeHost(children: unknown[], calls: CustomCall[] = [], notifications: 
     },
     hiddenByFold: (comp) => (readRun(comp)?.index ?? 0) > 0,
     statusTone: (comp) => statusTone(comp),
-    mouse: false,
   };
 }
 
@@ -279,24 +278,29 @@ test("a folded read run is one numbered target", () => {
   assert.ok([page1, page2, sibling].every((row) => row.expanded === true), "pin expands every member of a folded target");
 });
 
-// --- mouse -------------------------------------------------------------------------------
+// --- terminal ownership -----------------------------------------------------------------
 
-test("wheelDelta reads SGR wheel presses and ignores releases and buttons", () => {
-  assert.equal(wheelDelta("\x1b[<64;10;5M"), -1); // wheel up
-  assert.equal(wheelDelta("\x1b[<65;10;5M\x1b[<65;10;5M"), 2); // two wheel downs
-  assert.equal(wheelDelta("\x1b[<0;10;5M\x1b[<0;10;5m"), 0); // click press+release
-  assert.equal(wheelDelta("\x1b[<68;10;5M"), -1); // shift+wheel up still scrolls
+test("drill entry and exit write no terminal control sequences", () => {
+  const writes: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    enterDrillMode(makeHost([toolComp()]));
+    exitDrillMode();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  assert.deepEqual(writes, [], "Traceline must never take ownership of terminal mouse mode");
 });
 
-test("terminal-input hook consumes all mouse reports while active, none outside", () => {
-  assert.equal(handleDrillTerminalInput("\x1b[<64;1;1M"), undefined, "inactive: nothing consumed");
+test("terminal-input hook ignores mouse reports while drill is active", () => {
   const rows = [toolComp({ args: { path: "/tmp/aaa/a.ts" } }), toolComp({ args: { path: "/tmp/bbb/b.ts" } })];
   enterDrillMode(makeHost(rows));
-  assert.equal(drillState()!.selected, 0);
-  assert.deepEqual(handleDrillTerminalInput("\x1b[<64;1;1M"), { consume: true });
-  assert.equal(drillState()!.selected, 1, "wheel up walks to the older row");
-  assert.deepEqual(handleDrillTerminalInput("\x1b[<0;3;3M"), { consume: true }, "clicks are swallowed, not leaked");
-  assert.equal(handleDrillTerminalInput("plain keys"), undefined, "keyboard input passes through");
+  assert.equal(handleDrillTerminalInput("\x1b[<64;1;1M"), undefined);
+  assert.equal(drillState()!.selected, 0, "mouse input cannot move the drill selection");
 });
 
 // --- foreign chords (§9.13: the mode never silently eats an app-level keystroke) --------


### PR DESCRIPTION
## What changed

- remove drill-mode mouse enable and disable sequences
- remove wheel parsing and mouse-event consumption
- remove the `drillMouse` setting
- keep drill mode keyboard-only and preserve foreign-chord exit
- state the no-mouse rule in the README and design language

## Why

The older click experiment was removed because Traceline should not own terminal mouse mode. Drill mode later reintroduced the same ownership for wheel navigation as a bounded exception. Pi 0.84 fullscreen now owns mouse reporting itself, which makes that exception both unnecessary and unsafe.

Future row clicking should use a public Pi component-click API. This change does not restore the old screen-row hit map.

## Verification

- `npm run check`: 332 tests pass
- `npm run test:smoke:drill`: passes against real Pi in regular mode
- the same real-Pi drill smoke passes with `--tui-mode fullscreen`
- drill entry and exit are covered by a regression test that records no terminal writes

Closes #92
