### PR TITLE
refactor(meantime): simplify live rate accounting

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -719,17 +719,12 @@ surface users feel most and can verify least.
   typed content event) and bundles network, queue, and prefill. It is one number on
   purpose: the split is not observable, so no split is claimed. Prefill work is
   still nameable as a cause from usage evidence (uncached prompt tokens)
-- rates wear the §4 grammar: a live writing rate is estimated from streamed writing
-  chars through a chars-per-token ratio and wears `~` in progressive tense; thinking
-  shows no live rate because its streamed text may be verbatim, summarized or elided
-  depending on the provider, so it is not portable token evidence. A resolved rate is
-  provider output tokens over the observed whole-call stream span, exact, past tense.
-  The live writing ratio self-calibrates
-  from resolved writing chars over non-reasoning output tokens. A call with streamed
-  thinking but no positive provider reasoning-token breakdown cannot calibrate that
-  ratio; some compatible routes normalize a missing breakdown to zero.
-  Calls with silent reasoning show no resolved rate: their hidden generation has no
-  observable start boundary
+- rates wear the §4 grammar: live writing rate is estimated from streamed chars and
+  wears `~`; thinking has no live rate because its text is not reliable token evidence
+  across providers. Resolved rate is exact provider output over the observed stream
+  span. Writing calibration excludes provider-reported reasoning tokens and skips calls
+  without a usable split. Silent reasoning has no resolved rate because its generation
+  start is not observable
 - a silent pre-text gap is `waiting`, never `thinking`, until usage confirms
   reasoning tokens (§7: no definite words on soft evidence). A resolved call whose
   usage reports reasoning tokens but whose stream carried no thinking blocks marks

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -190,10 +190,8 @@ not a mock. Anything requiring a live terminal goes to the smoke layer instead.
   live or resolved tool time, and harness duration is only attached when a next request
   supplies an end boundary.
 - **Per-model baselines and calibration**: medians filter on provider-qualified model
-  identity and need the configured sample floor. Live thinking shows no rate;
-  writing-rate calibration uses visible writing chars over non-reasoning output tokens
-  and rejects streamed-thinking calls without a positive provider reasoning-token
-  breakdown, including compatible routes that normalize a missing breakdown to zero.
+  identity and need the configured sample floor. Live thinking has no rate; writing
+  calibration skips calls without a usable reasoning split.
 - **Session totals and config parsing**: open idle time contributes to idle, active is
   the watched span minus idle, and malformed boundary values are ignored.
 - **Feature-flag registration**: the default config registers no hooks or command;

--- a/extensions/pi-meantime/README.md
+++ b/extensions/pi-meantime/README.md
@@ -8,12 +8,9 @@ Explains where the wall-clock went. pi's footer *counts* elapsed time; meantime
 *decomposes* it: is the model thinking or stuck, why was that call slow, and where did
 the session actually go?
 
