### PR TITLE
fix(contextimate): deduplicate startup blocks across TUI containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Contextimate now reconciles its startup block across the live TUI tree, preventing
+  duplicate blocks when another extension rehosts Pi's startup resources or after
+  repeated reloads. It no longer resets headers owned by other extensions.
 - Meantime no longer estimates live tok/s from streamed thinking text, whose
   relationship to reasoning tokens varies by provider. Live rate appears only while
   writing, calibrated from visible writing chars and non-reasoning output tokens.

--- a/extensions/pi-contextimate/index.ts
+++ b/extensions/pi-contextimate/index.ts
@@ -5,7 +5,7 @@ import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { homedir } from "node:os";
 import { stripAnsi } from "../_lib/ansi.ts";
 import { isJsonObject, positiveNumberValue, stringValue } from "../_lib/boundary.ts";
-import { findContainerBy, isResourceRow, RESOURCE_HEADER_RE, type ContainerLike } from "../_lib/chat.ts";
+import { RESOURCE_HEADER_RE, type ContainerLike } from "../_lib/chat.ts";
 import { configPaths, expandHomePath, readJsonConfig } from "../_lib/config.ts";
 import { compactCount } from "../_lib/fmt.ts";
 import {
@@ -40,6 +40,14 @@ import {
   type SessionEstimate,
   type SessionSource,
 } from "./session-accounting.ts";
+import {
+  collectContainers,
+  findContextBlockTarget,
+  prefixBlockLocations,
+  reconcileContextBlockTree,
+  removeExistingPrefixBlocks,
+  type ContextimateTui,
+} from "./startup-block.ts";
 
 type ViewMode = "summary" | "compact" | "expanded";
 
@@ -154,11 +162,6 @@ type PrefixSnapshot = {
    * (issue #58): the count is old-currency, the window is new-currency, and the two
    * must not be composed. Cleared by the first post-switch usage. */
   preSwitchUsage?: { billedModel: string };
-};
-
-type ContextimateTui = {
-  children?: unknown[];
-  requestRender?: (force?: boolean) => void;
 };
 
 type ContextimateGlobal = typeof globalThis & {
@@ -1333,67 +1336,21 @@ class StartupContextComponent implements Component {
   }
 }
 
-function renderPlain(component: Component, width = 120): string {
-  try {
-    return stripAnsi(component.render(width).join("\n"));
-  } catch {
-    return "";
-  }
-}
-
-function isPrefixBlock(component: unknown): component is StartupContextComponent {
-  return !!component && typeof component === "object" && (component as { __piContextimateBlock?: boolean }).__piContextimateBlock === true;
-}
-
-// _lib/chat.ts isResourceRow, minus the panel itself: the [Contextimate] block renders
-// arbitrary text the fuzzy [Section] regex must never re-anchor on.
-function isResourceComponent(component: unknown): boolean {
-  return !isPrefixBlock(component) && isResourceRow(component);
-}
-
-function isBlankComponent(component: Component): boolean {
-  const text = renderPlain(component, 80);
-  return text.trim().length === 0;
-}
-
-function findResourceChatContainer(node: unknown): ContainerLike | undefined {
-  return findContainerBy(node, (children) => children.some((child) => isResourceComponent(child)));
-}
-
-function removeExistingPrefixBlocks(chat: ContainerLike): void {
-  if (!Array.isArray(chat.children)) return;
-  chat.children = chat.children.filter((child) => !isPrefixBlock(child));
-}
-
-function insertionIndexAfterResourceList(chat: ContainerLike): number {
-  if (!Array.isArray(chat.children)) return -1;
-  let index = -1;
-  for (let i = 0; i < chat.children.length; i++) {
-    if (!isResourceComponent(chat.children[i])) continue;
-    index = i;
-    if (i + 1 < chat.children.length && isBlankComponent(chat.children[i + 1] as Component)) index = i + 1;
-  }
-  return index;
-}
-
 function isContextBlockInstalled(block: StartupContextComponent): boolean {
-  const chat = g.__piContextimateChat;
-  return Array.isArray(chat?.children) && chat.children.includes(block);
+  const tui = g.__piContextimateTui;
+  const target = findContextBlockTarget(tui, g.__piContextimateChat);
+  if (!tui || !target) return false;
+  const locations = prefixBlockLocations(tui);
+  return locations.length === 1 && locations[0]?.container === target && locations[0].block === block;
 }
 
 function installContextBlock(block: StartupContextComponent): boolean {
   const tui = g.__piContextimateTui;
-  const chat = findResourceChatContainer(tui) ?? g.__piContextimateChat;
-  if (!chat || !Array.isArray(chat.children)) return false;
+  const chat = findContextBlockTarget(tui, g.__piContextimateChat);
+  if (!tui || !chat || !Array.isArray(chat.children)) return false;
 
   g.__piContextimateChat = chat;
-  if (chat.children.includes(block)) return true;
-
-  removeExistingPrefixBlocks(chat);
-  const insertAfter = insertionIndexAfterResourceList(chat);
-  const insertAt = insertAfter >= 0 ? insertAfter + 1 : 0;
-  chat.children.splice(insertAt, 0, block);
-  tui?.requestRender?.(true);
+  if (reconcileContextBlockTree(tui, chat, block)) tui.requestRender?.(true);
   return true;
 }
 
@@ -1461,6 +1418,11 @@ export const internals = {
   renderCompact,
   renderExpanded,
   stripAnsi,
+  // startup block lifecycle
+  collectContainers,
+  prefixBlockLocations,
+  removeExistingPrefixBlocks,
+  reconcileContextBlockTree,
 };
 
 export type {
@@ -1491,8 +1453,8 @@ export default function piContextimate(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     if (!ctx.hasUI) return;
 
-    // Restore Pi's normal header; this extension now renders below Pi's loaded-resource list.
-    ctx.ui.setHeader(undefined);
+    if (g.__piContextimateInstallTimer) clearTimeout(g.__piContextimateInstallTimer);
+    g.__piContextimateInstallTimer = undefined;
 
     const currentMode = g.__piContextimateMode ?? DEFAULT_MODE;
     const config = loadContextimateConfig(ctx.cwd);
@@ -1548,7 +1510,11 @@ export default function piContextimate(pi: ExtensionAPI) {
 
   pi.on("session_shutdown", async () => {
     if (g.__piContextimateInstallTimer) clearTimeout(g.__piContextimateInstallTimer);
+    removeExistingPrefixBlocks(g.__piContextimateTui);
     g.__piContextimateInstallTimer = undefined;
+    g.__piContextimateBlock = undefined;
+    g.__piContextimateChat = undefined;
+    g.__piContextimateTui = undefined;
   });
 
   pi.registerCommand("contextimate", {

--- a/extensions/pi-contextimate/startup-block.ts
+++ b/extensions/pi-contextimate/startup-block.ts
@@ -1,0 +1,102 @@
+import type { Component } from "@earendil-works/pi-tui";
+import { stripAnsi } from "../_lib/ansi.ts";
+import { findContainerBy, isResourceRow, type ContainerLike } from "../_lib/chat.ts";
+
+export type ContextimateTui = {
+  children?: unknown[];
+  requestRender?: (force?: boolean) => void;
+};
+
+export type PrefixBlock = Component & {
+  __piContextimateBlock: true;
+};
+
+function renderPlain(component: Component, width = 120): string {
+  try {
+    return stripAnsi(component.render(width).join("\n"));
+  } catch {
+    return "";
+  }
+}
+
+function isPrefixBlock(component: unknown): component is PrefixBlock {
+  return !!component && typeof component === "object" && (component as { __piContextimateBlock?: boolean }).__piContextimateBlock === true;
+}
+
+function isResourceComponent(component: unknown): boolean {
+  return !isPrefixBlock(component) && isResourceRow(component);
+}
+
+function isBlankComponent(component: Component): boolean {
+  return renderPlain(component, 80).trim().length === 0;
+}
+
+function findResourceChatContainer(node: unknown): ContainerLike | undefined {
+  return findContainerBy(node, (children) => children.some((child) => isResourceComponent(child)));
+}
+
+export function collectContainers(node: unknown, seen = new Set<unknown>(), out: ContainerLike[] = []): ContainerLike[] {
+  if (!node || typeof node !== "object" || seen.has(node)) return out;
+  seen.add(node);
+  const children = (node as { children?: unknown[] }).children;
+  if (!Array.isArray(children)) return out;
+  out.push(node as ContainerLike);
+  for (const child of children) collectContainers(child, seen, out);
+  return out;
+}
+
+export function prefixBlockLocations(node: unknown): Array<{ container: ContainerLike; block: PrefixBlock }> {
+  const locations: Array<{ container: ContainerLike; block: PrefixBlock }> = [];
+  for (const container of collectContainers(node)) {
+    for (const child of container.children) {
+      if (isPrefixBlock(child)) locations.push({ container, block: child });
+    }
+  }
+  return locations;
+}
+
+export function removeExistingPrefixBlocks(node: unknown): number {
+  let removed = 0;
+  for (const container of collectContainers(node)) {
+    for (let index = container.children.length - 1; index >= 0; index--) {
+      if (!isPrefixBlock(container.children[index])) continue;
+      container.children.splice(index, 1);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+function insertionIndexAfterResourceList(chat: ContainerLike): number {
+  let index = -1;
+  for (let i = 0; i < chat.children.length; i++) {
+    if (!isResourceComponent(chat.children[i])) continue;
+    index = i;
+    if (i + 1 < chat.children.length && isBlankComponent(chat.children[i + 1] as Component)) index = i + 1;
+  }
+  return index;
+}
+
+export function findContextBlockTarget(
+  tui: ContextimateTui | undefined,
+  cached: ContainerLike | undefined,
+): ContainerLike | undefined {
+  if (!tui) return undefined;
+  const liveContainers = collectContainers(tui);
+  return (
+    findResourceChatContainer(tui) ??
+    findContainerBy(tui, (children) => children.some((child) => isPrefixBlock(child))) ??
+    (cached && liveContainers.includes(cached) ? cached : undefined)
+  );
+}
+
+export function reconcileContextBlockTree(root: unknown, target: ContainerLike, block: PrefixBlock): boolean {
+  const locations = prefixBlockLocations(root);
+  if (locations.length === 1 && locations[0]?.container === target && locations[0].block === block) return false;
+
+  removeExistingPrefixBlocks(root);
+  const insertAfter = insertionIndexAfterResourceList(target);
+  const insertAt = insertAfter >= 0 ? insertAfter + 1 : 0;
+  target.children.splice(insertAt, 0, block);
+  return true;
+}

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -6,7 +6,7 @@
     "defaultTsMax": 350,
     "files": {
       "extensions/pi-cachemire/index.ts": 859,
-      "extensions/pi-contextimate/index.ts": 1568,
+      "extensions/pi-contextimate/index.ts": 1534,
       "extensions/pi-traceline/index.ts": 1730,
       "tests/contract/pi-internals.test.ts": 401,
       "tests/traceline/one-line.test.ts": 774

--- a/tests/contextimate/startup-lifecycle.test.ts
+++ b/tests/contextimate/startup-lifecycle.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { Component } from "@earendil-works/pi-tui";
+import { internals } from "../../extensions/pi-contextimate/index.ts";
+
+const {
+  prefixBlockLocations,
+  removeExistingPrefixBlocks,
+  reconcileContextBlockTree,
+} = internals;
+
+type TestContainer = { children: unknown[] };
+type TestPrefixBlock = Component & { __piContextimateBlock: true };
+
+function component(lines: string[]): Component {
+  return {
+    render: () => lines,
+    invalidate: () => {},
+  };
+}
+
+function prefixBlock(label: string): TestPrefixBlock {
+  return {
+    __piContextimateBlock: true,
+    render: () => [`[Contextimate] ${label}`],
+    invalidate: () => {},
+  };
+}
+
+test("startup block reconciliation removes stale blocks across the live TUI tree", () => {
+  const resource = component(["[Context]  AGENTS.md"]);
+  const spacer = component([""]);
+  const retained = component(["retained by another extension"]);
+  const stale = prefixBlock("stale");
+  const duplicate = prefixBlock("duplicate");
+  const active = prefixBlock("active");
+  const target: TestContainer = { children: [resource, spacer, duplicate, retained] };
+  const staleContainer: TestContainer = { children: [stale] };
+  const root: TestContainer = { children: [staleContainer, target] };
+  const targetChildren = target.children;
+  const staleChildren = staleContainer.children;
+
+  assert.equal(reconcileContextBlockTree(root, target, active), true);
+  assert.equal(target.children, targetChildren, "target children array identity is preserved");
+  assert.equal(staleContainer.children, staleChildren, "stale container array identity is preserved");
+  assert.deepEqual(target.children, [resource, spacer, active, retained]);
+  assert.deepEqual(staleContainer.children, []);
+  assert.deepEqual(prefixBlockLocations(root), [{ container: target, block: active }]);
+
+  assert.equal(reconcileContextBlockTree(root, target, active), false, "canonical installation is idempotent");
+  assert.deepEqual(target.children, [resource, spacer, active, retained]);
+});
+
+test("startup cleanup removes every marked block without replacing container arrays", () => {
+  const first = prefixBlock("first");
+  const second = prefixBlock("second");
+  const nested: TestContainer = { children: [second] };
+  const root: TestContainer = { children: [first, nested] };
+  const rootChildren = root.children;
+  const nestedChildren = nested.children;
+
+  assert.equal(removeExistingPrefixBlocks(root), 2);
+  assert.equal(root.children, rootChildren);
+  assert.equal(nested.children, nestedChildren);
+  assert.deepEqual(root.children, [nested]);
+  assert.deepEqual(nested.children, []);
+});

--- a/tests/smoke/startup-smoke.mjs
+++ b/tests/smoke/startup-smoke.mjs
@@ -168,8 +168,15 @@ try {
   waitFor("post-reload render", (text) => text.includes("[Contextimate]"), 60000);
   sleep(2000); // settle: reload re-renders the startup listing
   pane = capture({ visibleOnly: true });
-  const blocks = (pane.match(/\[Contextimate\]/g) ?? []).length;
+  let blocks = (pane.match(/\[Contextimate\]/g) ?? []).length;
   check("exactly one estimator block after /reload", blocks === 1, `found ${blocks}`);
+
+  run(["tmux", "send-keys", "-t", session, "/reload", "Enter"]);
+  waitFor("second post-reload render", (text) => text.includes("[Contextimate]"), 60000);
+  sleep(2000);
+  pane = capture({ visibleOnly: true });
+  blocks = (pane.match(/\[Contextimate\]/g) ?? []).length;
+  check("exactly one estimator block after repeated /reload", blocks === 1, `found ${blocks}`);
 
   // 4. The Ctrl+T chat rebuild (pi clears + rebuilds the chat container from session
   // messages, dropping raw appended children): cachemire's /cache ledger line must
@@ -200,6 +207,8 @@ try {
     !/Thinking blocks: (hidden|visible)/.test(pane),
     "status line still rendered",
   );
+  blocks = (pane.match(/\[Contextimate\]/g) ?? []).length;
+  check("exactly one estimator block after the Ctrl+T chat rebuild", blocks === 1, `found ${blocks}`);
   check("cachemire ledger survives the Ctrl+T chat rebuild", pane.includes("cache & loop ledger"));
   check("meantime pace panel survives the Ctrl+T chat rebuild", pane.includes("no timed model calls yet"));
 } finally {


### PR DESCRIPTION
## Summary

- reconcile Contextimate startup blocks across the entire live TUI tree instead of only the selected container
- preserve container child-array identity while removing stale blocks
- stop resetting headers owned by other extensions
- clear session-scoped startup ownership on shutdown
- add focused lifecycle regression coverage and strengthen reload/Ctrl+T smoke assertions

## Why

Extensions such as `pi-welcome-screen` can rehost Pi's startup resources. Contextimate previously cleaned only one cached container, so an old block could remain mounted while a new block was inserted elsewhere. The cached-container check could also treat a detached block as installed.

The new reconciliation pass identifies the current reachable target, removes every stale marked block in place, and inserts exactly one active block.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- focused startup lifecycle tests: 2/2 passed
- composed live startup with `pi-welcome-screen`: manually verified, duplicate no longer reproduces

`npm test` currently reports 319 passing and 6 failing tests, all in `tests/cachemire/model-switch-events.test.ts`; this change does not touch Cachemire.