### PR TITLE
Preserve Cachemire fingerprints across hot reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Cachemire keeps live request fingerprints across Pi hot reloads, allowing the first
+  post-reload miss to identify changed tool schemas and other prompt-prefix mutations.
 - Meantime no longer estimates live tok/s from streamed thinking text, whose
   relationship to reasoning tokens varies by provider. Live rate appears only while
   writing, calibrated from visible writing chars and non-reasoning output tokens.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -198,9 +198,11 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   abandoned leaf. Use the last provider-billed prompt on the selected path as a
   comparison baseline. It is not the whole next prompt, which includes new suffix
   content. A later request refreshes that baseline only when session ancestry and its
-  provider, model, cache evidence and payload fingerprint prove compatibility. The
-  intentional suffix divergence is ordinary prefix growth; withhold its estimate until
-  provider usage makes the new request exact
+  provider, model, cache evidence and payload fingerprint prove compatibility. A hot
+  reload carries live fingerprints onto the same persisted provider calls, so a tool or
+  system-prefix change made by the reload remains observable. The intentional suffix
+  divergence is ordinary prefix growth; withhold its estimate until provider usage makes
+  the new request exact
 - a model switch re-prices the conversation; the wording leads with the consequence
   (the whole prompt goes uncached to the new provider): `cache cold expected · model
   switched · next send ~32.4k uncached to anthropic (est)`. The headline is the

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -175,9 +175,12 @@ Working state and rendered output live in the extension process. Cachemire adds 
 session entries or exports. Corrected Moonshot and Together counts become ordinary Pi
 assistant usage and follow Pi's normal session lifecycle.
 
-On restore, Cachemire rebuilds its ledger and branch baselines from billed usage in
-assistant messages. Payload fingerprints, request-start observations and live retention
-fields are not persisted. Diagnoses that need those fields remain unknown.
+On hot reload, Cachemire reattaches the process-live payload fingerprints to their
+persisted provider calls. Tool-schema and other prefix changes introduced by the reload
+therefore remain diagnosable. On process restart or session resume, Cachemire rebuilds
+its ledger and branch baselines from billed usage in assistant messages. Payload
+fingerprints, request-start observations and live retention fields are not persisted;
+diagnoses that need those fields remain unknown.
 
 Only the interactive Pi extension instance owns the process-global state. Nested
 headless sessions cannot overwrite its ledger, clock or model metadata. The interactive

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -163,10 +163,12 @@ Cachemire follows these rules:
   follows Pi's normal session persistence; Cachemire adds no custom session entries.
 - Freshness wording follows the generated policy table above. Unknown retention stays
   silent. Under subscription auth, Cachemire marks savings as notional.
-- Sessions restored with `--continue` rebuild the active ledger and all-branch cache
-  baselines from session usage. Cachemire marks restored rows and excludes them from
-  savings because their pricing context is unknown. Model-level policies resolve through
-  the same registry; request-only payload evidence does not survive restore.
+- Hot reloads reattach process-live payload fingerprints to the same persisted calls,
+  so tool-schema and other prefix changes remain diagnosable. Sessions restored with
+  `--continue` rebuild the active ledger and all-branch cache baselines from session
+  usage. Cachemire marks restored rows and excludes them from savings because their
+  pricing context is unknown. Model-level policies resolve through the same registry;
+  request-only payload evidence does not survive a process restart or session resume.
 
 ## Understand the model behind the wording
 

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -476,7 +476,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
   const ownsState = () => g.__piCachemireOwner === ownerToken;
   bindProviderUsageOverlays(pi);
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", async (event, ctx) => {
     if (!ctx.hasUI) return;
     if (g.__piCachemireOwner !== undefined && !ownsState()) return;
     g.__piCachemireOwner = ownerToken;
@@ -484,7 +484,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     const entries = ctx.sessionManager.getEntries();
     const { messages } = buildSessionContext(entries, ctx.sessionManager.getLeafId());
     s.records = restoreBranchRecords(messages as unknown as Array<Record<string, unknown>>, classifyCall);