-**A tempo line above the input box** names the current phase of the wait and how long
-it has held, so a long silence reads as information instead of anxiety. Live writing
-rate is estimated from streamed writing chars and wears `~`. Thinking shows no rate:
-its streamed text may be verbatim, summarized or elided depending on the provider, so
-it is not portable token evidence. The line turns warning ink once the wait passes the
-session's own slow-start bar, and hides when the loop is idle:
+**A tempo line above the input box** names the current phase and its duration. Live
+`~tok/s` appears only while writing. The line turns warning ink once the wait passes
+this session's slow-start bar, and hides when the loop is idle:
 
 ```
 ◍ waiting · 3s                                       (no first token yet)
@@ -39,18 +36,7 @@ rates. Healthy calls print nothing:
 write, tools, total, output tokens, exact tok/s), notes where a row earned one, a
 totals row, and one session line with an active-against-idle share bar. A ledger
 that spans model switches states the model count and marks each transition. Idle is
-a first-class bucket, not noise; it is often the session's punchline:
-
-```
-[Meantime]
-  /pace · event-boundary wall clock · usage-based tok/s · process-local
-  call    ttft   think   write   tools   total     out  tok/s
-     1    1.9s     42s    8.0s     31s   1m22s    2.1k     48
-     2    1.7s    3.0s     12s    4.2s     17s    0.8k     41
-     3     14s    6.1s    5.0s     22s     26s    0.7k     35  slow start (median 1.9s)
-  totals: 3 calls · waiting 18s · thinking 51s · writing 25s · tools 57s · harness 4.6s
-  timed 1h42m   ██▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  active 10m (10%) · idle 1h32m
-```
+a first-class bucket, not noise.
 
 ![Meantime pace ledger](../../docs/img/pi-meantime-ledger.png)
 
@@ -114,15 +100,11 @@ Honesty rules:
 - Time to first token is one number on purpose: it bundles network, queue, and
   prefill, and that split is not observable, so no split is claimed. Prefill is still
   nameable as a *cause* from usage evidence (uncached prompt tokens).
-- Resolved tok/s is exact: provider output tokens over the observed whole-call stream
-  span. Live writing tok/s is an estimate from visible text and tool-argument chars and
-  always wears `~`. Thinking shows no live rate because its streamed text has a
-  provider-dependent relationship to the reasoning-token stream. The writing
-  chars-per-token ratio self-calibrates from resolved calls after subtracting
-  provider-reported reasoning tokens; a call with streamed thinking but no positive
-  reasoning-token breakdown cannot calibrate it. Silent-reasoning calls show no
-  resolved rate because their hidden generation has no
-  observable start boundary.
+- Resolved tok/s is exact provider output over the observed stream span. Live writing
+  tok/s is estimated from visible text and tool arguments and wears `~`; thinking has no
+  rate. Calibration excludes provider-reported reasoning tokens and skips calls without
+  a usable split. Silent reasoning has no resolved rate because its start is not
+  observable.
 - A silent pre-text gap is `waiting`, never `thinking`. When usage later reports
   reasoning tokens for a call whose stream carried no thinking blocks, the row is
   noted `wait incl. silent reasoning` rather than inventing a thinking span.

--- a/extensions/pi-meantime/index.ts
+++ b/extensions/pi-meantime/index.ts
@@ -24,26 +24,7 @@ import {
   type MeantimeConfig,
 } from "./timing.ts";
 
-/**
- * pi-meantime — where did the time go, and why? ("what happened in the meantime?")
- *
- * pi's footer already *counts* elapsed time; meantime *explains* it:
- *   1. "Is it thinking, or stuck?"  → a live tempo line above the editor decomposing the
- *      current wait: waiting (no first token yet) / thinking / writing (with a
- *      visible-output ~tok/s estimate) / tools, hidden when the loop is idle.
- *   2. "Why was that one slow?"     → anomaly notices against the session's own rolling
- *      per-model median: slow starts (with prefill named as cause when usage proves it)
- *      and collapsed stream rates. Silence when healthy.
- *   3. "Where did the session go?"  → /pace: a per-call ledger (ttft / think / write /
- *      tools / total / out / exact tok/s) with totals and an active-vs-idle share bar.
- *
- * All durations are event-boundary observations from this process (design language
- * §10.1); resolved tok/s is exact provider usage over the observed stream span; live
- * writing rate is estimated and wears `~`, while provider-dependent thinking text
- * supports no portable rate. Display is UI-only: nothing meantime renders enters
- * LLM context, session entries, or exports, and nothing is reconstructed from restored
- * session history (message timestamps cannot yield TTFT or segment splits).
- */
+/** Live phase, anomaly notices and the `/pace` timing ledger. UI-only (§10). */
 
 // --- live state ---------------------------------------------------------------------------
 
@@ -252,7 +233,6 @@ export function registerMeantime(pi: ExtensionAPI, config: MeantimeConfig): void
     updateWidget(now);
   });
 
-  // Hot path: one O(1) state-machine step per streamed token; the 1s timer re-renders.
   pi.on("message_update", async (event) => {
     if (!s.live) return;
     const streamEvent = event.assistantMessageEvent;

--- a/extensions/pi-meantime/render.ts
+++ b/extensions/pi-meantime/render.ts
@@ -26,7 +26,6 @@ export interface WidgetSnapshot {
   openTools: number;
   /** Union of completed and open tool intervals in the current phase. */
   toolElapsedMs: number;
-  /** Live writing-rate calibration ratio; the estimate wears `~` (§10.1). */
   writingCharsPerToken: number;
   /** Session baseline for flagging an anomalous wait mid-stream, when one exists. */
   slowStartBar?: { medianMs: number; thresholdMs: number };
@@ -39,13 +38,6 @@ export interface WidgetLine {
 
 const LIVE_RATE_MIN_MS = 2_000;
 
-function liveWritingRatePart(chars: number, ms: number, charsPerToken: number): string {
-  if (ms < LIVE_RATE_MIN_MS || chars <= 0 || charsPerToken <= 0) return "";
-  return `${SEP}${formatRate(chars / charsPerToken / (ms / 1000))}`;
-}
-
-/** One `◍` line above the editor, or undefined when the loop is idle (principle 6:
- * pi's footer already counts elapsed; this line exists to decompose an active wait). */
 export function tempoWidget(snap: WidgetSnapshot): WidgetLine | undefined {
   if (!snap.runActive) return undefined;
   const live = snap.live;
@@ -63,8 +55,8 @@ export function tempoWidget(snap: WidgetSnapshot): WidgetLine | undefined {
     const kind = live.segment?.kind ?? live.lastKind ?? "writing";
     const openMs = live.segment ? Math.max(0, snap.now - live.segment.startedAt) : 0;
     const ms = (kind === "thinking" ? live.thinkMs : live.writeMs) + openMs;
-    const rate = kind === "writing"
-      ? liveWritingRatePart(live.writeChars, ms, snap.writingCharsPerToken)
+    const rate = kind === "writing" && ms >= LIVE_RATE_MIN_MS && live.writeChars > 0
+      ? `${SEP}${formatRate(live.writeChars / snap.writingCharsPerToken / (ms / 1000))}`
       : "";
     return {
       tone: "running",

--- a/extensions/pi-meantime/timing.ts
+++ b/extensions/pi-meantime/timing.ts
@@ -1,7 +1,4 @@
-// pi-meantime timing model (design language §10): pure state machines and arithmetic,
-// no pi imports. Every number here is an event-boundary observation measured in this
-// process; nothing is provider-reported timing (none exists) and nothing is
-// reconstructed from session history.
+// Pure timing state machines and arithmetic; no pi imports.
 
 import type { MeantimeConfig } from "./config.ts";
 export { DEFAULT_CONFIG, parseMeantimeConfig } from "./config.ts";
@@ -24,14 +21,12 @@ export interface LiveCall {
   lastKind?: SegmentKind;
   thinkMs: number;
   writeMs: number;
-  /** Visible text and tool-argument chars; thinking text is not portable token evidence. */
   writeChars: number;
-  /** The stream carried visible thinking blocks (vs silent server-side reasoning). */
-  sawThinkingStream: boolean;
+  thinkingStreamed: boolean;
 }
 
 export function newLiveCall(index: number, requestAt: number): LiveCall {
-  return { index, requestAt, thinkMs: 0, writeMs: 0, writeChars: 0, sawThinkingStream: false };
+  return { index, requestAt, thinkMs: 0, writeMs: 0, writeChars: 0, thinkingStreamed: false };
 }
 
 // pi-ai's AssistantMessageEvent types, mapped to segments. The bare "start" event is
@@ -61,15 +56,13 @@ export function applyStreamEvent(live: LiveCall, type: string, deltaLength: numb
   const kind = SEGMENT_OF[type];
   if (kind !== undefined) {
     if (live.firstTokenAt === undefined) live.firstTokenAt = now;
-    if (kind === "thinking") live.sawThinkingStream = true;
+    if (kind === "thinking") live.thinkingStreamed = true;
+    else live.writeChars += deltaLength;
     if (live.segment?.kind !== kind) {
       closeSegment(live, now);
       live.segment = { kind, startedAt: now };
       live.lastKind = kind;
     }
-    // Thinking text may be verbatim, summarized or elided depending on the provider.
-    // Only writing chars can support a portable live token-rate estimate (§10.1).
-    if (kind === "writing" && deltaLength > 0) live.writeChars += deltaLength;
     return;
   }
   if (SEGMENT_END.has(type)) closeSegment(live, now);
@@ -88,21 +81,17 @@ export interface UsageLike {
 
 export interface CallTiming {
   index: number;
-  requestAt: number;
   /** Request sent to first typed content event; undefined when no content ever streamed. */
   ttftMs?: number;
   thinkMs: number;
   writeMs: number;
-  /** Visible text and tool-argument chars used to calibrate live writing rate. */
   writeChars: number;
-  /** Whether the stream exposed provider-dependent thinking text. */
-  thinkingStreamed: boolean;
+  /** Output tokens attributable to writing; absent when usage cannot split streamed thinking. */
+  writingTokens?: number;
   /** Request sent to stream end. Columns do not claim to sum to this (§10.2). */
   totalMs: number;
   outputTokens: number;
-  reasoningTokens?: number;
-  /** usage.reasoning > 0 with no thinking blocks on the stream: the wait includes
-   * silent reasoning, and streamed chars undercount output tokens. */
+  /** Provider-reported reasoning with no thinking blocks on the stream. */
   silentReasoning: boolean;
   /** input + cacheWrite: the prompt tokens the provider had to prefill uncached.
    * The evidence behind a named slow-start cause (§10.1). */
@@ -124,18 +113,19 @@ export function resolveCall(live: LiveCall, usage: UsageLike, now: number, model
   closeSegment(live, now);
   const ttftMs = live.firstTokenAt !== undefined ? Math.max(0, live.firstTokenAt - live.requestAt) : undefined;
   const streamMs = live.firstTokenAt !== undefined ? Math.max(0, now - live.firstTokenAt) : 0;
-  const silentReasoning = (usage.reasoning ?? 0) > 0 && !live.sawThinkingStream;
+  const reasoningTokens = usage.reasoning ?? 0;
+  const silentReasoning = reasoningTokens > 0 && !live.thinkingStreamed;
+  const canCountWritingTokens = !live.thinkingStreamed || reasoningTokens > 0;
+  const writingTokens = canCountWritingTokens ? usage.output - reasoningTokens : undefined;
   return {
     index: live.index,
-    requestAt: live.requestAt,
     ttftMs,
     thinkMs: live.thinkMs,
     writeMs: live.writeMs,
     writeChars: live.writeChars,
-    thinkingStreamed: live.sawThinkingStream,
+    writingTokens,
     totalMs: Math.max(0, now - live.requestAt),
     outputTokens: usage.output,
-    reasoningTokens: usage.reasoning,
     silentReasoning,
     uncachedPromptTokens: usage.input + usage.cacheWrite,
     // Silent reasoning happened before the first observable content event, so its
@@ -250,28 +240,16 @@ export function detectSlowStream(call: CallTiming, prior: CallTiming[], config: 
 
 // --- live-rate calibration (design language §10.1) ---------------------------------------
 
-/** Starting writing ratio before resolved evidence exists; the estimate wears `~`. */
 export const DEFAULT_WRITING_CHARS_PER_TOKEN = 3;
 const CALIBRATION_MIN_TOKENS = 50;
-
-/** Visible writing chars over non-reasoning output tokens from the most recent resolved
- * call with enough signal. Streamed thinking without a positive provider reasoning
- * breakdown cannot identify how many output tokens belonged to writing (§10.1). */
-function writingTokensForCalibration(call: CallTiming): number | undefined {
-  // Some OpenAI-compatible routes normalize a missing reasoning breakdown to zero.
-  // A visible thinking stream makes that zero contradictory, so fail closed.
-  if (call.thinkingStreamed && (call.reasoningTokens ?? 0) === 0) return undefined;
-  return Math.max(0, call.outputTokens - (call.reasoningTokens ?? 0));
-}
 
 export function calibratedWritingCharsPerToken(calls: CallTiming[], model?: string): number {
   for (let i = calls.length - 1; i >= 0; i--) {
     const call = calls[i]!;
     if (model !== undefined && call.model !== undefined && call.model !== model) continue;
-    if (call.writeChars <= 0) continue;
-    const writingTokens = writingTokensForCalibration(call);
-    if (writingTokens === undefined || writingTokens < CALIBRATION_MIN_TOKENS) continue;
-    return call.writeChars / writingTokens;
+    if (call.writeChars <= 0 || call.writingTokens === undefined) continue;
+    if (call.writingTokens < CALIBRATION_MIN_TOKENS) continue;
+    return call.writeChars / call.writingTokens;
   }
   return DEFAULT_WRITING_CHARS_PER_TOKEN;
 }

--- a/tests/meantime/goldens.test.ts
+++ b/tests/meantime/goldens.test.ts
@@ -25,11 +25,9 @@ import { expectGolden, plainTheme } from "../helpers.ts";
 function call(index: number, overrides: Partial<CallTiming>): CallTiming {
   return {
     index,
-    requestAt: 0,
     thinkMs: 0,
     writeMs: 0,
     writeChars: 0,
-    thinkingStreamed: false,
     totalMs: 0,
     outputTokens: 0,
     silentReasoning: false,
@@ -42,28 +40,28 @@ function call(index: number, overrides: Partial<CallTiming>): CallTiming {
 // overlapped tools and a harness stall, then a collapsed stream rate.
 const CALLS: CallTiming[] = [
   call(1, {
-    ttftMs: 1_900, thinkMs: 42_000, writeMs: 8_000, writeChars: 6_100, thinkingStreamed: true, totalMs: 82_000,
+    ttftMs: 1_900, thinkMs: 42_000, writeMs: 8_000, totalMs: 82_000,
     outputTokens: 2_100, tokPerSec: 48, uncachedPromptTokens: 138_200,
     toolsMs: 31_000, toolsCount: 2, toolsOverlapMs: 0, harnessMs: 300,
   }),
   call(2, {
-    ttftMs: 1_700, writeMs: 12_000, writeChars: 2_400, totalMs: 15_000,
+    ttftMs: 1_700, writeMs: 12_000, totalMs: 15_000,
     outputTokens: 800, tokPerSec: 41, uncachedPromptTokens: 1_100,
     toolsMs: 4_200, toolsCount: 1, toolsOverlapMs: 0, harnessMs: 200,
   }),
   call(3, {
-    ttftMs: 2_100, thinkMs: 6_000, writeMs: 9_000, writeChars: 3_900, thinkingStreamed: true, totalMs: 18_000,
+    ttftMs: 2_100, thinkMs: 6_000, writeMs: 9_000, totalMs: 18_000,
     outputTokens: 1_200, tokPerSec: 52, uncachedPromptTokens: 900,
     toolsMs: 0, toolsCount: 0, toolsOverlapMs: 0, harnessMs: 150,
   }),
   call(4, {
-    ttftMs: 14_200, writeMs: 5_000, writeChars: 1_800, totalMs: 20_000,
-    outputTokens: 700, reasoningTokens: 450, silentReasoning: true,
+    ttftMs: 14_200, writeMs: 5_000, totalMs: 20_000,
+    outputTokens: 700, silentReasoning: true,
     uncachedPromptTokens: 145_300,
     toolsMs: 22_000, toolsCount: 3, toolsOverlapMs: 12_000, harnessMs: 4_100,
   }),
   call(5, {
-    ttftMs: 2_000, writeMs: 180_000, writeChars: 6_800, totalMs: 192_000,
+    ttftMs: 2_000, writeMs: 180_000, totalMs: 192_000,
     outputTokens: 2_100, tokPerSec: 11, uncachedPromptTokens: 1_000,
   }),
 ];
@@ -73,7 +71,7 @@ function liveThinking(): LiveCall {
   live.firstTokenAt = 1_900;
   live.segment = { kind: "thinking", startedAt: 1_900 };
   live.lastKind = "thinking";
-  live.sawThinkingStream = true;
+  live.thinkingStreamed = true;
   return live;
 }
 

--- a/tests/meantime/render.test.ts
+++ b/tests/meantime/render.test.ts
@@ -8,12 +8,10 @@ function call(index: number, model: string): CallTiming {
   return {
     index,
     model,
-    requestAt: 0,
     ttftMs: 1_000,
     thinkMs: 0,
     writeMs: 1_000,
     writeChars: 300,
-    thinkingStreamed: false,
     totalMs: 2_000,
     outputTokens: 100,
     silentReasoning: false,

--- a/tests/meantime/timing.test.ts
+++ b/tests/meantime/timing.test.ts
@@ -1,7 +1,3 @@
-// pi-meantime timing model: the segment state machine, resolution arithmetic, interval
-// union, relative baselines, calibration, and config parsing. These encode the design
-// language §10.1 honesty rules; a wrong answer here renders as a plausible-looking
-// number a human cannot re-derive, which is exactly the docs/testing.md layer-2 risk.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -30,12 +26,11 @@ const USAGE: UsageLike = { input: 1_200, output: 2_000, cacheRead: 100_000, cach
 function call(overrides: Partial<CallTiming>): CallTiming {
   return {
     index: 1,
-    requestAt: 0,
     ttftMs: 2_000,
     thinkMs: 0,
     writeMs: 1_000,
     writeChars: 6_000,
-    thinkingStreamed: false,
+    writingTokens: 2_000,
     totalMs: 10_000,
     outputTokens: 2_000,
     silentReasoning: false,
@@ -54,7 +49,7 @@ test("segment machine: first content sets TTFT; the bare start event does not", 
   applyStreamEvent(live, "thinking_start", 0, 1_900);
   assert.equal(live.firstTokenAt, 1_900);
   assert.equal(live.segment?.kind, "thinking");
-  assert.equal(live.sawThinkingStream, true);
+  assert.equal(live.thinkingStreamed, true);
 });
 
 test("segment machine: spans run start to end, so intra-segment stalls belong to the segment", () => {
@@ -64,24 +59,12 @@ test("segment machine: spans run start to end, so intra-segment stalls belong to
   applyStreamEvent(live, "thinking_delta", 40, 9_000); // 7s stall inside thinking
   applyStreamEvent(live, "thinking_end", 0, 10_000);
   assert.equal(live.thinkMs, 9_000);
-  assert.equal(live.sawThinkingStream, true);
-  assert.equal(live.writeChars, 0, "provider-dependent thinking text is not writing-token evidence");
-  assert.equal(live.writeMs, 0);
-});
-
-test("segment machine: a kind change closes the open segment even without an end event", () => {
-  const live = newLiveCall(1, 0);
-  applyStreamEvent(live, "thinking_delta", 10, 1_000);
-  applyStreamEvent(live, "text_delta", 20, 4_000); // no thinking_end seen
-  applyStreamEvent(live, "text_end", 0, 6_000);
-  assert.equal(live.thinkMs, 3_000);
-  assert.equal(live.writeMs, 2_000);
-  assert.equal(live.writeChars, 20);
-  assert.equal(live.lastKind, "writing");
+  assert.equal(live.writeChars, 0);
 });
 
 test("segment machine: tool-argument streaming is writing (the model emitting tokens)", () => {
   const live = newLiveCall(1, 0);
+  applyStreamEvent(live, "text_start", 0, 1_000);
   applyStreamEvent(live, "text_delta", 15, 1_000);
   applyStreamEvent(live, "text_end", 0, 2_000);
   applyStreamEvent(live, "toolcall_start", 0, 2_100);
@@ -89,41 +72,50 @@ test("segment machine: tool-argument streaming is writing (the model emitting to
   applyStreamEvent(live, "toolcall_end", 0, 3_100);
   assert.equal(live.writeMs, 2_000); // 1000→2000 text + 2100→3100 toolcall
   assert.equal(live.writeChars, 100);
-  assert.equal(live.sawThinkingStream, false);
 });
 
 // --- resolution -----------------------------------------------------------------------------
 
 test("resolveCall: ttft, exact rate over the stream span, and prefill evidence", () => {
   const live = newLiveCall(3, 0);
-  applyStreamEvent(live, "text_delta", 50, 2_000);
+  applyStreamEvent(live, "text_start", 0, 2_000);
+  applyStreamEvent(live, "text_delta", 50, 2_500);
+  applyStreamEvent(live, "text_end", 0, 12_000);
   const resolved = resolveCall(live, USAGE, 12_000, "claude-opus-4-8");
   assert.equal(resolved.ttftMs, 2_000);
   assert.equal(resolved.totalMs, 12_000);
   assert.equal(resolved.tokPerSec, 2_000 / 10); // output ÷ (streamEnd − firstToken)
   assert.equal(resolved.uncachedPromptTokens, 4_200); // input + cacheWrite
-  assert.equal(resolved.silentReasoning, false);
   assert.equal(resolved.writeChars, 50);
-  assert.equal(resolved.thinkingStreamed, false);
-  assert.equal(resolved.writeMs, 10_000); // open segment closed at resolution
+  assert.equal(resolved.writingTokens, 2_000);
+  assert.equal(resolved.writeMs, 10_000);
 });
 
 test("resolveCall: reasoning tokens with no thinking stream marks silent reasoning", () => {
   const live = newLiveCall(1, 0);
-  applyStreamEvent(live, "text_delta", 10, 8_000); // long silent gap, then text
+  applyStreamEvent(live, "text_start", 0, 8_000);
+  applyStreamEvent(live, "text_delta", 10, 8_500);
+  applyStreamEvent(live, "text_end", 0, 10_000);
   const resolved = resolveCall(live, { ...USAGE, reasoning: 900 }, 10_000);
   assert.equal(resolved.silentReasoning, true);
-  assert.equal(resolved.tokPerSec, undefined, "unobserved reasoning time makes a resolved rate incomparable");
-  const streamed = resolveCall(
-    (() => {
-      const l = newLiveCall(2, 0);
-      applyStreamEvent(l, "thinking_delta", 10, 1_000);
-      return l;
-    })(),
-    { ...USAGE, reasoning: 900 },
-    5_000,
-  );
-  assert.equal(streamed.silentReasoning, false);
+  assert.equal(resolved.tokPerSec, undefined);
+  assert.equal(resolved.writingTokens, 1_100);
+});
+
+test("resolveCall: streamed thinking needs a positive reasoning breakdown for calibration", () => {
+  const resolve = (reasoning?: number) => {
+    const live = newLiveCall(1, 0);
+    applyStreamEvent(live, "thinking_start", 0, 1_000);
+    applyStreamEvent(live, "thinking_delta", 10, 1_500);
+    applyStreamEvent(live, "thinking_end", 0, 3_000);
+    applyStreamEvent(live, "text_start", 0, 3_000);
+    applyStreamEvent(live, "text_delta", 10, 3_500);
+    applyStreamEvent(live, "text_end", 0, 5_000);
+    return resolveCall(live, { ...USAGE, reasoning }, 5_000);
+  };
+  assert.equal(resolve().writingTokens, undefined);
+  assert.equal(resolve(0).writingTokens, undefined);
+  assert.equal(resolve(900).writingTokens, 1_100);
 });
 
 test("resolveCall: no content ever streamed → no ttft, no rate claimed", () => {
@@ -215,16 +207,13 @@ test("detectSlowStream: collapsed rate on calls with enough output", () => {
 
 // --- calibration ----------------------------------------------------------------------------
 
-test("calibratedWritingCharsPerToken: uses writing tokens and rejects thinking without a positive breakdown", () => {
+test("calibratedWritingCharsPerToken: last eligible writing sample wins", () => {
   assert.equal(calibratedWritingCharsPerToken([]), DEFAULT_WRITING_CHARS_PER_TOKEN);
   const calls = [
-    call({ writeChars: 5_000, outputTokens: 2_000 }), // 2.5, no reasoning
-    call({ writeChars: 7_000, outputTokens: 4_000, reasoningTokens: 2_000, thinkingStreamed: true }), // 3.5
-    // Excluded: streamed thinking with no provider breakdown cannot identify writing tokens.
-    call({ writeChars: 12_000, outputTokens: 3_000, reasoningTokens: undefined, thinkingStreamed: true }),
-    // Excluded: compatible routes can normalize that missing breakdown to a contradictory zero.
-    call({ writeChars: 10_000, outputTokens: 2_500, reasoningTokens: 0, thinkingStreamed: true }),
-    call({ writeChars: 100, outputTokens: 20 }), // excluded: too little writing-token signal
+    call({ writeChars: 5_000, writingTokens: 2_000 }),
+    call({ writeChars: 7_000, writingTokens: 2_000 }),
+    call({ writeChars: 12_000, writingTokens: undefined }),
+    call({ writeChars: 100, writingTokens: 20 }),
   ];
   assert.equal(calibratedWritingCharsPerToken(calls), 3.5);
   const modelCalls = [


### PR DESCRIPTION
## Summary

- replace raw resolved reasoning/stream flags with the derived writing-token count the calibrator actually needs
- inline one-use live-rate and calibration helpers, and remove stale resolved timing state
- use real start/delta/end stream sequences in tests and drop a malformed-stream fixture
- trim duplicate implementation and documentation commentary

Net: 90 fewer lines with unchanged rendered output.

## Verification

- `npm run check` (331 tests)