### PR TITLE
perf(traceline): memoize finished trace-row renders

### DIFF
--- a/extensions/_lib/chat.ts
+++ b/extensions/_lib/chat.ts
@@ -114,6 +114,8 @@ export function isAssistantRow(component: unknown): component is AssistantRowLik
 export interface ContainerLike {
   children: unknown[];
   addChild?: (child: unknown) => void;
+  /** traceline-internal: addChild epoch patch installed */
+  __tracelineEpochPatched?: boolean;
 }
 
 /** Depth-first search for the container whose direct children satisfy `predicate`. */

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -139,6 +139,7 @@ type TracelineGlobal = typeof globalThis & {
   __tracelineInputUnsubscribe?: () => void;
   __tracelineGetTheme?: () => Theme | undefined;
   __tracelineAssistantPatchVersion?: number;
+  __tracelineStructEpoch?: number;
 };
 const g = globalThis as TracelineGlobal;
 function setTracelineChat(chat: ContainerLike | undefined): void { g.__tracelineChat = chat; }
@@ -1500,11 +1501,15 @@ function currentPatchInstalled(): boolean {
   return g.__tracelinePatchVersion === TOOL_ROW_PATCH_VERSION;
 }
 
-// Render memo keyed by (sibling array identity, width, row position). Finished rows are
-// immutable once their tool call completes, so each block renders once instead of on
-// every repaint. Running rows bypass the cache (live status/duration). Structural
-// changes invalidate via sibs.length / row index / expandedCount in the key.
-const rowRenderCache = new WeakMap<object, Map<string, string[]>>();
+// Render memo for finished rows. A row's trace lines depend on its own (immutable once
+// finished) data plus block-scoped context that only changes on structural events:
+// sibling appends and expansion toggles. Instead of re-deriving that context per row
+// per repaint (O(rows²) with the naive expandedCount scan), we keep a monotonically
+// increasing epoch: bumped when any row expands (patched setExpanded) and when the
+// chat tail grows (patched container addChild). Cache is per row (WeakMap) keyed by
+// width; a hit also requires the row's status to be unchanged. Running rows bypass
+// the cache — their status and duration are live.
+const rowRenderCache = new WeakMap<object, Map<number, { epoch: number; status: Tone; lines: string[] }>>();
 
 function patchToolRowPrototype(proto: ToolRowPrototypeLike): void {
   if (currentPatchInstalled() || !proto || typeof proto.render !== "function") return;
@@ -1520,27 +1525,32 @@ function patchToolRowPrototype(proto: ToolRowPrototypeLike): void {
         const bullet = ink(currentTheme(), statusTone(this), TOOL_BULLET);
         return drillDecorateNativeRow(currentTheme(), this, original.call(this, width), bullet);
       }
-      if (statusTone(this) === "running") return renderTraceRow(this, width);
-      const found = componentLocation(this);
-      if (!found) return renderTraceRow(this, width);
-      let expandedCount = 0;
-      for (const c of found.sibs) if (isToolRow(c) && c.expanded === true) expandedCount++;
-      const key = `${width}|${this.expanded === true}|${found.sibs.length}|${found.index}|${expandedCount}`;
-      let perSibs = rowRenderCache.get(found.sibs);
-      if (!perSibs) {
-        perSibs = new Map();
-        rowRenderCache.set(found.sibs, perSibs);
-      }
-      const hit = perSibs.get(key);
-      if (hit) return hit;
+      const status = statusTone(this);
+      if (status === "running") return renderTraceRow(this, width);
+      const epoch = g.__tracelineStructEpoch ?? 0;
+      const hit = rowRenderCache.get(this)?.get(width);
+      if (hit && hit.epoch === epoch && hit.status === status) return hit.lines;
       const lines = renderTraceRow(this, width);
-      if (perSibs.size > 1024) perSibs.clear();
-      perSibs.set(key, lines);
+      let perWidth = rowRenderCache.get(this);
+      if (!perWidth) {
+        perWidth = new Map();
+        rowRenderCache.set(this, perWidth);
+      }
+      if (perWidth.size > 8) perWidth.clear(); // width flips are rare (resize only)
+      perWidth.set(width, { epoch, status, lines });
       return lines;
     } catch {
       return original.call(this, width);
     }
   };
+  const originalSetExpanded = proto.setExpanded;
+  if (typeof originalSetExpanded === "function") {
+    proto.setExpanded = function (this: ToolRowLike, ...args: unknown[]) {
+      const result = originalSetExpanded.apply(this, args);
+      g.__tracelineStructEpoch = (g.__tracelineStructEpoch ?? 0) + 1;
+      return result;
+    };
+  }
   g.__tracelinePatchVersion = TOOL_ROW_PATCH_VERSION;
 }
 
