### PR TITLE
Fix Cachemire thinking-change cache classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   `<skills_instructions>` list that `pi-codex-conversion` injects per turn is now
   parsed into the usual `Skill frontmatter` row. Pinned by a contract test against
   the installed adapter.
+- Cachemire no longer marks direct Anthropic Claude Fable 5.1 cache state stale when
+  its thinking effort changes. Live Pi 0.85.1 calls retained the full prior prefix, and
+  Pi's built-in model record declares its mid-conversation effort protocol. GPT-6 Astra
+  remains a real mutation in Pi 0.85.1 because Pi changes request-level effort instead
+  of appending OpenAI's cache-safe `configuration_update` item.
 - Development: the repo now lints with Oxlint and a vendored copy of
   [anti-slop](https://github.com/dmmulroy/anti-slop) (`tools/oxlint/anti-slop`,
   `.oxlintrc.json`), fed into the existing agent-lint baseline as shrink-only debt.

--- a/docs/cache-thinking-change-audit-2026-09-10.md
+++ b/docs/cache-thinking-change-audit-2026-09-10.md
@@ -1,0 +1,106 @@
+# Thinking-change cache audit, 2026-09-10
+
+This audit separates model capability from the wire protocol Pi 0.85.1 actually sends.
+It covers direct Anthropic Claude Fable 5.1 and the configured OpenAI Codex route for
+GPT-6 Astra.
+
+## Verdict
+
+| route | cache-safe effort change in Pi 0.85.1 | evidence | Cachemire policy |
+|---|---|---|---|
+| `anthropic/claude-fable-5-1` | yes | live high-to-low call read the full 13,303-token prior prefix | do not mark thinking stale or name it as a break cause |
+| `openai-codex/gpt-6-astra` | no | live low-to-high call read 0 cached tokens while its low-to-low control read 5,888 | keep the changed request-level effort as a cache mutation |
+
+These findings are route-specific. They do not establish the same behaviour for a
+gateway that happens to expose either model name.
+
+## Pi and provider contracts
+
+Pi's installed Anthropic model catalogue marks Claude Fable 5.1 with
+`supportsMidConvoEffort: true`. Its Anthropic request builder keeps the top-level
+effort fixed, appends per-turn system effort markers and requests
+`thinking.block_binding.prefix_mismatch_behavior: "drop_block"`. Assistant messages
+retain their provider thinking level so the next request can reproduce prior turns.
+This matches Anthropic's Fable 5.1-specific beta: a mid-conversation system message can
+carry per-message `output_config.effort` without changing the cached prefix. Anthropic's
+general rule still says changing request-level effort invalidates cache breakpoints.
+
+The local `models.json` currently overrides the catalogue entry without that
+compatibility flag. In that effective configuration Pi changes top-level
+`output_config.effort` directly. The live high-to-low test still read the complete
+15,103-token message-heavy prior prefix in a follow-up probe, so Cachemire treats the
+exact direct Fable 5.1 route as cache-safe in this runtime as well as honouring Pi's
+general compatibility flag. This observation does not extend to other models that use
+request-level effort.
+
+OpenAI's reasoning guide requires a different protocol for GPT-6 Astra: keep the
+request-level `reasoning.effort` fixed and append this item before the next user
+message:
+
+```json
+{
+  "type": "configuration_update",
+  "reasoning": { "effort": "high" }
+}
+```
+
+Pi 0.85.1's OpenAI Responses and OpenAI Codex Responses request builders do not emit
+that item. They set the current effort on the request-level reasoning field instead.
+Cachemire needs no Astra model exception: the current payload difference remains a real
+cache-key mutation, while a future append-only implementation will naturally retain
+the old fingerprint as a prefix.
+
+## Live checks
+
+The probes used Pi's `ModelRuntime`, real provider authentication and a stable prefix
+long enough to be cached.
+
+### Claude Fable 5.1
+
+The effective local high-to-low run included a genuine signed thinking block on the
+first response:
+
+- first call: 13,303 cache-write tokens, 0 cache-read tokens
+- second call: 13,303 cache-read tokens, 585 cache-write tokens
+- first response: 173 reasoning tokens
+
+A second high-to-low probe moved the long stable prefix into the first user message and
+kept the system prompt short. Its first call wrote 15,103 tokens; the follow-up read all
+15,103 and wrote a 642-token suffix. This rules out a hit confined to stable system
+instructions while message history was reprocessed.
+
+Repeating with the built-in mid-conversation compatibility contract produced the same
+full-prefix hit. Captured requests kept top-level effort at `high`, carried a historical
+`high` system effort marker, then appended a `low` marker for the new turn.
+
+A separate end-to-end Pi TUI run loaded the worktree extension and the effective local
+model override. The model used the real Bash tool at `low`, switched to `high` through
+Pi's thinking picker, then used Bash again. Cachemire showed no stale or break line. The
+first 2-call turn line reported 2.5k read and 2.6k written; the 2-call turn after the
+switch reported 5.2k read and 0.2k written. An independent file check confirmed both
+tool mutations. This low-to-high result complements the high-to-low provider probe.
+
+### GPT-6 Astra
+
+Two fresh-session runs used the same stable prefix:
+
+- low-to-low control: second call read 5,888 cached tokens and sent 169 uncached input
+  tokens
+- low-to-high change: second call read 0 cached tokens and sent 6,057 uncached input
+  tokens
+
+Captured Pi payloads changed request-level reasoning effort and contained no
+`configuration_update` item.
+
+## Sources
+
+- OpenAI, [Reasoning models](https://developers.openai.com/api/docs/guides/reasoning),
+  section "Change reasoning mid-conversation", accessed 2026-09-10
+- OpenAI, [Prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching),
+  section "Keep changing content after the breakpoint", accessed 2026-09-10
+- Anthropic, [Effort](https://platform.claude.com/docs/en/build-with-claude/effort#change-effort-mid-conversation-beta),
+  section "Change effort mid-conversation", accessed 2026-09-10
+- Anthropic,
+  [Mid-conversation system messages and tool changes](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages),
+  accessed 2026-09-10
+- installed `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` 0.85.1

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -235,7 +235,14 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   usage
 - status one-liners are lowercase; Title Case only for panel headers and row labels
 - state causes from observed evidence (payload diffs, usage), never inference,
-  and say `unknown` when unknown
+  and say `unknown` when unknown. A thinking-effort change is a cause only when
+  the active model and wire protocol make it cache-key material. Direct Anthropic
+  Claude Fable 5.1 and models declaring Pi's mid-conversation effort capability
+  keep the prior prefix warm, so the keystroke alone must not produce a stale clock
+  or break notice. Enabling or disabling thinking remains a distinct mutation.
+  GPT-6 Astra is neutral only when the request appends an OpenAI `configuration_update`
+  while leaving request-level effort unchanged; a changed request-level effort remains
+  a cache mutation
 
 ## 8. Panels
 

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -17,7 +17,9 @@ The wider provider inventory and implementation record are in
 The [`GPT-6 Astra audit`](./cache-astra-audit-2026-09-08.md) records the newer model's
 official contract, sanitized Codex observations and unresolved route limits. Cachemire
 keeps an observed request policy pending until reported cache reads or writes confirm
-that an entry exists.
+that an entry exists. The
+[`thinking-change audit`](./cache-thinking-change-audit-2026-09-10.md) records how
+Pi 0.85.1 handles Claude Fable 5.1 and GPT-6 Astra effort changes.
 
 ## Moonshot and Together usage
 
@@ -102,10 +104,20 @@ clock to show.
 
 ## Thinking changes follow wire evidence
 
-Cachemire fingerprints the wire form, not the Pi keystroke. Anthropic thinking changes
-can invalidate message cache entries. A known Anthropic TTL therefore supports an
-in-flight warning when the outgoing wire value changes. Levels that map to the same wire
-value stay silent.
+Cachemire fingerprints the wire form, not the Pi keystroke. Direct Anthropic Claude
+Fable 5.1 preserves the prior cached prefix across effort changes. Pi's declared
+`supportsMidConvoEffort` capability is the general form of that contract. Cachemire
+therefore keeps the clock and notices silent for those routes even when the outgoing
+effort value changes. Other Anthropic thinking changes can invalidate message cache
+entries. A known Anthropic TTL therefore supports an in-flight warning when their
+outgoing wire value changes. Levels that map to the same wire value stay silent.
+
+GPT-6 Astra preserves the prefix only when the client appends a
+`configuration_update` input item and leaves request-level `reasoning.effort`
+unchanged. Pi 0.85.1 changes the request-level value instead, on both OpenAI Responses
+implementations, so Cachemire continues to classify that observed difference as a
+thinking mutation. A later Pi implementation of the append-only protocol will compare
+as ordinary prefix growth without a model-name exception.
 
 Unknown routes get no retention-based prediction. If billed usage later proves a miss,
 Cachemire can report an observed payload mutation. A miss without such evidence keeps an

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -65,6 +65,11 @@ expectation. Past-tense wording shows exact actuals.
 Healthy caches stay quiet. Notices appear only above a materiality threshold. The
 default threshold is $0.05 or 20k re-written tokens.
 
+Changing thinking effort on direct Anthropic Claude Fable 5.1 also stays quiet because
+the model preserves the cached prefix. GPT-6 Astra needs an append-only
+`configuration_update` for the same result; Pi 0.85.1 changes request-level effort, so
+Cachemire still treats that payload change as material.
+
 ```
 ◍ cache breaking · re-writing ~138.2k (~$2.59) · cause: 5m TTL reached after 9h50m idle   (in flight)
 ◍ cache after compaction · reused 34.9k of the last pre-compaction 72.5k prompt (48%) · processed 39.1k uncached
@@ -185,7 +190,9 @@ Cachemire uses 4 rules:
   prompt count is a baseline, not the whole next prompt.
 
 Read the [retention audit](../../docs/cache-retention-audit-2026-08-04.md) for policy
-evidence and [`docs/pi-cachemire.md`](../../docs/pi-cachemire.md) for lifecycle semantics.
+evidence, the [thinking-change audit](../../docs/cache-thinking-change-audit-2026-09-10.md)
+for the Fable and Astra probes, and
+[`docs/pi-cachemire.md`](../../docs/pi-cachemire.md) for lifecycle semantics.
 
 ## Compare Cachemire with the other extensions
 

--- a/extensions/pi-cachemire/classify.ts
+++ b/extensions/pi-cachemire/classify.ts
@@ -13,6 +13,7 @@ import type {
   RequestFingerprint,
   UsageLike,
 } from "./types.ts";
+import { thinkingChangesPreserveCache, type ThinkingRoute } from "./thinking.ts";
 
 // Anthropic's two contract retentions; the wire's cache_control ttl names which one.
 export const TTL_SHORT_MS = 5 * 60 * 1000;
@@ -81,7 +82,10 @@ function findTtlMs(payload: Record<string, unknown>): number | undefined {
   return undefined;
 }
 
-export function fingerprintPayload(payload: unknown): RequestFingerprint {
+export function fingerprintPayload(
+  payload: unknown,
+  thinkingRoute?: ThinkingRoute,
+): RequestFingerprint {
   const body = isJsonObject(payload) ? payload : {};
   if (Array.isArray(body.input) || typeof body.instructions === "string") {
     const tools = Array.isArray(body.tools) ? body.tools : [];
@@ -122,6 +126,7 @@ export function fingerprintPayload(payload: unknown): RequestFingerprint {
         body.thinking ?? additional?.thinking,
         body.output_config ?? additional?.output_config,
       ),
+      thinkingCacheNeutral: thinkingChangesPreserveCache(thinkingRoute) ? true : undefined,
     };
   }
   return { kind: "unknown", toolHashes: [], messageHashes: [] };
@@ -139,6 +144,10 @@ function describeAnthropicThinking(thinking: unknown, outputConfig: unknown): st
     return effort ? `thinking effort ${effort}` : "thinking adaptive";
   }
   return "thinking off";
+}
+
+function isEffortThinking(value: string | undefined): boolean {
+  return value?.startsWith("thinking effort ") === true;
 }
 
 // --- forensics: name the first divergent prefix segment --------------------------------
@@ -169,7 +178,9 @@ export function diffFingerprints(prev: RequestFingerprint, cur: RequestFingerpri
   }
   // Before history: a thinking change is the root cause; any history-rendering churn it
   // drags along (e.g. thinking blocks stripped on disable) is a side effect.
-  if (prev.thinking !== cur.thinking) {
+  const cacheSafeEffortChange = cur.thinkingCacheNeutral === true &&
+    isEffortThinking(prev.thinking) && isEffortThinking(cur.thinking);
+  if (prev.thinking !== cur.thinking && !cacheSafeEffortChange) {
     return { kind: "thinking", detail: `thinking changed (${prev.thinking ?? "?"} \u2192 ${cur.thinking ?? "?"})` };
   }
   // History: the previous request's messages must be a prefix of the current ones.

--- a/extensions/pi-cachemire/clock.ts
+++ b/extensions/pi-cachemire/clock.ts
@@ -80,7 +80,7 @@ export function cacheClock(input: ClockInput): ClockState {
   const window = input.window ?? UNKNOWN_WINDOW;
   if (input.thinkingChanged && window.kind === "contract") {
     // No survival promise here: docs say system/tools outlive *budget* changes, but a
-    // live adaptive-effort change on claude-fable-5 re-wrote 100% of the prompt.
+    // live adaptive-effort change on claude-fable-5 (not 5.1) re-wrote 100% of the prompt.
     return { phase: "stale", text: "cache stale \u00b7 thinking level changed \u00b7 next send may re-write the prompt" };
   }
   if (window.kind === "contract") {

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -41,6 +41,7 @@ import {
   type RetentionMatch,
   windowLabel,
 } from "./retention.ts";
+import { thinkingChangeInvalidatesCache, type ThinkingRoute } from "./thinking.ts";
 import { clearCacheWidgetTimer, type CacheWidgetRuntime, updateCacheWidget } from "./widget.ts";
 import type {
   BreakPrediction,
@@ -100,38 +101,15 @@ const DEFAULT_CONFIG: CachemireConfig = {
   missWarnTokens: 20_000,
 };
 
-/**
- * What a pi thinking level becomes on the anthropic wire — mirrors pi-ai's
- * mapThinkingLevelToEffort (model map override first, then minimal/low→low,
- * medium→medium, high→high, anything else→high) plus the off→disabled case.
- */
-function wireThinkingEffort(
-  map: Partial<Record<string, string | null>> | undefined,
-  level: string,
-): string {
-  if (level === "off") return "off";
-  const mapped = map?.[level];
-  if (typeof mapped === "string") return mapped;
-  if (level === "minimal" || level === "low") return "low";
-  if (level === "medium" || level === "high") return level;
-  return "high";
-}
-
-/**
- * Whether switching pi thinking levels changes what actually goes on the wire. Two
- * levels mapping to the same effort are a wire no-op: live-verified on claude-fable-5,
- * where minimal→low (both effort "low") produced a byte-identical payload and a 100%
- * cache hit — a naive "any level change breaks cache" flip would have lied. This is the
- * effort-based (adaptive) view; budget models can differ where efforts collide, which
- * under-flips the widget — the send-time fingerprint diff still catches those exactly.
- */
-function thinkingLevelsDiffer(
-  map: Partial<Record<string, string | null>> | undefined,
-  a: string | undefined,
-  b: string | undefined,
-): boolean {
-  if (a === undefined || b === undefined) return false;
-  return wireThinkingEffort(map, a) !== wireThinkingEffort(map, b);
+function thinkingRoute(model: ExtensionContext["model"]): ThinkingRoute | undefined {
+  if (!model) return undefined;
+  return {
+    provider: model.provider,
+    model: model.id,
+    api: model.api,
+    supportsMidConvoEffort:
+      isJsonObject(model.compat) && model.compat.supportsMidConvoEffort === true,
+  };
 }
 
 // Glyphs and ink come from the family style (_lib/style.ts, design language §§1–3):
@@ -524,7 +502,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
   pi.on("before_provider_request", async (event, ctx) => {
     if (!ownsState()) return;
     const firstAttempt = s.pendingRequestAt === undefined;
-    s.pendingFingerprint = fingerprintPayload(event.payload);
+    s.pendingFingerprint = fingerprintPayload(event.payload, thinkingRoute(ctx.model));
     const requestAt = Date.now();
     const entries = ctx.sessionManager.getEntries();
     hydrateLineageResponseIds(s.lineages, entries);
@@ -620,10 +598,16 @@ export default function piCachemire(pi: ExtensionAPI): void {
     s.lastCallThinkingLevel ??= event.previousLevel;
     s.currentThinkingLevel = event.level;
     // Material only when something was billed at the old level AND the new level changes
-    // the wire params for this model (see thinkingLevelsDiffer); cycling back before the
-    // next call revives the cache. The send-time fingerprint diff remains the authority.
+    // the wire params for this model; cycling back before the next call revives the
+    // cache. Cache-safe mid-conversation effort protocols stay neutral here and in the
+    // send-time fingerprint diff.
     s.thinkingChanged = s.records.length > 0 && ctx.model?.reasoning === true &&
-      thinkingLevelsDiffer(ctx.model.thinkingLevelMap, s.lastCallThinkingLevel, event.level);
+      thinkingChangeInvalidatesCache(
+        thinkingRoute(ctx.model),
+        ctx.model.thinkingLevelMap,
+        s.lastCallThinkingLevel,
+        event.level,
+      );
     updateWidget();
   });
 
@@ -816,8 +800,6 @@ export default function piCachemire(pi: ExtensionAPI): void {
 export const internals = {
   fingerprintPayload,
   inferAnthropicTtlMs,
-  wireThinkingEffort,
-  thinkingLevelsDiffer,
   windowLabel,
   pastWindow,
   OPENAI_EXTENDED_WINDOW,

--- a/extensions/pi-cachemire/thinking.ts
+++ b/extensions/pi-cachemire/thinking.ts
@@ -1,0 +1,43 @@
+export interface ThinkingRoute {
+	provider: string;
+	model: string;
+	api: string;
+	supportsMidConvoEffort: boolean;
+}
+
+export function wireThinkingEffort(
+	map: Partial<Record<string, string | null>> | undefined,
+	level: string,
+): string {
+	if (level === "off") return "off";
+	const mapped = map?.[level];
+	if (typeof mapped === "string") return mapped;
+	if (level === "minimal" || level === "low") return "low";
+	if (level === "medium" || level === "high") return level;
+	return "high";
+}
+
+export function thinkingChangesPreserveCache(route: ThinkingRoute | undefined): boolean {
+	if (route?.api !== "anthropic-messages") return false;
+	// The exact-model fallback covers stale local overrides that shadow Pi's catalogue
+	// flag. Direct Pi 0.85.1 calls retained full message-heavy prefixes on both changes.
+	return (
+		route.supportsMidConvoEffort ||
+		(route.provider === "anthropic" && route.model === "claude-fable-5-1")
+	);
+}
+
+export function thinkingChangeInvalidatesCache(
+	route: ThinkingRoute | undefined,
+	map: Partial<Record<string, string | null>> | undefined,
+	previousLevel: string | undefined,
+	nextLevel: string | undefined,
+): boolean {
+	if (previousLevel === undefined || nextLevel === undefined) return false;
+	const previousEffort = wireThinkingEffort(map, previousLevel);
+	const nextEffort = wireThinkingEffort(map, nextLevel);
+	return (
+		previousEffort !== nextEffort &&
+		(!thinkingChangesPreserveCache(route) || previousEffort === "off" || nextEffort === "off")
+	);
+}

--- a/extensions/pi-cachemire/types.ts
+++ b/extensions/pi-cachemire/types.ts
@@ -25,6 +25,8 @@ export interface RequestFingerprint {
   ttlMs?: number;
   /** Canonical thinking/reasoning wire parameters. */
   thinking?: string;
+  /** The active route promises that effort changes leave the cached prefix intact. */
+  thinkingCacheNeutral?: true;
 }
 
 export type CauseKind =

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -70,9 +70,6 @@
       "scripts/dev/bash-corpus/report.ts": {
         "const THEME_CODES: Record<string, number> = { dim: 245, muted: 246, text: 255, success: 41, warning: 220, error: 196, accent: 214 };": 1
       },
-      "tests/cachemire/economics-and-render.test.ts": {
-        "const fable = { xhigh: \"xhigh\" } as Record<string, string | null>;": 1
-      },
       "tests/cachemire/lineage-events.test.ts": {
         "return { handlers, commands };": 1
       },
@@ -325,7 +322,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 852,
+      "extensions/pi-cachemire/index.ts": 834,
       "extensions/pi-contextimate/index.ts": 1483,
       "extensions/pi-traceline/index.ts": 1677,
       "tests/contract/pi-internals.test.ts": 355,
@@ -333,7 +330,7 @@
     }
   },
   "internalsBudgets": {
-    "extensions/pi-cachemire/index.ts": 34,
+    "extensions/pi-cachemire/index.ts": 32,
     "extensions/pi-contextimate/index.ts": 28,
     "extensions/pi-traceline/index.ts": 55
   }

--- a/tests/cachemire/economics-and-render.test.ts
+++ b/tests/cachemire/economics-and-render.test.ts
@@ -12,7 +12,7 @@ const {
   cacheClock, renderRunSummary, renderMissLine, renderLedger,
   inferAnthropicTtlMs, predictBreak, renderBreakingLine, renderHeldLine,
   OPENAI_EXTENDED_WINDOW, OPENAI_MINIMUM_WINDOW,
-  thinkingLevelsDiffer, wireThinkingEffort, nextClockUpdateMs,
+  nextClockUpdateMs,
 } = internals;
 
 const CONTRACT_5M = { kind: "contract", ttlMs: 5 * 60_000, source: "observed" } as const;
@@ -148,25 +148,6 @@ test("cache clock schedules only useful state changes", () => {
       prior: { requestAt: 0, window: OPENAI_EXTENDED_WINDOW },
     },
   }), 24 * 60 * MIN - MIN);
-});
-
-test("thinking level changes are material only when they change the wire params", () => {
-  // Wire mapping mirrors pi-ai's mapThinkingLevelToEffort + the off→disabled case.
-  assert.equal(wireThinkingEffort(undefined, "minimal"), "low");
-  assert.equal(wireThinkingEffort(undefined, "xhigh"), "high", "unmapped xhigh falls back to high");
-  assert.equal(wireThinkingEffort({ xhigh: "xhigh" }, "xhigh"), "xhigh");
-  assert.equal(wireThinkingEffort(undefined, "off"), "off");
-
-  assert.equal(thinkingLevelsDiffer(undefined, "low", "high"), true);
-  assert.equal(thinkingLevelsDiffer(undefined, undefined, "high"), false, "unknown baseline: never invent a break");
-  // claude-fable-5 (adaptive, map { xhigh: "xhigh" }): minimal→low is a wire no-op —
-  // both become effort "low" (live-verified: byte-identical payload, 100% cache hit).
-  const fable = { xhigh: "xhigh" } as Record<string, string | null>;
-  assert.equal(thinkingLevelsDiffer(fable, "minimal", "low"), false);
-  assert.equal(thinkingLevelsDiffer(fable, "low", "medium"), true, "effort low → medium changes output_config");
-  assert.equal(thinkingLevelsDiffer(fable, "minimal", "off"), true, "off disables thinking on the wire");
-  assert.equal(thinkingLevelsDiffer(fable, "off", "xhigh"), true);
-  assert.equal(thinkingLevelsDiffer(fable, "xhigh", "high"), true);
 });
 
 test("anthropic TTL inference mirrors pi-ai's env resolution", () => {

--- a/tests/cachemire/thinking-events.test.ts
+++ b/tests/cachemire/thinking-events.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
+
+import piCachemire from "../../extensions/pi-cachemire/index.ts";
+import { hostExtension, IsolatedProject } from "../harness/extension-host.ts";
+
+const fable: Model<"anthropic-messages"> = {
+	id: "claude-fable-5-1",
+	name: "Claude Fable 5.1",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	thinkingLevelMap: { off: null, minimal: "low", low: "low", medium: "medium", high: "high" },
+	input: ["text", "image"],
+	cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+	contextWindow: 1_000_000,
+	maxTokens: 128_000,
+};
+
+const payload = {
+	model: fable.id,
+	system: [{ type: "text", text: "fixture", cache_control: { type: "ephemeral" } }],
+	messages: [{ role: "user", content: [{ type: "text", text: "first" }] }],
+	thinking: { type: "adaptive" },
+	output_config: { effort: "low" },
+};
+
+const assistant: AssistantMessage = {
+	role: "assistant",
+	content: [{ type: "text", text: "answer" }],
+	provider: fable.provider,
+	api: fable.api,
+	model: fable.id,
+	usage: {
+		input: 2,
+		output: 10,
+		cacheRead: 0,
+		cacheWrite: 100_000,
+		totalTokens: 100_012,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: Date.now(),
+};
+
+test("thinking_level_select keeps direct Claude Fable 5.1 cache UI silent", async () => {
+	const project = new IsolatedProject();
+	const host = await hostExtension(piCachemire, { project, model: fable, thinkingLevel: "low" });
+	try {
+		await host.session.extensionRunner.emitBeforeProviderRequest(payload);
+		await host.session.extensionRunner.emitMessageEnd({ type: "message_end", message: assistant });
+		assert.equal(host.ui.widgetLines("pi-cachemire"), undefined, "a healthy cache is silent");
+
+		await host.session.extensionRunner.emit({
+			type: "thinking_level_select",
+			previousLevel: "low",
+			level: "high",
+		});
+		assert.equal(
+			host.ui.widgetLines("pi-cachemire"),
+			undefined,
+			"the cache-safe effort change must not show a false stale clock",
+		);
+	} finally {
+		await host.dispose();
+		project.dispose();
+	}
+});

--- a/tests/cachemire/thinking.test.ts
+++ b/tests/cachemire/thinking.test.ts
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { diffFingerprints, fingerprintPayload } from "../../extensions/pi-cachemire/classify.ts";
+import {
+	thinkingChangeInvalidatesCache,
+	thinkingChangesPreserveCache,
+	wireThinkingEffort,
+	type ThinkingRoute,
+} from "../../extensions/pi-cachemire/thinking.ts";
+
+const directAnthropic = (
+	model: string,
+	supportsMidConvoEffort = false,
+): ThinkingRoute => ({
+	provider: "anthropic",
+	model,
+	api: "anthropic-messages",
+	supportsMidConvoEffort,
+});
+
+const anthropicRequest = (effort: string, messages: unknown[] = [
+	{ role: "user", content: [{ type: "text", text: "first" }] },
+]) => ({
+	model: "claude-fable-5-1",
+	system: "fixture",
+	messages,
+	thinking: { type: "adaptive" },
+	output_config: { effort },
+});
+
+test("thinking levels use Pi's adaptive effort mapping", () => {
+	assert.equal(wireThinkingEffort(undefined, "minimal"), "low");
+	assert.equal(wireThinkingEffort(undefined, "xhigh"), "high");
+	assert.equal(wireThinkingEffort({ xhigh: "xhigh" }, "xhigh"), "xhigh");
+	assert.equal(wireThinkingEffort(undefined, "off"), "off");
+
+	assert.equal(thinkingChangeInvalidatesCache(undefined, undefined, "low", "high"), true);
+	assert.equal(thinkingChangeInvalidatesCache(undefined, undefined, undefined, "high"), false);
+	const fableMap = { xhigh: "xhigh" };
+	assert.equal(thinkingChangeInvalidatesCache(undefined, fableMap, "minimal", "low"), false);
+	assert.equal(thinkingChangeInvalidatesCache(undefined, fableMap, "low", "medium"), true);
+});
+
+test("only verified Anthropic routes make effort changes cache-neutral", () => {
+	const fable = directAnthropic("claude-fable-5-1");
+	assert.equal(thinkingChangesPreserveCache(fable), true);
+	assert.equal(thinkingChangeInvalidatesCache(fable, undefined, "low", "high"), false);
+	assert.equal(
+		thinkingChangeInvalidatesCache(fable, undefined, "off", "high"),
+		true,
+		"the live evidence covers effort changes, not enabling thinking",
+	);
+
+	assert.equal(thinkingChangesPreserveCache(directAnthropic("future-claude", true)), true);
+	assert.equal(thinkingChangesPreserveCache(directAnthropic("claude-fable-5")), false);
+	assert.equal(thinkingChangesPreserveCache({
+		...fable,
+		provider: "radius",
+		api: "pi-messages",
+	}), false, "a matching gateway model name is not direct Anthropic evidence");
+	assert.equal(thinkingChangesPreserveCache({
+		provider: "openai-codex",
+		model: "gpt-6-astra",
+		api: "openai-codex-responses",
+		supportsMidConvoEffort: true,
+	}), false, "Pi's Anthropic compatibility flag cannot bless another wire protocol");
+});
+
+test("direct Claude Fable 5.1 fingerprints ignore effort-only changes", () => {
+	const route = directAnthropic("claude-fable-5-1");
+	const before = fingerprintPayload(anthropicRequest("low"), route);
+	const after = fingerprintPayload(anthropicRequest("high"), route);
+	assert.equal(diffFingerprints(before, after), undefined);
+	assert.equal(
+		diffFingerprints(
+			fingerprintPayload(anthropicRequest("low")),
+			fingerprintPayload(anthropicRequest("high")),
+		)?.kind,
+		"thinking",
+		"the same wire change remains material without route evidence",
+	);
+	assert.equal(diffFingerprints(
+		fingerprintPayload({ ...anthropicRequest("low"), thinking: undefined }, route),
+		fingerprintPayload(anthropicRequest("high"), route),
+	)?.kind, "thinking", "enabling thinking is not an effort-only change");
+});
+
+test("Pi's managed Fable effort markers preserve a strict message prefix", () => {
+	const marker = (effort: string) => ({ role: "system", content: [], output_config: { effort } });
+	const firstUser = { role: "user", content: [{ type: "text", text: "first" }] };
+	const assistant = { role: "assistant", content: [{ type: "text", text: "answer" }] };
+	const secondUser = { role: "user", content: [{ type: "text", text: "second" }] };
+	const managed = (messages: unknown[]) => ({
+		...anthropicRequest("high", messages),
+		thinking: { type: "adaptive", block_binding: { prefix_mismatch_behavior: "drop_block" } },
+	});
+	const first = fingerprintPayload(managed([firstUser, marker("high")]));
+	const next = fingerprintPayload(managed([
+		firstUser,
+		marker("high"),
+		assistant,
+		secondUser,
+		marker("low"),
+	]));
+	assert.equal(diffFingerprints(first, next), undefined);
+	assert.equal(diffFingerprints(first, fingerprintPayload(managed([
+		firstUser,
+		assistant,
+		secondUser,
+		marker("low"),
+	])))?.kind, "history", "dropping the historical marker would rewrite the prefix");
+});
+
+test("GPT-6 Astra stays material until Pi appends configuration_update", () => {
+	const user = { role: "user", content: [{ type: "input_text", text: "first" }] };
+	const request = (effort: string, input: unknown[]) => ({
+		model: "gpt-6-astra",
+		instructions: "fixture",
+		reasoning: { effort },
+		input,
+	});
+	const first = fingerprintPayload(request("low", [user]));
+	assert.equal(
+		diffFingerprints(first, fingerprintPayload(request("high", [user])))?.kind,
+		"thinking",
+		"Pi 0.85.1 changes request-level effort",
+	);
+	assert.equal(diffFingerprints(first, fingerprintPayload(request("low", [
+		user,
+		{ type: "configuration_update", reasoning: { effort: "high" } },
+		{ role: "user", content: [{ type: "input_text", text: "second" }] },
+	]))), undefined, "the documented append-only protocol preserves the old prefix");
+});

--- a/tests/contract/pi-cache-retention-seams.test.ts
+++ b/tests/contract/pi-cache-retention-seams.test.ts
@@ -122,6 +122,28 @@ test("installed GPT-5.6 and GPT-6 Astra models keep direct API and Codex routes 
   }
 });
 
+test("installed Claude Fable 5.1 declares Pi's cache-safe effort protocol", () => {
+  const fable = modelRecord("anthropic.json", "anthropic-messages", "claude-fable-5-1");
+  assert.equal(fable.provider, "anthropic");
+  assert.ok(isJsonObject(fable.compat));
+  assert.equal(fable.compat.supportsMidConvoEffort, true);
+
+  const anthropic = source("anthropic-messages.js");
+  assert.match(anthropic, /insertThinkingLevelMessages\(converted, activeEffort\)/);
+  assert.match(anthropic, /prefix_mismatch_behavior: "drop_block"/);
+  assert.match(anthropic, /params\.output_config = \{ effort: "high" \}/);
+  assert.match(anthropic, /providerThinkingLevel/);
+});
+
+test("Pi 0.85.1 changes Astra request-level effort instead of appending an update", () => {
+  const direct = source("openai-responses.js");
+  const codex = source("openai-codex-responses.js");
+  assert.match(direct, /params\.reasoning = \{\s*effort:/);
+  assert.match(codex, /body\.reasoning = \{\s*effort,/);
+  assert.doesNotMatch(direct, /configuration_update/);
+  assert.doesNotMatch(codex, /configuration_update/);
+});
+
 test("installed provider records keep Cachemire's new routes exact", () => {
   for (const [file, api, model, provider] of [
     ["minimax.json", "anthropic-messages", "MiniMax-M2.7", "minimax"],

--- a/tests/harness/extension-host.ts
+++ b/tests/harness/extension-host.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import {
   type AgentSession,
+  type CreateAgentSessionOptions,
   createAgentSession,
   DefaultResourceLoader,
   type ExtensionFactory,
@@ -86,9 +87,15 @@ export type HostedExtension = {
 
 export async function hostExtension(
   factory: ExtensionFactory,
-  options: { project: IsolatedProject; interactive?: boolean; reason?: SessionStartEvent["reason"] },
+  options: {
+    project: IsolatedProject;
+    interactive?: boolean;
+    reason?: SessionStartEvent["reason"];
+    model?: CreateAgentSessionOptions["model"];
+    thinkingLevel?: CreateAgentSessionOptions["thinkingLevel"];
+  },
 ): Promise<HostedExtension> {
-  const { project, interactive = true, reason = "startup" } = options;
+  const { project, interactive = true, reason = "startup", model, thinkingLevel } = options;
   const cwd = project.dir;
   const agentDir = join(project.home, ".pi", "agent");
   const loader = new DefaultResourceLoader({ cwd, agentDir, extensionFactories: [factory] });
@@ -101,6 +108,8 @@ export async function hostExtension(
     agentDir,
     resourceLoader: loader,
     sessionManager: SessionManager.inMemory(cwd),
+    model,
+    thinkingLevel,
     noTools: "all",
     sessionStartEvent: { type: "session_start", reason },
   });


### PR DESCRIPTION
## Summary

- treat effort-to-effort changes as cache-neutral on direct Claude Fable 5.1 and Anthropic routes using Pi's `supportsMidConvoEffort` protocol
- keep thinking enable/disable transitions and GPT-6 Astra's current request-level effort changes material
- add focused classifier, event-flow, and installed Pi 0.85.1 contract coverage
- document the provider contracts and live cache probes

## Runtime evidence

- Claude Fable 5.1 high-to-low retained a complete 15,103-token message-heavy prefix; a real Pi TUI low-to-high run also stayed warm and produced no Cachemire stale/break notice
- GPT-6 Astra low-to-high read 0 cached tokens, versus 5,888 on a low-to-low control, matching Pi 0.85.1's request-level `reasoning.effort` payload

## Checks

- `npm run check` (375 tests)
- independent implementation review: no merge-blocking findings
