### PR TITLE
fix(traceline): retain multiline native call summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Traceline keeps continuation lines from native tool-call renderers in compact
+  summaries. A `Ran` header followed by a command now shows `Ran · command`,
+  without tool-specific adapters. Expanded calls and results stay native.
+
 ## 0.11.0 (2026-09-08)
 
 - Traceline: click a tool trace or reasoning run in fullscreen Pi to expand or

--- a/LOG.md
+++ b/LOG.md
@@ -146,3 +146,19 @@ every 0.5 s on the pi process:
 
 Rendered folds, ranges and size columns looked correct in both captures. Released
 v0.11.0 from main after the soak.
+## 2026-09-08: preserve multiline call summaries
+
+Reproduced generic call renderers collapsing to `Ran` because Traceline kept only
+one line. Added a tool-independent call summarizer that joins continuation lines,
+removes layout indentation and tree branches, and preserves ANSI styling. Removed
+per-line expand hints before joining and restricted path reconstruction to single
+lines so read continuations survive too. Native expanded rendering is unchanged.
+
+Six new real-Pi component tests cover execution states, command/code/exploration
+layouts, distinct invocations with matching headers, colour preservation, widths
+1 through 100 and click expansion. Updated the obsolete first-line-only test.
+The initial regressions failed before implementation. Final full suite: 345 passed,
+the same four baseline contract failures; lint and typecheck pass. Verified actual
+installed Codex-conversion renderers and reviewed screenshots at 100 and 50 columns.
+All real-Pi smoke suites passed, including fullscreen clicks, Drill, pager fidelity,
+reasoning and startup/reload. No PR comments posted.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -414,7 +414,12 @@ Read, edit and write rows dim what is boring and bolden what discriminates:
 ### 9.6 Native rows
 
 Rows for other tools (`grep`, `web_search`, `fetch_content`, `mcp`, and kin)
-reuse pi's native invocation line. Spans the native renderer left unstyled demote
+reuse pi's native call rendering, not just its first line. Non-empty continuation
+lines join the header with ` · `, with indentation and leading tree-branch markers
+removed: `Ran` followed by `└ surf tabs.list` becomes `Ran · surf tabs.list`.
+Middle truncation keeps the head and operative tail within the shared body budget.
+Result rendering is never included; expanded rows remain native. Single-line calls
+keep their existing presentation. Spans the native renderer left unstyled demote
 to L3-dim; spans pi deliberately coloured (patterns, ranges, backticks) and
 bold-only spans survive untouched. §9.3's "bold is the trace row's white" holds
 for every tool, not just the hand-rebuilt rows.

--- a/extensions/pi-traceline/call-summary.ts
+++ b/extensions/pi-traceline/call-summary.ts
@@ -1,0 +1,29 @@
+import { ansiEndIndex, stripAnsi } from "../_lib/ansi.ts";
+import { SEP } from "../_lib/style.ts";
+
+/** Flatten call-only rendering; results and expanded geometry remain native. */
+export function summarizeCallLines(lines: string[]): string | undefined {
+  const visible = lines.filter((line) => stripAnsi(line).trim().length > 0);
+  if (visible.length === 0) return undefined;
+  return visible.map((line, index) => {
+    const plain = stripAnsi(line);
+    // Tree branches describe vertical layout, not the invocation. Leave ordinary
+    // code operators and list bullets untouched; only continuation branches go.
+    const prefix = index === 0 ? /^\s*/ : /^\s*(?:[└├]─?\s+)?/;
+    const start = plain.match(prefix)![0].length;
+    const end = plain.trimEnd().length;
+    let text = "";
+    let column = 0;
+    for (let i = 0; i < line.length; i++) {
+      const escapeEnd = ansiEndIndex(line, i);
+      if (escapeEnd !== undefined) {
+        text += line.slice(i, escapeEnd + 1);
+        i = escapeEnd;
+      } else {
+        if (column >= start && column < end) text += line[i];
+        column++;
+      }
+    }
+    return text;
+  }).join(SEP);
+}