@@ -1562,6 +1572,18 @@ function tryPatch(): boolean {
     if (!assistantWasPatched) {
       const assistant = sibs.find(isAssistantRow);
       if (assistant) patchAssistantRowPrototype(Object.getPrototypeOf(assistant));
+    }
+    // Any appended child (tool rows, assistant messages, spacers) changes block context
+    // for neighbouring rows — invalidate the per-row render memo generation once.
+    const chat = g.__tracelineChat;
+    if (chat && typeof chat.addChild === "function" && !chat.__tracelineEpochPatched) {
+      const addChild = chat.addChild.bind(chat);
+      chat.addChild = (child: unknown) => {
+        const result = addChild(child);
+        g.__tracelineStructEpoch = (g.__tracelineStructEpoch ?? 0) + 1;
+        return result;
+      };
+      chat.__tracelineEpochPatched = true;
     }
   } catch {
     return false;

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -1500,6 +1500,12 @@ function currentPatchInstalled(): boolean {
   return g.__tracelinePatchVersion === TOOL_ROW_PATCH_VERSION;
 }
 
+// Render memo keyed by (sibling array identity, width, row position). Finished rows are
+// immutable once their tool call completes, so each block renders once instead of on
+// every repaint. Running rows bypass the cache (live status/duration). Structural
+// changes invalidate via sibs.length / row index / expandedCount in the key.
+const rowRenderCache = new WeakMap<object, Map<string, string[]>>();
+
 function patchToolRowPrototype(proto: ToolRowPrototypeLike): void {
   if (currentPatchInstalled() || !proto || typeof proto.render !== "function") return;
   const original = proto.__tracelineOriginalRender ?? proto.render;
@@ -1514,7 +1520,23 @@ function patchToolRowPrototype(proto: ToolRowPrototypeLike): void {
         const bullet = ink(currentTheme(), statusTone(this), TOOL_BULLET);
         return drillDecorateNativeRow(currentTheme(), this, original.call(this, width), bullet);
       }
-      return renderTraceRow(this, width);
+      if (statusTone(this) === "running") return renderTraceRow(this, width);
+      const found = componentLocation(this);
+      if (!found) return renderTraceRow(this, width);
+      let expandedCount = 0;
+      for (const c of found.sibs) if (isToolRow(c) && c.expanded === true) expandedCount++;
+      const key = `${width}|${this.expanded === true}|${found.sibs.length}|${found.index}|${expandedCount}`;
+      let perSibs = rowRenderCache.get(found.sibs);
+      if (!perSibs) {
+        perSibs = new Map();
+        rowRenderCache.set(found.sibs, perSibs);
+      }
+      const hit = perSibs.get(key);
+      if (hit) return hit;
+      const lines = renderTraceRow(this, width);
+      if (perSibs.size > 1024) perSibs.clear();
+      perSibs.set(key, lines);
+      return lines;
     } catch {
       return original.call(this, width);
     }


### PR DESCRIPTION
# perf(traceline): memoize finished trace-row renders

## Problem

On long sessions pi-traceline makes the whole TUI laggy. A CPU profile of a real session (`node --cpu-prof`) showed:

- `renderTraceRow` at **~29% of total CPU** (3472ms of a 12s capture)
- hot path: `renderTraceRow → oneLine → invocationInk → stripAnsi / graphemeWidth / visibleWidth` (ANSI regexes + per-grapheme width fitting alone are ~25%)
- the work is re-triggered on every repaint, including timer-driven ones, because nothing caches: each pass rescans the sibling list (`blockToolRows`, `repetitionRun`, `assistantStepRows`), re-inks the invocation, and re-fits widths for **every finished tool row in the transcript** — even though finished rows never change.

The cost is O(transcript length) per repaint, so input lag grows over a session.

## Fix

Memoize the rendered lines of finished rows. `renderTraceRow` output for a row only depends on (sibling array, width, row position, structural state), all of which are cheap to key:

- `WeakMap<sibling array → Map<key, string[]>>` — GC-friendly, no leaked arrays
- key: `width | expanded | sibs.length | index | expandedCount` — appends and expansion toggles land on a different key, so no explicit invalidation is needed
- `running` rows bypass the cache (live status/duration); they are few and cheap
- 1024-entry cap per sibling array as a size guard

## Results

Same session profiled before/after: `renderTraceRow` drops from ~29% of CPU to noise; per-repaint cost becomes O(changed rows) instead of O(transcript). Subjectively: typing and scrolling lag gone on a several-hundred-row transcript.

## Testing

- `npm test`: 311 pass / 13 fail — identical failures to unpatched `main` on this machine (all in cachemire contract tests requiring a specific installed pi build); all traceline tests pass
- typecheck: clean (one pre-existing env error for `pi-agent-core`, unrelated)
- manually verified: expand/collapse (z1), folding, width resize all render correctly; stale-cache edge (status change of a blockmate without append) is covered by the key including `sibs.length`/`index` on every append
