### PR TITLE
Enable no-shape-in-symbol-names; no-runtime-typeof for pure modules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -36,21 +36,28 @@
     "anti-slop/no-widen-then-assert": "error",
     "anti-slop/require-safety-comment-for-type-assertion": "error",
 
-    // `typeof` also narrows already-typed unions. Banning its syntax rewards wrapper
-    // functions, not validation. TypeScript still checks every runtime source file.
-    "anti-slop/no-runtime-typeof": "off",
-    // Unknown is honest at an input boundary. Apply this check to the reviewed pure
-    // modules below, not files that also parse config, provider data or Pi internals.
-    "anti-slop/no-unknown-parameters": "off"
+    // Unknown and typeof are honest at an input boundary. Apply these checks to the
+    // reviewed pure modules below, not files that also parse config, provider data or
+    // Pi internals.
+    "anti-slop/no-unknown-parameters": "off",
+    "anti-slop/no-runtime-typeof": "off"
   },
   "overrides": [
     {
       // These modules format typed values or calculate timing. Review this list when
       // extracting another pure module. This syntactic check is a backstop, not proof
       // that all incoming data has been validated (aliases and predicates need review).
-      "files": ["extensions/_lib/fmt.ts", "extensions/_lib/ansi.ts", "extensions/pi-meantime/timing.ts", "extensions/pi-meantime/render.ts"],
+      "files": [
+        "extensions/_lib/ansi.ts",
+        "extensions/_lib/fmt.ts",
+        "extensions/_lib/forecast.ts",
+        "extensions/_lib/heuristics.ts",
+        "extensions/pi-meantime/timing.ts",
+        "extensions/pi-meantime/render.ts"
+      ],
       "rules": {
-        "anti-slop/no-unknown-parameters": "error"
+        "anti-slop/no-unknown-parameters": "error",
+        "anti-slop/no-runtime-typeof": "error"
       }
     },
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -29,8 +29,7 @@
     "anti-slop/no-object-parameters": "error",
     "anti-slop/no-reflect-apply": "error",
     "anti-slop/no-reflect-get": "error",
-    // Shape is precise domain language for provider payload formats in this repo.
-    "anti-slop/no-shape-in-symbol-names": "off",
+    "anti-slop/no-shape-in-symbol-names": "error",
     "anti-slop/no-unknown-returns": "error",
     "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-unsafe-dictionary-type": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   UI; Meantime's opt-in specs and Cachemire's nested-session contract use it.
   Traceline's nested-session ownership is a real-terminal smoke (`test:smoke:nested`).
   The test-only `internals` exports may no longer grow (POG012).
+- Development: `no-shape-in-symbol-names` is on; tool payload builders are named for
+  their role (`ToolDefinition`, `toolPayload(tool, format)`). `no-runtime-typeof`
+  guards the reviewed pure modules, now including `_lib/forecast.ts` and
+  `_lib/heuristics.ts`; forecast messages carry a declared content type and config
+  denominators are validated once, at parse time.
 - Traceline keeps continuation lines from native tool-call renderers in compact
   summaries. A `Ran` header followed by a command now shows `Ran · command`,
   without tool-specific adapters. Expanded calls and results stay native.

--- a/docs/agent-coding-standard.md
+++ b/docs/agent-coding-standard.md
@@ -28,6 +28,9 @@ enabled rules reject low-evidence TypeScript. `npm run lint:slop` prints their f
 diagnostics; `npm run lint` adds them to the existing migration ledger.
 
 Ordinary type narrowing stays. Do not extract a helper merely to satisfy a syntax rule.
+The reviewed pure modules listed in `.oxlintrc.json` `overrides` are the exception:
+there, `unknown` parameters and `typeof` checks are rejected outright, because a value
+that still needs its representation probed has not been decoded at its boundary.
 A baseline entry is debt with an intended fix; correct code that a rule rejects gets a
 rule-level decision in `.oxlintrc.json` with its reason, or an inline
 `oxlint-disable-next-line` with a justification, not a baseline entry.

--- a/docs/pi-contextimate.md
+++ b/docs/pi-contextimate.md
@@ -145,7 +145,7 @@ Later files override scalar fields, `profiles` merge by name, and `rules` append
 
 `match` values take exact strings, `*`/`?` globs, or regex strings like `"/claude.*4-8/i"`. Built-in rules cannot be disabled, but a later matching custom rule shadows their values.
 
-`toolNumerator` picks the payload shape to count:
+`toolNumerator` picks the payload format to count:
 
 - `openai-cookbook`: the local formula above (the OpenAI-Codex default; the name is kept for config compatibility)
 - `openai-responses` / `openai-codex-responses`: Responses-style function objects
@@ -155,12 +155,12 @@ Later files override scalar fields, `profiles` merge by name, and `rules` append
 - `bedrock`: `{ toolSpec: ... }`
 - `raw-schema`: the unshaped schema, as a fallback
 
-Unknown names fall back to the Responses shape. Custom `toolShapes` templates and the legacy `prefix-inspector.json` config paths were removed in 0.4.0: a configurable approximation cannot beat measuring the real payload.
+Unknown names fall back to the Responses format. Custom `toolShapes` templates and the legacy `prefix-inspector.json` config paths were removed in 0.4.0: a configurable approximation cannot beat measuring the real payload.
 
 ## Recalibrating for a new provider or model
 
 1. Capture what Pi actually sends: `pi-contextimate-probe-prefix`.
 2. Get provider counts and suggested divisors from the captured payload: `pi-contextimate-check-provider-tokens`.
-3. Paste the suggested values into a `rules` entry, with the closest built-in `toolNumerator` shape.
+3. Paste the suggested values into a `rules` entry, with the closest built-in `toolNumerator` format.
 
 If the provider has no count endpoint, run controlled live probes instead: hold everything else constant, vary one section, and subtract a minimal baseline from the recorded usage. Record chars per token separately for prose and for tool schemas; they usually differ. [`scripts/contextimate/README.md`](../scripts/contextimate/README.md) documents the scripts, credentials and safety notes (captured payloads can contain sensitive prompt data; keep them local).

--- a/extensions/_lib/forecast.ts
+++ b/extensions/_lib/forecast.ts
@@ -15,8 +15,8 @@ export type TargetModel = ModelSummary & {
 };
 
 // Callers pass convertToLlm() output (pi-ai Message[]), typed structurally so _lib
-// carries no pi-ai type dependency.
-type ForecastBlock = {
+// carries no pi-ai type dependency; the cast at that seam is the boundary.
+export type ForecastBlock = {
   type: string;
   text?: string;
   thinking?: string;
@@ -30,7 +30,7 @@ type ForecastBlock = {
 
 export type ForecastMessage = {
   role: string;
-  content: unknown;
+  content: string | ForecastBlock[];
   provider?: string;
   api?: string;
   model?: string;
@@ -47,11 +47,6 @@ interface HistoryForecast {
 const NON_VISION_USER_PLACEHOLDER_CHARS = "(image omitted: model does not support images)".length;
 const NON_VISION_TOOL_PLACEHOLDER_CHARS = "(tool image omitted: model does not support images)".length;
 
-function blockList(content: unknown): ForecastBlock[] {
-  if (!Array.isArray(content)) return [];
-  return content.filter((block): block is ForecastBlock => typeof block === "object" && block !== null);
-}
-
 export function forecastHistoryForTarget(messages: readonly ForecastMessage[], target: TargetModel): HistoryForecast {
   const visionTarget = target.input?.includes("image") ?? true;
   const forecast: HistoryForecast = { textChars: 0, keptReasoningChars: 0, imageChars: 0 };
@@ -59,9 +54,9 @@ export function forecastHistoryForTarget(messages: readonly ForecastMessage[], t
     if (message.role === "assistant") {
       if (message.stopReason === "error" || message.stopReason === "aborted") continue;
       const isSame = message.provider === target.provider && message.api === target.api && message.model === target.id;
-      for (const block of blockList(message.content)) {
+      for (const block of Array.isArray(message.content) ? message.content : []) {
         if (block.type === "thinking") {
-          const signature = typeof block.thinkingSignature === "string" ? block.thinkingSignature : undefined;
+          const signature = block.thinkingSignature;
           const readable = block.thinking ?? "";
           if (block.redacted) {
             if (isSame && signature !== undefined) forecast.keptReasoningChars += signature.length;
@@ -77,16 +72,14 @@ export function forecastHistoryForTarget(messages: readonly ForecastMessage[], t
         }
         if (block.type === "toolCall") {
           forecast.textChars += JSON.stringify({ id: block.id, name: block.name, arguments: block.arguments }).length;
-          if (isSame && typeof block.thoughtSignature === "string") {
-            forecast.keptReasoningChars += block.thoughtSignature.length;
-          }
+          if (isSame && block.thoughtSignature !== undefined) forecast.keptReasoningChars += block.thoughtSignature.length;
           continue;
         }
         if (block.type === "text") forecast.textChars += (block.text ?? "").length;
       }
       continue;
     }
-    if (typeof message.content === "string") {
+    if (!Array.isArray(message.content)) {
       forecast.textChars += message.content.length;
       continue;
     }
@@ -94,7 +87,7 @@ export function forecastHistoryForTarget(messages: readonly ForecastMessage[], t
       ? NON_VISION_TOOL_PLACEHOLDER_CHARS
       : NON_VISION_USER_PLACEHOLDER_CHARS;
     let inImageRun = false;
-    for (const block of blockList(message.content)) {
+    for (const block of message.content) {
       if (block.type === "image") {
         if (visionTarget) forecast.imageChars += ESTIMATED_IMAGE_CHARS;
         else if (!inImageRun) forecast.imageChars += placeholderChars;

--- a/extensions/_lib/forecast.ts
+++ b/extensions/_lib/forecast.ts
@@ -4,7 +4,7 @@ import {
   fallbackHeuristicNumbers,
   type ModelSummary,
 } from "./heuristics.ts";
-import { estimateToolListTokens, type ToolShape } from "./tool-payloads.ts";
+import { estimateToolListTokens, type ToolDefinition } from "./tool-payloads.ts";
 
 // Pi's compaction estimator uses the same flat cost for every retained image.
 export const ESTIMATED_IMAGE_CHARS = 4800;
@@ -111,7 +111,7 @@ export function forecastHistoryForTarget(messages: readonly ForecastMessage[], t
 export function forecastTargetPrompt(args: {
   history: readonly ForecastMessage[];
   systemPromptChars: number;
-  tools: ToolShape[];
+  tools: ToolDefinition[];
   target: TargetModel;
 }) {
   const heuristic = builtInHeuristicForModel(args.target) ?? fallbackHeuristicNumbers();

--- a/extensions/_lib/heuristics.ts
+++ b/extensions/_lib/heuristics.ts
@@ -34,11 +34,7 @@ type TokenizerProfile = Omit<HeuristicNumbers, "toolDenominator" | "toolNumerato
 type ToolProfile = Pick<HeuristicNumbers, "toolDenominator" | "toolNumerator">;
 type BuiltInHeuristic = Partial<HeuristicNumbers> & Pick<HeuristicNumbers, "label">;
 
-export function cleanDenominator(value: unknown, fallback = 4): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
-}
-
-// Denominators are sanitized once, at heuristic resolution; by the time one reaches a
+// Denominators are validated once, when config is parsed; by the time one reaches a
 // count it is a trusted positive number.
 export function estimateCharsAsTokens(chars: number, denominator: number): number {
   return Math.ceil(chars / denominator);

--- a/extensions/_lib/tool-payloads.ts
+++ b/extensions/_lib/tool-payloads.ts
@@ -1,11 +1,11 @@
-// Provider-shaped tool payloads and token estimators shared by the family.
+// Provider tool payload formats and token estimators shared by the family.
 
 import { isJsonObject, type JsonValue } from "./boundary.ts";
 import { estimateCharsAsTokens, type HeuristicNumbers } from "./heuristics.ts";
 
 /** The slice of a tool definition the estimators need; contextimate's ToolSummary
  * satisfies it structurally. */
-export type ToolShape = {
+export type ToolDefinition = {
   name: string;
   description: string;
   schema: unknown;
@@ -68,9 +68,9 @@ export function safeMinifiedJson(value: unknown): string {
   }
 }
 
-// --- provider tool payload shapes ---------------------------------------------------------
+// --- provider tool payload formats ---------------------------------------------------------
 
-export function openAIResponsesToolPayload(tool: ToolShape): unknown {
+export function openAIResponsesToolPayload(tool: ToolDefinition): unknown {
   return {
     type: "function",
     name: tool.name,
@@ -80,8 +80,10 @@ export function openAIResponsesToolPayload(tool: ToolShape): unknown {
   };
 }
 
-export function toolPayloadForShape(tool: ToolShape & { promptGuidelines?: string[] }, shape: string): unknown {
-  switch (shape) {
+/** `format` is a `toolNumerator` name; `openai-cookbook` and unknown names take the
+ * OpenAI Responses payload. */
+export function toolPayload(tool: ToolDefinition & { promptGuidelines?: string[] }, format: string): unknown {
+  switch (format) {
     case "openai-chat":
     case "openai-completions":
     case "mistral":
@@ -122,8 +124,8 @@ export function toolPayloadForShape(tool: ToolShape & { promptGuidelines?: strin
   }
 }
 
-export function aggregateToolPayloadForShape(tools: Array<ToolShape & { promptGuidelines?: string[] }>, shape: string): unknown {
-  if (shape === "gemini" || shape === "google" || shape === "vertex") {
+export function aggregateToolPayload(tools: Array<ToolDefinition & { promptGuidelines?: string[] }>, format: string): unknown {
+  if (format === "gemini" || format === "google" || format === "vertex") {
     return {
       functionDeclarations: tools.map((tool) => ({
         name: tool.name,
@@ -132,11 +134,11 @@ export function aggregateToolPayloadForShape(tools: Array<ToolShape & { promptGu
       })),
     };
   }
-  return tools.map((tool) => toolPayloadForShape(tool, shape));
+  return tools.map((tool) => toolPayload(tool, format));
 }
 
-export function toolPayloadLabel(shape: string): string {
-  switch (shape) {
+export function toolPayloadLabel(format: string): string {
+  switch (format) {
     case "openai-responses":
     case "openai-codex-responses":
       return "OpenAI Responses tool payload";
@@ -157,7 +159,7 @@ export function toolPayloadLabel(shape: string): string {
     case "raw-schema":
       return "Raw tool schema payload";
     default:
-      return `Unknown tool shape ${shape}; OpenAI Responses fallback`;
+      return `Unknown tool payload format ${format}; OpenAI Responses fallback`;
   }
 }
 
@@ -167,7 +169,7 @@ function estimateOpenAIToolTextTokens(text: string): number {
   return estimateCharsAsTokens(text.length, OPENAI_TOOL_TEXT_FRAGMENT_DENOMINATOR);
 }
 
-export function estimateOpenAIToolDefinitionTokens(tool: ToolShape): number {
+export function estimateOpenAIToolDefinitionTokens(tool: ToolDefinition): number {
   let tokens = 7;
   tokens += estimateOpenAIToolTextTokens(`${tool.name}:${trimFinalPeriod(tool.description)}`);
   const propertyEntries = Object.entries(getSchemaProperties(tool.schema));
@@ -205,7 +207,7 @@ function estimateOpenAIPropertyTokens(propertyName: string, property: unknown): 
   return tokens;
 }
 
-export function estimateOpenAIFunctionToolTokens(tools: ToolShape[]): number {
+export function estimateOpenAIFunctionToolTokens(tools: ToolDefinition[]): number {
   // OpenAI's public token-counting docs say exact tool counts need the Responses
   // input-token endpoint. For no-API-call startup estimates, use the older
   // cookbook/tiktoken-style schema-summary formula: model-specific constants plus
@@ -221,13 +223,13 @@ export function estimateOpenAIFunctionToolTokens(tools: ToolShape[]): number {
 }
 
 /** Total estimated tokens for a tool list under a family heuristic: the cookbook
- * formula where it applies, the shaped-payload char ratio everywhere else. */
+ * formula where it applies, the payload char ratio everywhere else. */
 export function estimateToolListTokens(
-  tools: Array<ToolShape & { promptGuidelines?: string[] }>,
+  tools: Array<ToolDefinition & { promptGuidelines?: string[] }>,
   heuristic: Pick<HeuristicNumbers, "toolNumerator" | "toolDenominator">,
 ): number {
   if (tools.length === 0) return 0;
   if (heuristic.toolNumerator === "openai-cookbook") return estimateOpenAIFunctionToolTokens(tools);
-  const content = safeMinifiedJson(aggregateToolPayloadForShape(tools, heuristic.toolNumerator));
+  const content = safeMinifiedJson(aggregateToolPayload(tools, heuristic.toolNumerator));
   return estimateCharsAsTokens(content.length, heuristic.toolDenominator);
 }

--- a/extensions/pi-cachemire/forecast.ts
+++ b/extensions/pi-cachemire/forecast.ts
@@ -4,7 +4,7 @@
 import { buildSessionContext, convertToLlm } from "@earendil-works/pi-coding-agent";
 import type { ExtensionAPI, SessionEntry } from "@earendil-works/pi-coding-agent";
 import { forecastTargetPrompt, type ForecastMessage } from "../_lib/forecast.ts";
-import type { ToolShape } from "../_lib/tool-payloads.ts";
+import type { ToolDefinition } from "../_lib/tool-payloads.ts";
 import { findBranchBaseline, pathContainsCompaction } from "./lineage.ts";
 import type { CacheLineageSnapshot, CacheWindow } from "./types.ts";
 
@@ -15,7 +15,7 @@ export type SwitchTarget = {
   input?: readonly string[];
 };
 
-export function activeToolShapes(pi: Pick<ExtensionAPI, "getActiveTools" | "getAllTools">): ToolShape[] {
+export function activeToolDefinitions(pi: Pick<ExtensionAPI, "getActiveTools" | "getAllTools">): ToolDefinition[] {
   const active = new Set(pi.getActiveTools());
   return pi.getAllTools()
     .filter((tool) => active.has(tool.name))
@@ -38,7 +38,7 @@ export function computeSwitchForecast(args: {
   entries: SessionEntry[];
   activeLeafId: string | null;
   systemPromptChars: number;
-  tools: ToolShape[];
+  tools: ToolDefinition[];
   snapshots: readonly CacheLineageSnapshot[];
 }): SwitchForecast {
   const forecast: SwitchForecast = {

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -22,7 +22,7 @@ import {
   pastWindow,
 } from "./classify.ts";
 import { UNKNOWN_WINDOW, cacheClock, nextClockUpdateMs, withinWarmHorizon } from "./clock.ts";
-import { activeToolShapes, computeSwitchForecast, type SwitchForecast, type SwitchTarget } from "./forecast.ts";
+import { activeToolDefinitions, computeSwitchForecast, type SwitchForecast, type SwitchTarget } from "./forecast.ts";
 import { restoreBranchRecords } from "./ledger.ts";
 import {
   cacheStateForLineage,
@@ -462,7 +462,7 @@ function refreshSwitchForecast(
     entries: ctx.sessionManager.getEntries(),
     activeLeafId,
     systemPromptChars: ctx.getSystemPrompt().length,
-    tools: activeToolShapes(pi),
+    tools: activeToolDefinitions(pi),
     snapshots: s.lineages,
   });
 }

--- a/extensions/pi-contextimate/index.ts
+++ b/extensions/pi-contextimate/index.ts
@@ -16,7 +16,7 @@ import {
   type ModelSummary,
 } from "../_lib/heuristics.ts";
 import {
-  aggregateToolPayloadForShape,
+  aggregateToolPayload,
   arrayItemsSchema,
   estimateOpenAIFunctionToolTokens,
   estimateOpenAIToolDefinitionTokens,
@@ -28,7 +28,7 @@ import {
   schemaArrayItemProperties,
   schemaPropertyDescription,
   schemaPropertyType,
-  toolPayloadForShape,
+  toolPayload,
   toolPayloadLabel,
 } from "../_lib/tool-payloads.ts";
 import { ELLIPSIS, GLYPH, SEP, ink, panelHeader } from "../_lib/style.ts";
@@ -133,7 +133,7 @@ type ToolNumeratorResult = {
   label: string;
   content: string;
   chars: number;
-  /** Present only for the openai-cookbook formula; ratio shapes divide chars instead. */
+  /** Present only for the openai-cookbook formula; ratio numerators divide chars instead. */
   tokens?: number;
 };
 
@@ -220,7 +220,7 @@ function formatPercent(value: number | null): string | undefined {
 
 // Denominators are sanitized once, at heuristic resolution (applyHeuristicPatch); by
 // the time one reaches a count it is a trusted positive number. The shared estimator
-// slice (denominators, payload shapes, the OpenAI tool formula) lives in
+// slice (denominators, payload formats, the OpenAI tool formula) lives in
 // _lib/heuristics.ts so cachemire's model-switch forecast uses the same numbers.
 
 function formatDenominator(value: number): string {
@@ -593,8 +593,8 @@ function resolveHeuristic(model: ModelSummary | undefined, config: ContextimateC
 }
 
 function buildToolNumerator(tools: ToolSummary[], heuristic: ResolvedHeuristic): ToolNumeratorResult {
-  const shape = heuristic.toolNumerator;
-  if (shape === "openai-cookbook") {
+  const numerator = heuristic.toolNumerator;
+  if (numerator === "openai-cookbook") {
     const content = safeMinifiedJson(tools.map(openAIResponsesToolPayload));
     return {
       label: "OpenAI-style local formula",
@@ -603,9 +603,9 @@ function buildToolNumerator(tools: ToolSummary[], heuristic: ResolvedHeuristic):
       tokens: estimateOpenAIFunctionToolTokens(tools),
     };
   }
-  const content = safeMinifiedJson(aggregateToolPayloadForShape(tools, shape));
+  const content = safeMinifiedJson(aggregateToolPayload(tools, numerator));
   return {
-    label: toolPayloadLabel(shape),
+    label: toolPayloadLabel(numerator),
     content,
     chars: content.length,
   };
@@ -646,9 +646,9 @@ function buildToolFields(schema: unknown): ToolField[] {
 }
 
 function buildToolDisplayEstimate(tool: ToolSummary, heuristic: ResolvedHeuristic): ToolDisplayEstimate {
-  const shape = heuristic.toolNumerator;
-  const chars = safeMinifiedJson(toolPayloadForShape(tool, shape)).length;
-  if (shape === "openai-cookbook") {
+  const numerator = heuristic.toolNumerator;
+  const chars = safeMinifiedJson(toolPayload(tool, numerator)).length;
+  if (numerator === "openai-cookbook") {
     return { tokens: estimateOpenAIToolDefinitionTokens(tool), chars };
   }
   return { tokens: estimateCharsAsTokens(chars, heuristic.toolDenominator), chars };
@@ -1431,9 +1431,7 @@ export const internals = {
   parseContextimateConfig,
   cleanDenominator,
   resolveHeuristic,
-  // provider payload shaping
-  toolPayloadForShape,
-  aggregateToolPayloadForShape,
+  // provider payload formats
   buildToolNumerator,
   buildToolDisplayEstimate,
   // OpenAI cookbook-style formula

--- a/extensions/pi-contextimate/index.ts
+++ b/extensions/pi-contextimate/index.ts
@@ -10,7 +10,6 @@ import { configPaths, expandHomePath, readJsonConfig } from "../_lib/config.ts";
 import { compactCount } from "../_lib/fmt.ts";
 import {
   builtInHeuristicPatchForModel,
-  cleanDenominator,
   estimateCharsAsTokens,
   fallbackHeuristicNumbers,
   type ModelSummary,
@@ -551,22 +550,13 @@ function defaultHeuristic(): ResolvedHeuristic {
 }
 
 function applyHeuristicPatch(base: ResolvedHeuristic, patch: HeuristicProfile | Partial<ResolvedHeuristic>, source: string): ResolvedHeuristic {
-  const next = {
-    label: patch.label,
-    textDenominator: patch.textDenominator,
-    sessionDenominator: patch.sessionDenominator,
-    toolDenominator: patch.toolDenominator,
-    toolNumerator: patch.toolNumerator,
-  };
   return {
-    ...base,
-    ...next,
-    label: next.label ?? base.label,
+    label: patch.label ?? base.label,
     source,
-    textDenominator: cleanDenominator(next.textDenominator, base.textDenominator),
-    sessionDenominator: cleanDenominator(next.sessionDenominator, base.sessionDenominator),
-    toolDenominator: cleanDenominator(next.toolDenominator, base.toolDenominator),
-    toolNumerator: next.toolNumerator ?? base.toolNumerator,
+    textDenominator: patch.textDenominator ?? base.textDenominator,
+    sessionDenominator: patch.sessionDenominator ?? base.sessionDenominator,
+    toolDenominator: patch.toolDenominator ?? base.toolDenominator,
+    toolNumerator: patch.toolNumerator ?? base.toolNumerator,
   };
 }
 
@@ -1429,7 +1419,6 @@ export const internals = {
   buildSkillsSection,
   // heuristic resolution
   parseContextimateConfig,
-  cleanDenominator,
   resolveHeuristic,
   // provider payload formats
   buildToolNumerator,

--- a/extensions/pi-traceline/cache-hooks.ts
+++ b/extensions/pi-traceline/cache-hooks.ts
@@ -36,15 +36,15 @@ export function installAssistantCacheHook(
 ): void {
   const original = (proto.__tracelineOriginalAssistantRender ?? proto.render)!;
   proto.__tracelineOriginalAssistantRender = original;
-  const shapes = new WeakMap<AssistantRowDataLike, string>();
+  const fingerprints = new WeakMap<AssistantRowDataLike, string>();
   const changed = (row: AssistantRowDataLike) => {
     const content = row.lastMessage?.content;
     const ids = Array.isArray(content) ? content.filter((block) => block?.type === "toolCall").map((block) => block.id) : [];
-    const shape = JSON.stringify([row.hideThinkingBlock, isEmptyConnector(row), isCollapsedThinkingRow(row), ids]);
-    if (shapes.get(row) !== shape) { shapes.set(row, shape); dirty(row); }
+    const fingerprint = JSON.stringify([row.hideThinkingBlock, isEmptyConnector(row), isCollapsedThinkingRow(row), ids]);
+    if (fingerprints.get(row) !== fingerprint) { fingerprints.set(row, fingerprint); dirty(row); }
   };
   proto.render = function (this: AssistantRowDataLike, width: number) {
-    if (!shapes.has(this)) changed(this);
+    if (!fingerprints.has(this)) changed(this);
     beforeRender(this); return original.call(this, width);
   };
   const update = proto.__tracelineOriginalUpdateContent ?? proto.updateContent;

--- a/scripts/cachemire/model-switch-forecast-probe.ts
+++ b/scripts/cachemire/model-switch-forecast-probe.ts
@@ -21,7 +21,7 @@ import {
   type ForecastMessage,
   type TargetModel,
 } from "../../extensions/_lib/forecast.ts";
-import { activeToolShapes } from "../../extensions/pi-cachemire/forecast.ts";
+import { activeToolDefinitions } from "../../extensions/pi-cachemire/forecast.ts";
 
 const outputPath = process.env.PI_CACHEMIRE_FORECAST_CAPTURE ?? "/tmp/pi-cachemire-model-switch-forecast.jsonl";
 const runId = randomUUID();
@@ -73,7 +73,7 @@ function canonicalCounts(
     const history = convertToLlm(
       buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId()).messages,
     ) as unknown as ForecastMessage[];
-    const tools = activeToolShapes(pi);
+    const tools = activeToolDefinitions(pi);
     const systemPromptChars = ctx.getSystemPrompt().length;
     const historyCounts = forecastHistoryForTarget(history, target);
     const system = forecastTargetPrompt({ history: [], systemPromptChars, tools: [], target });

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -327,7 +327,7 @@
     "defaultTsMax": 350,
     "files": {
       "extensions/pi-cachemire/index.ts": 852,
-      "extensions/pi-contextimate/index.ts": 1566,
+      "extensions/pi-contextimate/index.ts": 1555,
       "extensions/pi-traceline/index.ts": 1677,
       "tests/contract/pi-internals.test.ts": 355,
       "tests/traceline/one-line.test.ts": 772
@@ -335,7 +335,7 @@
   },
   "internalsBudgets": {
     "extensions/pi-cachemire/index.ts": 34,
-    "extensions/pi-contextimate/index.ts": 31,
+    "extensions/pi-contextimate/index.ts": 30,
     "extensions/pi-traceline/index.ts": 55
   }
 }

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -140,10 +140,10 @@
         "const original = (chat[originalKey] as (() => unknown) | undefined) ?? chat.clear.bind(chat);": 1
       },
       "extensions/_lib/tool-payloads.ts": {
-        "export function aggregateToolPayloadForShape(tools: Array<ToolShape & { promptGuidelines?: string[] }>, shape: string): unknown {": 1,
+        "export function aggregateToolPayload(tools: Array<ToolDefinition & { promptGuidelines?: string[] }>, format: string): unknown {": 1,
         "export function arrayItemsSchema(property: unknown): unknown {": 1,
-        "export function openAIResponsesToolPayload(tool: ToolShape): unknown {": 1,
-        "export function toolPayloadForShape(tool: ToolShape & { promptGuidelines?: string[] }, shape: string): unknown {": 1
+        "export function openAIResponsesToolPayload(tool: ToolDefinition): unknown {": 1,
+        "export function toolPayload(tool: ToolDefinition & { promptGuidelines?: string[] }, format: string): unknown {": 1
       },
       "extensions/pi-cachemire/classify.ts": {
         "function stripCacheMarkers(value: unknown): unknown {": 1
@@ -327,7 +327,7 @@
     "defaultTsMax": 350,
     "files": {
       "extensions/pi-cachemire/index.ts": 852,
-      "extensions/pi-contextimate/index.ts": 1568,
+      "extensions/pi-contextimate/index.ts": 1566,
       "extensions/pi-traceline/index.ts": 1677,
       "tests/contract/pi-internals.test.ts": 355,
       "tests/traceline/one-line.test.ts": 772
@@ -335,7 +335,7 @@
   },
   "internalsBudgets": {
     "extensions/pi-cachemire/index.ts": 34,
-    "extensions/pi-contextimate/index.ts": 33,
+    "extensions/pi-contextimate/index.ts": 31,
     "extensions/pi-traceline/index.ts": 55
   }
 }

--- a/tests/agent-lint.test.ts
+++ b/tests/agent-lint.test.ts
@@ -171,20 +171,25 @@ test("line budgets for existing files ratchet down while new oversized files are
   assert.equal(readFileSync(baselinePath, "utf8"), before);
 });
 
-test("the repo policy allows typed union narrowing and boundary parsing but rejects untyped core input", () => {
+test("the repo policy allows boundary parsing but rejects untyped or typeof-probed core input", () => {
   const dir = oxlintFixtureRepo();
   writeFileSync(join(dir, ".oxlintrc.json"), readFileSync(new URL(".oxlintrc.json", repoRoot), "utf8"));
   const coreDir = join(dir, "extensions", "pi-meantime");
   mkdirSync(coreDir, { recursive: true });
   const core = join(coreDir, "render.ts");
   const boundary = join(coreDir, "config.ts");
-  writeFileSync(core, 'export function label(value: string | number): string { return typeof value === "string" ? value : String(value); }\n');
+  writeFileSync(core, 'export function label(value: string | number): string { return String(value); }\n');
   writeFileSync(boundary, 'export function parseLabel(value: unknown): string { return typeof value === "string" ? value : ""; }\n');
   const allowed = runLint(dir);
   assert.equal(allowed.status, 0, allowed.stderr);
 
-  writeFileSync(core, 'export function label(value: unknown): string { return typeof value === "string" ? value : ""; }\n');
-  const rejected = runLint(dir);
-  assert.notEqual(rejected.status, 0);
-  assert.match(rejected.stderr, /render.ts:1 anti-slop\(no-unknown-parameters\)/);
+  writeFileSync(core, 'export function label(value: string | number): string { return typeof value === "string" ? value : String(value); }\n');
+  const probed = runLint(dir);
+  assert.notEqual(probed.status, 0);
+  assert.match(probed.stderr, /render.ts:1 anti-slop\(no-runtime-typeof\)/);
+
+  writeFileSync(core, 'export function label(value: unknown): string { return value === undefined ? "" : String(value); }\n');
+  const untyped = runLint(dir);
+  assert.notEqual(untyped.status, 0);
+  assert.match(untyped.stderr, /render.ts:1 anti-slop\(no-unknown-parameters\)/);
 });

--- a/tests/contextimate/heuristics.test.ts
+++ b/tests/contextimate/heuristics.test.ts
@@ -12,7 +12,7 @@ import type { ContextimateConfig, ModelSummary } from "../../extensions/pi-conte
 import { anthropicModel, codexModel } from "../helpers.ts";
 import { tokenizerFamilies } from "./heuristic-family-fixtures.ts";
 
-const { parseContextimateConfig, resolveHeuristic, cleanDenominator } = internals;
+const { parseContextimateConfig, resolveHeuristic } = internals;
 
 function model(provider: string, id: string, api: string): ModelSummary {
   return { provider, id, api };
@@ -241,15 +241,6 @@ test("unknown provider keeps a defined label (regression: renderHeader crash)", 
     rules: [{ match: { provider: "anthropic" }, profile: "quiet" }],
   });
   assert.equal(profiled.label, "Claude 4.7+ heuristic", "label survives a label-less profile patch");
-});
-
-test("cleanDenominator rejects non-finite/non-positive values", () => {
-  assert.equal(cleanDenominator(0), 4);
-  assert.equal(cleanDenominator(-2), 4);
-  assert.equal(cleanDenominator(Number.NaN), 4);
-  assert.equal(cleanDenominator("3"), 4);
-  assert.equal(cleanDenominator(undefined, 2.6), 2.6);
-  assert.equal(cleanDenominator(3.3, 2.6), 3.3);
 });
 
 test("runtime config parsing drops invalid denominators before heuristic resolution", () => {

--- a/tests/contextimate/provider-check.test.ts
+++ b/tests/contextimate/provider-check.test.ts
@@ -22,15 +22,16 @@ import {
   vertexCountRequest,
 } from "../../scripts/contextimate/provider-token-counts.ts";
 import { isJsonObject, type JsonObject } from "../../extensions/_lib/boundary.ts";
+import { toolPayload } from "../../extensions/_lib/tool-payloads.ts";
 import { internals } from "../../extensions/pi-contextimate/index.ts";
 import { anthropicModel, fakePi, fixtureSystemPrompt } from "../helpers.ts";
 
-const { buildSnapshot, toolPayloadForShape } = internals;
+const { buildSnapshot } = internals;
 
 function capturedAnthropicPayload() {
   const snapshot = buildSnapshot(fakePi(), () => fixtureSystemPrompt(), undefined, () => undefined, () => anthropicModel, {});
   const tools = snapshot.tools.slice(0, 3).map((tool) => {
-    const payload = toolPayloadForShape(tool, "anthropic");
+    const payload = toolPayload(tool, "anthropic");
     assert.ok(isJsonObject(payload));
     return payload as JsonObject;
   });
@@ -50,7 +51,7 @@ function rowsById<T extends { id: string }>(rows: T[]): Record<string, T> {
   return Object.fromEntries(rows.map((row) => [row.id, row]));
 }
 
-test("captured Pi payloads resolve to their wire shape", () => {
+test("captured Pi payloads resolve to their wire format", () => {
   assert.equal(detectPayloadKind(capturedAnthropicPayload()), "anthropic");
   assert.equal(detectPayloadKind({ model: "gpt-5.6", input: [{ role: "developer", content: "system" }] }), "openai-responses");
   assert.equal(detectPayloadKind({ model: "glm-4.7", messages: [], stream: true }), "openai-chat");

--- a/tests/contextimate/tool-payloads.test.ts
+++ b/tests/contextimate/tool-payloads.test.ts
@@ -1,15 +1,14 @@
-// Provider payload shaping + the OpenAI cookbook-style formula. The displayed token
-// number is only as honest as these shapes; the formula constants are pinned against
+// Provider payload formats + the OpenAI cookbook-style formula. The displayed token
+// number is only as honest as these payloads; the formula constants are pinned against
 // hand-computed expectations so "harmless" refactors cannot drift them.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
+import { aggregateToolPayload, toolPayload } from "../../extensions/_lib/tool-payloads.ts";
 import { internals } from "../../extensions/pi-contextimate/index.ts";
 import type { ToolSummary } from "../../extensions/pi-contextimate/index.ts";
 
 const {
-  toolPayloadForShape,
-  aggregateToolPayloadForShape,
   buildToolNumerator,
   buildToolDisplayEstimate,
   estimateOpenAIToolDefinitionTokens,
@@ -40,33 +39,33 @@ const mode: ToolSummary = {
   promptGuidelines: [],
 };
 
-test("per-provider payload shapes are exact", () => {
-  assert.deepEqual(toolPayloadForShape(ping, "anthropic"), {
+test("per-provider payload formats are exact", () => {
+  assert.deepEqual(toolPayload(ping, "anthropic"), {
     name: "ping",
     description: "Send a ping.",
     input_schema: ping.schema,
   });
-  assert.deepEqual(toolPayloadForShape(ping, "openai-responses"), {
+  assert.deepEqual(toolPayload(ping, "openai-responses"), {
     type: "function",
     name: "ping",
     description: "Send a ping.",
     parameters: ping.schema,
     strict: null,
   });
-  assert.deepEqual(toolPayloadForShape(ping, "openai-chat"), {
+  assert.deepEqual(toolPayload(ping, "openai-chat"), {
     type: "function",
     function: { name: "ping", description: "Send a ping.", parameters: ping.schema, strict: null },
   });
-  assert.deepEqual(toolPayloadForShape(ping, "bedrock"), {
+  assert.deepEqual(toolPayload(ping, "bedrock"), {
     toolSpec: { name: "ping", description: "Send a ping.", inputSchema: { json: ping.schema } },
   });
-  assert.deepEqual(toolPayloadForShape(ping, "pi-messages"), {
+  assert.deepEqual(toolPayload(ping, "pi-messages"), {
     name: "ping",
     description: "Send a ping.",
     parameters: ping.schema,
   });
   // Gemini aggregates into one functionDeclarations wrapper.
-  assert.deepEqual(aggregateToolPayloadForShape([ping, mode], "gemini"), {
+  assert.deepEqual(aggregateToolPayload([ping, mode], "gemini"), {
     functionDeclarations: [
       { name: "ping", description: "Send a ping.", parametersJsonSchema: ping.schema },
       { name: "mode", description: "Pick a mode", parametersJsonSchema: mode.schema },
@@ -74,8 +73,8 @@ test("per-provider payload shapes are exact", () => {
   });
 });
 
-test("unknown shapes fall back to the OpenAI Responses payload", () => {
-  assert.deepEqual(toolPayloadForShape(ping, "some-future-shape"), toolPayloadForShape(ping, "openai-responses"));
+test("unknown formats fall back to the OpenAI Responses payload", () => {
+  assert.deepEqual(toolPayload(ping, "some-future-format"), toolPayload(ping, "openai-responses"));
 });
 
 test("OpenAI cookbook formula matches hand-computed expectations", () => {
@@ -91,19 +90,19 @@ test("OpenAI cookbook formula matches hand-computed expectations", () => {
 });
 
 test("displayed per-tool estimates count the same payload the section total counts", () => {
-  // Anthropic shape: the aggregate content must be exactly the JSON array of the
+  // Anthropic format: the aggregate content must be exactly the JSON array of the
   // per-tool payloads that buildToolDisplayEstimate measures.
   const heuristic = resolveHeuristic({ provider: "anthropic", id: "claude-opus-4-8", api: "anthropic-messages" }, {});
   const numerator = buildToolNumerator([ping, mode], heuristic);
-  const perTool = [ping, mode].map((tool) => JSON.stringify(toolPayloadForShape(tool, "anthropic")));
+  const perTool = [ping, mode].map((tool) => JSON.stringify(toolPayload(tool, "anthropic")));
   assert.equal(numerator.content, `[${perTool.join(",")}]`);
   for (const tool of [ping, mode]) {
     const estimate = buildToolDisplayEstimate(tool, heuristic);
-    assert.equal(estimate.chars, JSON.stringify(toolPayloadForShape(tool, "anthropic")).length);
+    assert.equal(estimate.chars, JSON.stringify(toolPayload(tool, "anthropic")).length);
     assert.equal(estimate.tokens, Math.ceil(estimate.chars / heuristic.toolDenominator));
   }
 
-  // Cookbook shape: per-tool display uses the per-tool formula; the section total is the
+  // Cookbook formula: per-tool display uses the per-tool formula; the section total is the
   // sum of per-tool formulas + the once-per-request constant.
   const codexHeuristic = resolveHeuristic({ provider: "openai-codex", id: "gpt-5.5", api: "openai-codex-responses" }, {});
   const codexNumerator = buildToolNumerator([ping, mode], codexHeuristic);

--- a/tests/lib/forecast.test.ts
+++ b/tests/lib/forecast.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import {
   forecastHistoryForTarget,
   forecastTargetPrompt,
+  type ForecastBlock,
   type ForecastMessage,
   type TargetModel,
 } from "../../extensions/_lib/forecast.ts";
@@ -25,7 +26,7 @@ const opus: TargetModel = {
   input: ["text", "image"],
 };
 
-function solTurn(content: unknown[], overrides: Partial<ForecastMessage> = {}): ForecastMessage {
+function solTurn(content: ForecastBlock[], overrides: Partial<ForecastMessage> = {}): ForecastMessage {
   return {
     role: "assistant",
     content,
@@ -93,7 +94,7 @@ test("aborted and error assistant turns contribute nothing", () => {
 
 test("images: pi's flat char convention for vision targets, placeholder for non-vision", () => {
   const history: ForecastMessage[] = [
-    { role: "user", content: [{ type: "image", data: "aGk=", mimeType: "image/png" }] },
+    { role: "user", content: [{ type: "image" }] },
   ];
   const vision = forecastHistoryForTarget(history, luna);
   assert.equal(vision.imageChars, 4800, "matches pi's compaction image estimate");


### PR DESCRIPTION
## Summary

Follow-ups from the #115 review of the three disabled anti-slop rules.

### `no-shape-in-symbol-names`: on

The "domain language" justification did not hold: every `shape` symbol had a better role name.

- `ToolShape` → `ToolDefinition` (the name/description/schema slice of a tool)
- `toolPayloadForShape(tool, shape)` → `toolPayload(tool, format)`; `aggregateToolPayloadForShape` → `aggregateToolPayload`; `format` is a `toolNumerator` name, documented on the function
- `activeToolShapes` → `activeToolDefinitions`
- Traceline's render-input `WeakMap` holds `fingerprints`, not `shapes`
- The user-facing `toolNumerator` config values are unchanged; `docs/pi-contextimate.md` says "payload format"

Tests import the two payload builders from `_lib/tool-payloads.ts` directly, so contextimate's `internals` shrinks by two.

### `no-runtime-typeof`: on for the reviewed pure modules

Still off globally (boundary files legitimately probe Pi seams, config, provider payloads). It joins `no-unknown-parameters` in the `overrides` block, and `_lib/forecast.ts` and `_lib/heuristics.ts` join that list after two real findings:

- `forecast.ts` re-checked `typeof block.thinkingSignature === "string"` on a field its own type declared as `string | undefined`. `ForecastMessage.content` is now `string | ForecastBlock[]`, the type the Pi-seam cast (`convertToLlm(...) as unknown as ForecastMessage[]`) already asserted; `blockList` and the re-checks go.
- `cleanDenominator` re-validated numbers `parseHeuristicProfile` had already validated with `positiveNumberValue`; built-in patches are code literals. `applyHeuristicPatch` now just falls back with `??`, and the helper plus its helper-test are gone. The behaviour spec (`runtime config parsing drops invalid denominators before heuristic resolution`) stays.

Policy spec in `tests/agent-lint.test.ts` now pins: boundary `typeof` allowed; core `typeof` rejected (`no-runtime-typeof`); core `unknown` rejected (`no-unknown-parameters`). `docs/agent-coding-standard.md` states the pure-module exception.

### `no-array-filter-map`: stays off

Two sites, both on tens-of-items render arrays; the accumulator rules already cover the expensive patterns.

## Verification

Revision: `2df5633`

- `npm run check`: lint (0 new findings, 175 baseline, budgets ratcheted down: contextimate lines 1568 → 1564, internals 33 → 30), typecheck, **365 tests** (one helper test removed).
- `npm run test:smoke`: all seven real-Pi smokes pass (click, reasoning click, thinking resume, drill, pager, nested session, startup).
- Mutations: a `shape` symbol and a `typeof` in `_lib/forecast.ts` each fail lint.

No behaviour change intended; the startup smoke exercises contextimate's heuristic resolution and rendering in real Pi. Not merged.