--- a/extensions/pi-traceline/index.ts
+++ b/extensions/pi-traceline/index.ts
@@ -65,6 +65,7 @@ import {
   type DiffStats,
 } from "./write-diff.ts";
 import { installThinkingPreviews } from "./thinking-preview.ts";
+import { summarizeCallLines } from "./call-summary.ts";
 import { handleThinkingToggleTerminalInput } from "./thinking-toggle.ts";
 import { createTracelineTuiOwner } from "./tui-owner.ts";
 
@@ -558,10 +559,6 @@ function compactJson(value: unknown): string {
   }
 }
 
-function firstVisibleLine(lines: string[]): string | undefined {
-  return lines.find((line) => stripAnsi(line).trim().length > 0);
-}
-
 // Bash commands keep their real newlines (heredocs, inline python, chained pipelines),
 // so first-line-only collapses them to an uninformative prefix like `$ python3 -c "`
 // (issue #10). Flatten every visible line into the one trace line, with a ↵ where each
@@ -914,24 +911,23 @@ function colourCommandPrefix(comp: ToolRowDataLike | undefined, line: string): s
   return `${ink(currentTheme(), verbTone(comp), `${BOLD}${prefix}${BOLD_OFF}`)}${rest}`;
 }
 
-// Prefer pi's own renderCall output for one-line mode (non-bash tools). This borrows
-// the native visual grammar (paths/backticks, warning line ranges, custom-tool
-// renderers) and only suppresses result/output lines by taking the first visible call
-// line. The verb is re-inked neutral bold (error rows error) per the family hierarchy.
-function nativeInvocationLine(comp: ToolRowDataLike | undefined): string | undefined {
-  return comp ? renderCache.memo(comp, `native-invocation:${objectCacheKey(currentTheme())}`, () => {
+// Borrow the complete native call grammar, including continuation lines (§9.6).
+// Results stay separate. Re-ink the verb neutral bold (error rows error).
+function nativeInvocationLine(comp: ToolRowLike): string | undefined {
+  return renderCache.memo(comp, `native-invocation:${objectCacheKey(currentTheme())}`, () => {
     const call = comp.callRendererComponent;
     if (!call || typeof call.render !== "function") return undefined;
     const rendered = call.render(ONE_LINE_CAPTURE_WIDTH);
-    const lines = Array.isArray(rendered) ? rendered : [];
-    const line = firstVisibleLine(lines);
-    // Demote *after* the verb re-ink: colourCommandPrefix strips foregrounds from the
-    // prefix region, so a dim span opened before the verb would lose its opener and
-    // strand the rest of the line back at the terminal default.
-    return line
-      ? dimUnstyledSpans(colourCommandPrefix(comp, stripSgrBackgrounds(stripTrailingExpandHint(line))))
-      : undefined;
-  }) : undefined;
+    const lines = (Array.isArray(rendered) ? rendered : []).map(stripTrailingExpandHint)
+      .filter((line) => stripAnsi(line).trim().length > 0);
+    const line = summarizeCallLines(lines);
+    // Demote after verb re-inking, which strips foregrounds from the prefix region;
+    // doing it first would lose the dim opener and leave its body at terminal default.
+    if (!line) return undefined;
+    const styled = dimUnstyledSpans(colourCommandPrefix(comp, stripSgrBackgrounds(line)));
+    // Path reconstruction is lossless only for a single native call line.
+    return lines.length === 1 ? pathEmphasisLine(comp, styled) ?? styled : styled;
+  });
 }
 
 // Rare fallback for tools without a renderCall component. Keep it intentionally plain;
@@ -1043,8 +1039,7 @@ function invocationInk(comp: ToolRowLike, available = Number.POSITIVE_INFINITY):
       return headline ? `${headline} ${body}` : body;
     }
     const native = nativeInvocationLine(comp);