-    s.lineages = restoreLineageSnapshots(entries);
+    s.lineages = restoreLineageSnapshots(entries, event.reason === "reload" ? s.lineages : undefined);
     const baseline = findBranchBaseline(entries, ctx.sessionManager.getLeafId(), s.lineages);
     const model = ctx.model;
     if (model) {

--- a/extensions/pi-cachemire/lineage.ts
+++ b/extensions/pi-cachemire/lineage.ts
@@ -70,11 +70,26 @@ function persistedEntryTimes(entries: readonly unknown[]): Map<string, number> {
 }
 
 /** Restore every normal provider call in the session tree, not only the active branch. */
-export function restoreLineageSnapshots(entries: readonly unknown[]): CacheLineageSnapshot[] {
+export function restoreLineageSnapshots(
+  entries: readonly unknown[],
+  previousSnapshots?: CacheLineageSnapshot[],
+): CacheLineageSnapshot[] {
   const entryTimes = persistedEntryTimes(entries);
-  return entries
+  const restored = entries
     .map((entry) => billedSnapshotFromEntry(entry, entryTimes))
     .filter((snapshot): snapshot is CacheLineageSnapshot => snapshot !== undefined);
+  if (!previousSnapshots) return restored;
+
+  const fingerprints = new Map<string, RequestFingerprint>();
+  for (const snapshot of previousSnapshots) {
+    if (snapshot.responseEntryId && snapshot.fingerprint) {
+      fingerprints.set(snapshot.responseEntryId, snapshot.fingerprint);
+    }
+  }
+  for (const snapshot of restored) {
+    if (snapshot.responseEntryId) snapshot.fingerprint = fingerprints.get(snapshot.responseEntryId);
+  }
+  return restored;
 }
 
 function responseLinkKey(snapshot: CacheLineageSnapshot): string {

--- a/tests/cachemire/lineage-events.test.ts
+++ b/tests/cachemire/lineage-events.test.ts
@@ -1,0 +1,185 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+import piCachemire from "../../extensions/pi-cachemire/index.ts";
+
+type Handler = (...args: unknown[]) => unknown;
+
+function probe(): { handlers: Map<string, Handler[]>; commands: Map<string, Handler> } {
+  const handlers = new Map<string, Handler[]>();
+  const commands = new Map<string, Handler>();
+  const pi = {
+    on(event: string, handler: Handler): void {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+    },
+    registerCommand(name: string, options: { handler: Handler }): void {
+      commands.set(name, options.handler);
+    },
+    registerProvider(): void {},
+    unregisterProvider(): void {},
+    getThinkingLevel: () => "off",
+  } as unknown as ExtensionAPI;
+  piCachemire(pi);
+  return { handlers, commands };
+}
+
+async function fire(runtime: ReturnType<typeof probe>, event: string, ...args: unknown[]): Promise<void> {
+  for (const handler of runtime.handlers.get(event) ?? []) await handler(...args);
+}
+
+function usage(input: number, cacheRead: number, cacheWrite = 0) {
+  return {
+    input,
+    output: 10,
+    cacheRead,
+    cacheWrite,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function assistant(timestamp: number, prompt: number) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "answer" }],
+    provider: "anthropic",
+    api: "anthropic-messages",
+    model: "claude-opus-4-8",
+    stopReason: "stop",
+    timestamp,
+    usage: usage(2, prompt - 2),
+  };
+}
+
+function payload(messages: string[], tools?: unknown[]) {
+  return {
+    model: "claude-opus-4-8",
+    system: [{ type: "text", text: "fixture", cache_control: { type: "ephemeral" } }],
+    messages: messages.map((text) => ({ role: "user", content: [{ type: "text", text }] })),
+    ...(tools ? { tools } : {}),
+  };
+}
+
+function context(entries: unknown[], leaf: { id: string }, notifications: string[]) {
+  return {
+    hasUI: true,
+    ui: {
+      theme: undefined,
+      setWidget(): void {},
+      notify(text: string): void {
+        notifications.push(text);
+      },
+    },
+    model: {
+      id: "claude-opus-4-8",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      reasoning: false,
+      cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+    },
+    sessionManager: {
+      getEntries: () => entries,
+      getLeafId: () => leaf.id,
+    },
+    modelRegistry: {
+      getRegisteredNativeProvider: () => undefined,
+      getRegisteredProviderConfig: () => undefined,
+    },
+    getSystemPrompt: () => "",
+  };
+}
+
+test("first request after hot reload diagnoses a changed tool schema", async () => {
+  const now = Date.now();
+  const entries: unknown[] = [{
+    type: "message",
+    id: "user-1",
+    parentId: null,
+    timestamp: new Date(now - 2_000).toISOString(),
+    message: { role: "user", content: "before reload", timestamp: now - 2_000 },
+  }];
+  const leaf = { id: "user-1" };
+  const notifications: string[] = [];
+  const oldTool = { name: "computer_use", description: "Control apps", input_schema: { type: "object" } };
+  const oldRuntime = probe();
+  const oldContext = context(entries, leaf, notifications);
+  const oldAssistant = assistant(now - 1_000, 100_000);
+
+  await fire(oldRuntime, "session_start", { reason: "startup" }, oldContext);
+  await fire(oldRuntime, "before_provider_request", { payload: payload(["before reload"], [oldTool]) }, oldContext);
+  await fire(oldRuntime, "message_end", { message: oldAssistant });
+  entries.push({
+    type: "message",
+    id: "assistant-1",
+    parentId: leaf.id,
+    timestamp: new Date(now - 1_000).toISOString(),
+    message: oldAssistant,
+  });
+  leaf.id = "assistant-1";
+  await fire(oldRuntime, "turn_end", {}, oldContext);
+  await fire(oldRuntime, "session_shutdown", { reason: "reload" });
+
+  const newRuntime = probe();
+  const newContext = context(entries, leaf, notifications);
+  await fire(newRuntime, "session_start", { reason: "reload" }, newContext);
+  try {
+    entries.push({
+      type: "message",
+      id: "user-2",
+      parentId: leaf.id,
+      timestamp: new Date(now).toISOString(),
+      message: { role: "user", content: "after reload", timestamp: now },
+    });
+    leaf.id = "user-2";
+    const changedTool = {
+      ...oldTool,
+      input_schema: { type: "object", properties: { code: { type: "string" } } },
+    };
+    await fire(
+      newRuntime,
+      "before_provider_request",
+      { payload: payload(["before reload", "after reload"], [changedTool]) },
+      newContext,
+    );
+    assert.match(notifications.at(-1)!, /cause: tools changed \(1 modified\)/);
+  } finally {
+    await fire(newRuntime, "agent_end");
+    await fire(newRuntime, "session_shutdown", { reason: "quit" });
+  }
+});
+
+test("session_tree rebases classification to the selected provider-known prompt", async () => {
+  const now = Date.now();
+  const entries = [
+    { type: "message", id: "user-base", parentId: null, timestamp: new Date(now - 4_000).toISOString(), message: { role: "user", content: "base", timestamp: now - 4_000 } },
+    { type: "message", id: "assistant-base", parentId: "user-base", timestamp: new Date(now - 3_000).toISOString(), message: assistant(now - 3_000, 100_000) },
+    { type: "message", id: "user-old", parentId: "assistant-base", timestamp: new Date(now - 2_000).toISOString(), message: { role: "user", content: "old branch", timestamp: now - 2_000 } },
+    { type: "message", id: "assistant-old", parentId: "user-old", timestamp: new Date(now - 1_000).toISOString(), message: assistant(now - 1_000, 200_000) },
+  ];
+  const notifications: string[] = [];
+  const leaf = { id: "assistant-old" };
+  const runtime = probe();
+  const ctx = context(entries, leaf, notifications);
+
+  await fire(runtime, "session_start", {}, ctx);
+  try {
+    leaf.id = "assistant-base";
+    await fire(runtime, "session_tree", { newLeafId: leaf.id, oldLeafId: "assistant-old" }, ctx);
+    await fire(runtime, "before_provider_request", { payload: payload(["base", "new branch"]) }, ctx);
+    await fire(runtime, "before_provider_request", { payload: payload(["base", "new branch"]) }, ctx);
+    assert.equal(notifications.length, 0, "branching must not price the abandoned 200k leaf");
+    await fire(runtime, "message_end", {
+      message: { ...assistant(now, 100_000), usage: usage(0, 90_000, 10_000) },
+    });
+
+    await fire(runtime, "before_provider_request", {
+      payload: payload(["base", "new branch", "aborted suffix"]),
+    }, ctx);
+    await fire(runtime, "agent_end");
+    await runtime.commands.get("cache")?.("", ctx);
+    assert.equal(notifications.length, 1);
+    assert.match(notifications[0]!, /\s3\s+.*● hit/);
+  } finally {
+    await fire(runtime, "session_shutdown", {});
+  }
+});

--- a/tests/cachemire/tree-lineage.test.ts
+++ b/tests/cachemire/tree-lineage.test.ts
@@ -1,8 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-import piCachemire, { internals } from "../../extensions/pi-cachemire/index.ts";
+import { internals } from "../../extensions/pi-cachemire/index.ts";
 import { cacheStateForLineage } from "../../extensions/pi-cachemire/lineage.ts";
 import type { CacheLineageSnapshot } from "../../extensions/pi-cachemire/types.ts";
 
@@ -15,32 +14,6 @@ const {
   resolveCacheLineage,
   restoreLineageSnapshots,
 } = internals;
-
-type Handler = (...args: unknown[]) => unknown;
-
-function extensionProbe(): { handlers: Map<string, Handler[]>; commands: Map<string, Handler> } {
-  const handlers = new Map<string, Handler[]>();
-  const commands = new Map<string, Handler>();
-  const pi = {
-    on(event: string, handler: Handler): void {
-      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
-    },
-    registerCommand(name: string, options: { handler: Handler }): void {
-      commands.set(name, options.handler);
-    },
-    registerProvider(): void {},
-    unregisterProvider(): void {},
-    getThinkingLevel(): string {
-      return "off";
-    },
-  } as unknown as ExtensionAPI;
-  piCachemire(pi);
-  return { handlers, commands };
-}
-
-async function fire(probe: ReturnType<typeof extensionProbe>, event: string, ...args: unknown[]): Promise<void> {
-  for (const handler of probe.handlers.get(event) ?? []) await handler(...args);
-}
 
 function usage(input: number, cacheRead: number, cacheWrite: number, output = 10) {
   return {
@@ -112,34 +85,6 @@ function resolve(
     currentFingerprint: current,
     compareFingerprints: diffFingerprints,
   });
-}
-
-function context(entries: unknown[], leaf: { id: string }, notifications: string[]) {
-  return {
-    hasUI: true,
-    ui: {
-      theme: undefined,
-      setWidget(): void {},
-      notify(text: string): void {
-        notifications.push(text);
-      },
-    },
-    model: {
-      id: "claude-opus-4-8",
-      provider: "anthropic",
-      api: "anthropic-messages",
-      reasoning: false,
-      cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
-    },
-    sessionManager: {
-      getEntries: () => entries,
-      getLeafId: () => leaf.id,
-    },
-    modelRegistry: {
-      getRegisteredNativeProvider: () => undefined,
-      getRegisteredProviderConfig: () => undefined,
-    },
-  };
 }
 
 test("restores every branch while selecting only the active path baseline", () => {
@@ -299,36 +244,4 @@ test("lineage-local freshness drives TTL prediction", () => {
   });
   assert.equal(prediction?.cause.kind, "ttl");
   assert.equal(prediction?.expectedRewriteTokens, 100_000);
-});
-
-test("session_tree rebases classification to the selected provider-known prompt", async () => {
-  const now = Date.now();
-  const entries = [
-    { type: "message", id: "user-base", parentId: null, timestamp: new Date(now - 4_000).toISOString(), message: { role: "user", content: "base", timestamp: now - 4_000 } },
-    { type: "message", id: "assistant-base", parentId: "user-base", timestamp: new Date(now - 3_000).toISOString(), message: assistant(now - 3_000, 100_000) },
-    { type: "message", id: "user-old", parentId: "assistant-base", timestamp: new Date(now - 2_000).toISOString(), message: { role: "user", content: "old branch", timestamp: now - 2_000 } },
-    { type: "message", id: "assistant-old", parentId: "user-old", timestamp: new Date(now - 1_000).toISOString(), message: assistant(now - 1_000, 200_000) },
-  ];
-  const notifications: string[] = [];
-  const leaf = { id: "assistant-old" };
-  const probe = extensionProbe();
-  const ctx = context(entries, leaf, notifications);
-
-  await fire(probe, "session_start", {}, ctx);
-  try {
-    leaf.id = "assistant-base";
-    await fire(probe, "session_tree", { newLeafId: leaf.id, oldLeafId: "assistant-old" }, ctx);
-    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch"]) }, ctx);
-    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch"]) }, ctx);
-    assert.equal(notifications.length, 0, "branching must not price the abandoned 200k leaf");
-    await fire(probe, "message_end", { message: { ...assistant(now, 100_000), usage: usage(0, 90_000, 10_000) } });
-
-    await fire(probe, "before_provider_request", { payload: payload(["base", "new branch", "aborted suffix"]) }, ctx);
-    await fire(probe, "agent_end");
-    await probe.commands.get("cache")?.("", ctx);
-    assert.equal(notifications.length, 1);
-    assert.match(notifications[0]!, /\s3\s+.*● hit/);
-  } finally {
-    await fire(probe, "session_shutdown", {});
-  }
 });


### PR DESCRIPTION
## Summary
- reattach process-live payload fingerprints to persisted provider calls during `/reload`
- match snapshots by durable assistant response entry ID, including responses linked immediately before reload
- keep process restarts and resumed/new sessions isolated; no payload data is added to JSONL
- document the hot-reload observability guarantee

## Verification
- `npm run check`
- focused reload, lineage, and session-isolation tests
- independent review: no issues found

## Real TUI smoke test

Recorded in an isolated real Pi 0.84.2 TUI against `anthropic/claude-fable-5`:

1. `schema_probe` starts at v1 with one `message` parameter.
2. A live call writes 10.9k cache tokens; the next reads 10.9k (100% cached).
3. The extension adds an optional `detail` parameter and `/reload` runs.
4. `/schema-version` confirms v2, then the next send reports `cause: tools changed (1 modified)` before the response. Provider usage resolves to an 11.0k rewrite.

https://github.com/user-attachments/assets/4d635cbe-af48-47e4-a65d-c5265d022de5