-    const base = native ? pathEmphasisLine(comp, native) ?? native : undefined;
-    return base ? tildify(base) : inkedFallbackLine(comp);
+    return native ? tildify(native) : inkedFallbackLine(comp);
   });
 }
 

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -7,7 +7,7 @@
     "files": {
       "extensions/pi-cachemire/index.ts": 852,
       "extensions/pi-contextimate/index.ts": 1568,
-      "extensions/pi-traceline/index.ts": 1685,
+      "extensions/pi-traceline/index.ts": 1680,
       "tests/contract/pi-internals.test.ts": 355,
       "tests/traceline/one-line.test.ts": 774
     }

--- a/tests/contract/pi-traceline-call-summary.test.ts
+++ b/tests/contract/pi-traceline-call-summary.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, test } from "node:test";
+import assert from "node:assert/strict";
+import { createReadTool, initTheme, ToolExecutionComponent } from "@earendil-works/pi-coding-agent";
+import { Text, visibleWidth } from "@earendil-works/pi-tui";
+import type { ToolRowLike } from "../../extensions/_lib/chat.ts";
+import type { TraceMousePrototype } from "../../extensions/pi-traceline/click.ts";
+import { internals as trace } from "../../extensions/pi-traceline/index.ts";
+import { assistantBefore } from "../traceline/runtime-fixtures.ts";
+
+initTheme(undefined, false);
+trace.patchToolRowPrototype(ToolExecutionComponent.prototype as unknown as TraceMousePrototype);
+afterEach(() => trace.setTracelineChat(undefined));
+
+let nextCallId = 0;
+function row(call: string, state: "success" | "running" | "error" = "success") {
+  const definition = {
+    ...createReadTool("/tmp"), name: "custom_action",
+    renderCall: () => new Text(call, 0, 0),
+    renderResult: () => new Text("SECRET_OUTPUT", 0, 0),
+  };
+  const comp = new ToolExecutionComponent("custom_action", `call-${nextCallId++}`, {}, {}, definition, { requestRender() {} } as never, "/tmp");
+  if (state !== "running") comp.updateResult({ content: [{ type: "text", text: "SECRET_OUTPUT" }], isError: state === "error" });
+  trace.setTracelineChat({ children: [assistantBefore([comp as unknown as ToolRowLike], [], true), comp] });
+  return comp;
+}
+function painted(comp: ToolExecutionComponent, width = 100) {
+  return comp.render(width).map(trace.stripAnsi).filter((line) => line.trim());
+}
+
+test("status-only call headers retain their command for every execution state", () => {
+  for (const state of ["success", "running", "error"] as const) {
+    const verb = state === "running" ? "Running" : "Ran";
+    assert.deepEqual(painted(row(`• ${verb}\n  └ surf tabs.list`, state)), [`  ▏ › ${verb} · surf tabs.list`]);
+  }
+});
+
+test("code and exploration calls retain every non-empty call line, not results", () => {
+  assert.deepEqual(painted(row("• Ran code\n  const tab = 1;\n\n  await inspect(tab);\n  └ browser")), [
+    "  ▏ › Ran code · const tab = 1; · await inspect(tab); · browser",
+  ]);
+  assert.deepEqual(painted(row("• Explored\n  ├ Read file.ts\n  └ Search keyword")), [
+    "  ▏ › Explored · Read file.ts · Search keyword",
+  ]);
+});
+
+test("matching headers do not fold different underlying invocations together", () => {
+  const a = row("• Ran\n  └ surf tabs.list"), b = row("• Ran\n  └ surf tabs.close");
+  const rows = [a, b];
+  trace.setTracelineChat({ children: [assistantBefore(rows as unknown as ToolRowLike[], [], true), ...rows] });
+  assert.deepEqual(painted(a), ["  ▏ › Ran · surf tabs.list"]);
+  assert.deepEqual(painted(b), ["  ▏ › Ran · surf tabs.close"]);
+});
+
+test("continuation styling survives removal of indentation and tree markers", () => {
+  const comp = row("• Ran\n\x1b[36m  └ surf tabs.list\x1b[39m");
+  const lines = comp.render(100);
+  assert.ok(lines.some((line) => line.includes("\x1b[36msurf tabs.list\x1b[39m")));
+  assert.deepEqual(painted(comp), ["  ▏ › Ran · surf tabs.list"]);
+});
+
+test("single-line calls keep their presentation and narrow summaries retain the tail", () => {
+  assert.deepEqual(painted(row("• Lookup customer")), ["  ▏ › Lookup customer"]);
+  const comp = row(`• Ran\n  └ ${"long-command ".repeat(15)}FINAL_ARGUMENT`);
+  for (let width = 1; width <= 100; width++) {
+    assert.ok(comp.render(width).every((line) => visibleWidth(line) <= width));
+  }
+  assert.match(painted(comp, 50)[0]!, /Ran.*….*FINAL_ARGUMENT$/);
+});
+
+test("clicking a flattened summary still opens native multiline call and result", () => {
+  const comp = row("• Ran\n  └ surf tabs.list");
+  const compact = comp.render(100);
+  const y = compact.findIndex((line) => trace.stripAnsi(line).includes("surf tabs.list"));
+  assert.ok(y >= 0);
+  assert.ok(comp.handleMouse({
+    type: "click", button: "left", x: 12, y, screenX: 12, screenY: y,
+    width: 100, height: compact.length, shift: false, alt: false, ctrl: false,
+  })?.handled);
+  const expanded = painted(comp);
+  assert.ok(expanded.some((line) => line.includes("└ surf tabs.list")));
+  assert.ok(expanded.some((line) => line.includes("SECRET_OUTPUT")));
+  comp.setExpanded(false);
+  assert.deepEqual(painted(comp), ["  ▏ › Ran · surf tabs.list"]);
+});

--- a/tests/traceline/one-line.test.ts
+++ b/tests/traceline/one-line.test.ts
@@ -733,13 +733,13 @@ test("hyperlinked read rows (OSC 8, ST-terminated): text survives stripAnsi, URL
   );
 });
 
-test("native invocation drops the expand hint and keeps only the first visible line", () => {
+test("native invocation drops per-line expand hints and retains continuation text", () => {
   const comp = toolComp({
     callRendererComponent: { render: () => ["read ~/projects/demo/file.ts:1-40 (ctrl+o to expand)", "  body line"] },
   });
   const visible = stripAnsi(oneLine(comp, 80));
   assert.ok(!visible.includes("to expand"), visible);
-  assert.ok(!visible.includes("body line"), visible);
+  assert.ok(visible.includes("file.ts:1-40 · body line"), visible);
 });
 
 test("tool-group spacing: blank before a group, tight within it, connectors skipped", () => {


### PR DESCRIPTION
## What changes

Generic native call summaries retain continuation lines instead of showing only a status header such as Ran. For example:

    • Ran
      └ surf tabs.list

becomes:

    › Ran · surf tabs.list

No tool-name adapters or argument-schema dependencies. Preserve ANSI styling, strip per-line expansion hints and layout indentation/tree branches, and retain existing middle truncation. Path reconstruction only applies to single-line calls so it cannot discard continuations. Expanded calls/results and native mouse handling remain unchanged.

## Verification

- Six new real-Pi component tests covering execution states, code/exploration layouts, repetition identity, colours, widths 1–100 and native click expansion. Updated the obsolete first-line-only test.
- Red/green regression checks.
- Lint and typecheck pass.
- Full suite: 361 pass, 0 fail (rebased on v0.11.0; the summariser now runs inside the scoped render cache memo).
- All real-Pi smoke suites pass, including tool/reasoning clicks, Drill, pager fidelity and startup/reload.
- Checked actual installed Codex-conversion command, exploration and code renderers; reviewed 100- and 50-column screenshots.

Rebased onto main after #113: `nativeInvocationLine` keeps its `renderCache.memo` wrapper with the multiline body inside; path emphasis moved with it. Real-Pi smoke suites pass on the rebased branch.