### PR TITLE
fix(cachemire): let the bill outrank the payload for thinking-effort changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@
   Pi's built-in model record declares its mid-conversation effort protocol. GPT-6 Astra
   remains a real mutation in Pi 0.85.1 because Pi changes request-level effort instead
   of appending OpenAI's cache-safe `configuration_update` item.
+- Cachemire lets the bill outrank the payload for thinking-effort changes. A
+  later-loaded extension (for example `pi-codex-conversion`'s append-only
+  `configuration_update` for GPT-6 Astra) can rewrite a request after Cachemire has
+  read it, so billed effort-to-effort changes on a route now decide what Cachemire
+  expects from that route for the rest of the process: a hit on an effort the route
+  has never billed silences the stale clock and in-flight claim for later changes
+  there, and says so once (`cache held · … · effort low → high kept the prefix warm on
+  this route`); a miss the payload attributed to thinking reinstates them. A hit on a
+  previously billed effort proves nothing (providers keep a warm entry per effort),
+  and a resumed session seeds those efforts from Pi's persisted level changes within
+  the last 24 hours. On/off toggles stay material.
+  The `/cache` ledger names the change on hit rows. `predictBreak` and the session
+  economics helpers moved to `extensions/pi-cachemire/economics.ts`.
 - Development: the repo now lints with Oxlint and a vendored copy of
   [anti-slop](https://github.com/dmmulroy/anti-slop) (`tools/oxlint/anti-slop`,
   `.oxlintrc.json`), fed into the existing agent-lint baseline as shrink-only debt.

--- a/docs/cache-thinking-change-audit-2026-09-10.md
+++ b/docs/cache-thinking-change-audit-2026-09-10.md
@@ -92,6 +92,51 @@ Two fresh-session runs used the same stable prefix:
 Captured Pi payloads changed request-level reasoning effort and contained no
 `configuration_update` item.
 
+## Addendum (same day): the hook position is not the wire
+
+The Astra result above describes stock Pi. With `@howaboua/pi-codex-conversion`
+3.0.31 active (its 3.0.26 release keeps request-level effort fixed and appends
+OpenAI's `configuration_update` item on effort changes), the same low-to-high change
+on `openai-codex/gpt-6-astra` kept reading the prior prefix: usage showed cache reads
+above 98% of the prompt. Cachemire nevertheless saw a changed request-level effort
+at its `before_provider_request` hook and warned about a break that never came.
+
+Pi's extension runner (`dist/core/extensions/runner.js`) runs
+`before_provider_request` per extension in load order and threads each replacement
+payload only into later handlers; an extension-registered provider then transforms
+the request after every hook. Whatever Cachemire reads at its hook is therefore the
+payload at that position, not proof of the wire form. Inspecting further down the
+chain is not available to an extension, and pinning Cachemire to another extension's
+internals would tie it to one setup.
+
+Cachemire now lets the bill outrank the payload. The static contract (Pi's
+`supportsMidConvoEffort` flag or the verified direct Fable 5.1 route) sets the
+expectation until an effort-to-effort change on a route is billed; from then on the
+most recent billed verdict on that exact provider, API and model decides, for the
+rest of the process. A hit on an effort the route has never billed records that the
+route keeps its prefix; a miss the payload attributed to thinking, with no closed
+retention window to blame, records that it breaks. Both directions stay observable:
+the first hit against an expected break says so once, and a miss still names the wire
+change. The contract suite pins the runner's hook order so a change there surfaces as
+a failing test.
+
+Live acceptance, same day, real `pi` 0.85.1 TUI in an isolated HOME with real tool
+calls on `openai-codex/gpt-6-astra` and a ~10.5k-token prompt:
+
+- Cachemire loaded before `pi-codex-conversion` (the live order): `low → high` hit,
+  `cache held · read 10.4k of 10.5k expected · effort low → high kept the prefix warm
+  on this route` printed once; `high → medium` hit silently; the `/cache` rows name
+  both changes
+- Cachemire loaded after it: same result on one run. On another run `high → medium`
+  billed a genuine 100% miss which Cachemire reported as `cause: unknown` (its hook
+  saw an append-only `configuration_update`, so thinking was not attributable) and
+  left the held verdict alone; a repeat of that order hit throughout
+- stock Pi, no conversion extension: `low → high` and `high → medium` each missed
+  and were named `thinking changed`; `medium → high` then read 10.6k of 10.8k back.
+  That hit is the `high` entry from two calls earlier, still within retention, not
+  effort neutrality: it is why a hit counts as evidence only on an effort the route
+  has never billed before
+
 ## Sources
 
 - OpenAI, [Reasoning models](https://developers.openai.com/api/docs/guides/reasoning),

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -243,6 +243,20 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   GPT-6 Astra is neutral only when the request appends an OpenAI `configuration_update`
   while leaving request-level effort unchanged; a changed request-level effort remains
   a cache mutation
+- the bill outranks the payload. Cachemire reads a request at its own hook position;
+  a later-loaded extension or an extension-registered provider may transform it
+  afterwards, so the payload Cachemire saw is not proof of what reached the wire.
+  Once an effort-to-effort change on a route has been billed, that verdict decides
+  the route's expectation for the rest of the process: a hit on an effort the route
+  has never billed before silences the stale clock and the in-flight claim for later
+  changes on the exact provider, API and model; a miss the payload attributed to
+  thinking, with no closed window to blame, reinstates them. A hit on an effort
+  billed earlier proves nothing: providers keep an entry per effort, and a return
+  within retention reads that entry back. The first hit that contradicts an expected
+  break says so once (`cache held · … · effort low → high kept the prefix warm on
+  this route`); an expected hit earns no line. Evidence never softens an on/off
+  toggle, and the payload diff still names the wire change when a miss follows, so
+  nothing is learned silently
 
 ## 8. Panels
 

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -119,6 +119,52 @@ implementations, so Cachemire continues to classify that observed difference as 
 thinking mutation. A later Pi implementation of the append-only protocol will compare
 as ordinary prefix growth without a model-name exception.
 
+### The bill outranks the payload
+
+Cachemire reads each request at its own `before_provider_request` position. Pi runs
+that hook per extension in load order and threads a replacement payload only into
+later handlers, and an extension-registered provider transforms the request after every
+hook. A later-loaded extension that rewrites Astra's effort change into an append-only
+`configuration_update` is therefore invisible to Cachemire, and so is any other
+transformation of that kind. The payload Cachemire saw is not proof of what reached the
+wire; the billed usage is.
+
+Cachemire therefore treats every billed effort-to-effort change as a verdict on its
+route (provider, API and model), for the rest of the Pi process:
+
+- a hit on an effort the route has never billed before records that the route keeps
+  its prefix. The stale clock and the in-flight `cache breaking` claim stay silent
+  for later effort changes on that route
+- a hit on an effort billed earlier in the process proves nothing. Providers keep a
+  cache entry per effort, so returning to a level within retention reads that level's
+  own entry back: stock Pi on Astra missed on `low → high` and `high → medium`, then
+  hit on `medium → high` because the `high` entry was still warm. Cachemire counts
+  the hit and leaves the verdict alone
+- a miss or partial that the payload diff attributed to thinking, with no closed
+  retention window to blame, records that the route breaks, and reinstates both
+- a miss with another named cause, or after a closed window, proves nothing about
+  effort and leaves the verdict alone
+
+The first hit that contradicts an expected break says so once:
+
+```
+◍ cache held · read 29.8k of 30.0k expected · effort low → high kept the prefix warm on this route
+```
+
+An expected hit earns no line, and the `/cache` ledger row reads
+`hit — effort low → high kept the prefix`. Evidence never softens turning thinking on <!-- agent-lint-disable-line POG007 -->
+or off, which stays a distinct mutation. The payload diff still names the wire change
+when a miss follows, so a route that stops holding (for example after the rewriting
+extension is disabled) corrects itself on the next billed change rather than staying
+quietly wrong.
+
+Verdicts live in the process, not the session: the behaviour belongs to the provider
+and extension stack, so `/new`, `/resume` and `/reload` keep them and a fresh `pi`
+starts without any. A resumed session still tells which efforts its history billed on
+the active path within the longest known retention (24 hours, OpenAI extended), read
+from Pi's persisted thinking-level entries, so a return to one of them in the new
+process is not mistaken for fresh evidence.
+
 Unknown routes get no retention-based prediction. If billed usage later proves a miss,
 Cachemire can report an observed payload mutation. A miss without such evidence keeps an
 unknown cause.

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -68,7 +68,18 @@ default threshold is $0.05 or 20k re-written tokens.
 Changing thinking effort on direct Anthropic Claude Fable 5.1 also stays quiet because
 the model preserves the cached prefix. GPT-6 Astra needs an append-only
 `configuration_update` for the same result; Pi 0.85.1 changes request-level effort, so
-Cachemire still treats that payload change as material.
+Cachemire expects that payload change to break the cache until the bill says otherwise.
+
+The bill outranks the payload. A later-loaded extension can rewrite the request after
+Cachemire has read it, so the billed effort changes on a route decide what Cachemire
+expects from that route for the rest of the process. A hit on an effort the route has
+never billed before says so once and silences later warnings on that route; a miss that
+the payload attributed to thinking reinstates them. Returning to an effort billed
+earlier proves nothing either way, because providers keep a warm entry per effort:
+
+```
+◍ cache held · read 29.8k of 30.0k expected · effort low → high kept the prefix warm on this route
+```
 
 ```
 ◍ cache breaking · re-writing ~138.2k (~$2.59) · cause: 5m TTL reached after 9h50m idle   (in flight)

--- a/extensions/pi-cachemire/economics.ts
+++ b/extensions/pi-cachemire/economics.ts
@@ -1,0 +1,96 @@
+// Break prediction at request time (before usage exists) and the session economics
+// that price it. Almost every break cause is knowable when the request is sent: the
+// idle gap vs TTL, pi's compact events, and the payload fingerprint diff. Predicting at
+// send time lets the notice sit between the user's action and the response, where the
+// causality lives, and the resolved actuals replace it in place when usage arrives.
+
+import { expiryCause, pastWindow } from "./classify.ts";
+import type { SwitchForecast } from "./forecast.ts";
+import type { BreakPrediction, CacheWindow, CallCause, CallRecord, ModelRates, UsageLike } from "./types.ts";
+
+export function predictBreak(args: {
+  isFirst: boolean;
+  inCompaction: boolean;
+  compacted: boolean;
+  gapMs?: number;
+  window?: CacheWindow;
+  expectedRead: number;
+  fingerprintCause?: CallCause;
+  /** The route's contract or billed evidence says effort changes keep the prefix. */
+  thinkingCacheNeutral?: boolean;
+  rates?: ModelRates;
+  /** Target-currency estimate while a model switch is pending (issue #57). */
+  switchForecast?: Pick<SwitchForecast, "estTokens" | "basis" | "targetProvider"> & { priorMayBeWarm: boolean };
+}): BreakPrediction | undefined {
+  // Cold starts are healthy and the compaction summarizer call is labelled, not warned.
+  if (args.isFirst || args.inCompaction || args.expectedRead <= 0) return undefined;
+  if (args.compacted) {
+    // The old prefix is gone; the new one's size is unknowable until usage arrives.
+    return { cause: { kind: "compaction", detail: "history compacted" } };
+  }
+  const sized = (cause: CallCause): BreakPrediction => ({
+    cause,
+    expectedRewriteTokens: args.expectedRead,
+    expectedUsd: rewriteCostUsd(args.expectedRead, args.rates),
+  });
+  if (args.fingerprintCause) {
+    // Model switches break the cache vs the *last* call for certain (caches are
+    // per-model on every provider), but the stored size is denominated in the old
+    // model's tokenizer — never show that number. When the shared heuristics produced
+    // a target-currency estimate, claim that instead, marked est. When the target
+    // model's own prior cache entry may still be warm (A→B→A), stay silent: the
+    // resolved line reports the truth when usage arrives.
+    if (args.fingerprintCause.kind === "model") {
+      const forecast = args.switchForecast;
+      if (forecast?.priorMayBeWarm) return undefined;
+      if (forecast?.estTokens === undefined) return { cause: args.fingerprintCause };
+      return {
+        cause: args.fingerprintCause,
+        estimatedRewriteTokens: forecast.estTokens,
+        estimatedUsd: rewriteCostUsd(forecast.estTokens, args.rates),
+        estimateBasis: forecast.basis,
+        targetProvider: forecast.targetProvider,
+      };
+    }
+    if (args.fingerprintCause.kind === "compaction") return { cause: args.fingerprintCause };
+    if (args.fingerprintCause.kind === "thinking") {
+      // Only an Anthropic contract window earns an in-flight claim, and not on a route
+      // whose billed evidence says it holds: that silences the claim without hiding
+      // the wire change from the resolved cause. The affected share of expectedRead is
+      // unknowable, so the prediction stays unsized.
+      return args.window?.kind === "contract" && args.thinkingCacheNeutral !== true
+        ? { cause: args.fingerprintCause }
+        : undefined;
+    }
+    return sized(args.fingerprintCause);
+  }
+  // Only a definite contract expiry or reached maximum earns an in-flight line.
+  if (pastWindow(args.window, args.gapMs)) {
+    return sized(expiryCause(args.window, args.gapMs)!);
+  }
+  return undefined;
+}
+
+export function uncachedCostUsd(usage: UsageLike, rates?: ModelRates): number | undefined {
+  if (!rates) return undefined;
+  const inputTokens = usage.input + usage.cacheRead + usage.cacheWrite;
+  return (inputTokens * rates.input + usage.output * rates.output) / 1_000_000;
+}
+
+export function rewriteCostUsd(tokens: number, rates?: ModelRates): number | undefined {
+  if (!rates) return undefined;
+  // Request-wide pricing tiers: the highest matching threshold prices the whole request.
+  const tier = (rates.tiers ?? [])
+    .filter((candidate) => tokens > candidate.inputTokensAbove)
+    .sort((a, b) => b.inputTokensAbove - a.inputTokensAbove)[0] ?? rates;
+  return (tokens * (tier.cacheWrite || tier.input)) / 1_000_000;
+}
+
+export function sessionSavings(records: CallRecord[]): { actual: number; uncached: number; saved: number; pct: number } | undefined {
+  const usable = records.filter((record) => record.costUsd !== undefined && record.uncachedUsd !== undefined);
+  if (usable.length === 0) return undefined;
+  const actual = usable.reduce((sum, record) => sum + (record.costUsd ?? 0), 0);
+  const uncached = usable.reduce((sum, record) => sum + (record.uncachedUsd ?? 0), 0);
+  if (uncached <= 0) return undefined;
+  return { actual, uncached, saved: uncached - actual, pct: (1 - actual / uncached) * 100 };
+}

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -14,14 +14,9 @@ import {
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import { GLYPH, SCALE, SEP, ink, panelHeader, type Tone } from "../_lib/style.ts";
-import {
-  classifyCall,
-  diffFingerprints,
-  expiryCause,
-  fingerprintPayload,
-  pastWindow,
-} from "./classify.ts";
+import { classifyCall, diffFingerprints, fingerprintPayload, pastWindow } from "./classify.ts";
 import { UNKNOWN_WINDOW, cacheClock, nextClockUpdateMs, withinWarmHorizon } from "./clock.ts";
+import { predictBreak, rewriteCostUsd, sessionSavings, uncachedCostUsd } from "./economics.ts";
 import { activeToolDefinitions, computeSwitchForecast, type SwitchForecast, type SwitchTarget } from "./forecast.ts";
 import { restoreBranchRecords } from "./ledger.ts";
 import {
@@ -31,7 +26,7 @@ import {
   resolveCacheLineage,
   restoreLineageSnapshots,
 } from "./lineage.ts";
-import { renderBreakingLine, renderHeldLine, renderMissLine, renderRunSummary } from "./render.ts";
+import { renderBreakingLine, renderHeldLine, renderLedgerEvent, renderMissLine, renderRunSummary } from "./render.ts";
 import {
   confirmedWindow,
   inferAnthropicTtlMs,
@@ -41,10 +36,16 @@ import {
   type RetentionMatch,
   windowLabel,
 } from "./retention.ts";
-import { thinkingChangeInvalidatesCache, type ThinkingRoute } from "./thinking.ts";
+import {
+  recordBilledThinking,
+  rememberBilledEfforts,
+  thinkingChangeInvalidatesCache,
+  thinkingChangesPreserveCache,
+  type ThinkingEvidenceLedger,
+  thinkingRoute,
+} from "./thinking.ts";
 import { clearCacheWidgetTimer, type CacheWidgetRuntime, updateCacheWidget } from "./widget.ts";
 import type {
-  BreakPrediction,
   CacheLineageSnapshot,
   CacheWindow,
   CachemireConfig,
@@ -54,7 +55,6 @@ import type {
   ModelRates,
   RequestFingerprint,
   RunAggregate,
-  UsageLike,
 } from "./types.ts";
 
 export type {
@@ -101,109 +101,9 @@ const DEFAULT_CONFIG: CachemireConfig = {
   missWarnTokens: 20_000,
 };
 
-function thinkingRoute(model: ExtensionContext["model"]): ThinkingRoute | undefined {
-  if (!model) return undefined;
-  return {
-    provider: model.provider,
-    model: model.id,
-    api: model.api,
-    supportsMidConvoEffort:
-      isJsonObject(model.compat) && model.compat.supportsMidConvoEffort === true,
-  };
-}
-
 // Glyphs and ink come from the family style (_lib/style.ts, design language §§1–3):
 // ◍ opens every loop-economics line, ○ ● ◑ ◌ are the status scale, and all colour
 // is theme-derived through ink() with raw-ANSI fallbacks before a Theme handle exists.
-
-// --- break prediction (at request time, before usage exists) ---------------------------
-// Almost every break cause is knowable when the request is sent: the idle gap vs TTL,
-// pi's compact events, and the payload fingerprint diff. Predicting at send time lets the
-// notice sit between the user's action and the response — where the causality lives —
-// and the resolved actuals replace it in place when usage arrives.
-
-function predictBreak(args: {
-  isFirst: boolean;
-  inCompaction: boolean;
-  compacted: boolean;
-  gapMs?: number;
-  window?: CacheWindow;
-  expectedRead: number;
-  fingerprintCause?: CallCause;
-  rates?: ModelRates;
-  /** Target-currency estimate while a model switch is pending (issue #57). */
-  switchForecast?: Pick<SwitchForecast, "estTokens" | "basis" | "targetProvider"> & { priorMayBeWarm: boolean };
-}): BreakPrediction | undefined {
-  // Cold starts are healthy and the compaction summarizer call is labelled, not warned.
-  if (args.isFirst || args.inCompaction || args.expectedRead <= 0) return undefined;
-  if (args.compacted) {
-    // The old prefix is gone; the new one's size is unknowable until usage arrives.
-    return { cause: { kind: "compaction", detail: "history compacted" } };
-  }
-  const sized = (cause: CallCause): BreakPrediction => ({
-    cause,
-    expectedRewriteTokens: args.expectedRead,
-    expectedUsd: rewriteCostUsd(args.expectedRead, args.rates),
-  });
-  if (args.fingerprintCause) {
-    // Model switches break the cache vs the *last* call for certain (caches are
-    // per-model on every provider), but the stored size is denominated in the old
-    // model's tokenizer — never show that number. When the shared heuristics produced
-    // a target-currency estimate, claim that instead, marked est. When the target
-    // model's own prior cache entry may still be warm (A→B→A), stay silent: the
-    // resolved line reports the truth when usage arrives.
-    if (args.fingerprintCause.kind === "model") {
-      const forecast = args.switchForecast;
-      if (forecast?.priorMayBeWarm) return undefined;
-      if (forecast?.estTokens === undefined) return { cause: args.fingerprintCause };
-      return {
-        cause: args.fingerprintCause,
-        estimatedRewriteTokens: forecast.estTokens,
-        estimatedUsd: rewriteCostUsd(forecast.estTokens, args.rates),
-        estimateBasis: forecast.basis,
-        targetProvider: forecast.targetProvider,
-      };
-    }
-    if (args.fingerprintCause.kind === "compaction") return { cause: args.fingerprintCause };
-    if (args.fingerprintCause.kind === "thinking") {
-      // Only an Anthropic contract window earns an in-flight claim. The affected share
-      // of expectedRead is unknowable, so the prediction stays unsized.
-      return args.window?.kind === "contract" ? { cause: args.fingerprintCause } : undefined;
-    }
-    return sized(args.fingerprintCause);
-  }
-  // Only a definite contract expiry or reached maximum earns an in-flight line.
-  if (pastWindow(args.window, args.gapMs)) {
-    return sized(expiryCause(args.window, args.gapMs)!);
-  }
-  return undefined;
-}
-
-// --- economics -------------------------------------------------------------------------
-
-function uncachedCostUsd(usage: UsageLike, rates?: ModelRates): number | undefined {
-  if (!rates) return undefined;
-  const inputTokens = usage.input + usage.cacheRead + usage.cacheWrite;
-  return (inputTokens * rates.input + usage.output * rates.output) / 1_000_000;
-}
-
-function rewriteCostUsd(tokens: number, rates?: ModelRates): number | undefined {
-  if (!rates) return undefined;
-  // Request-wide pricing tiers: the highest matching threshold prices the whole request.
-  const tier = (rates.tiers ?? [])
-    .filter((candidate) => tokens > candidate.inputTokensAbove)
-    .sort((a, b) => b.inputTokensAbove - a.inputTokensAbove)[0] ?? rates;
-  return (tokens * (tier.cacheWrite || tier.input)) / 1_000_000;
-}
-
-function sessionSavings(records: CallRecord[]): { actual: number; uncached: number; saved: number; pct: number } | undefined {
-  const usable = records.filter((record) => record.costUsd !== undefined && record.uncachedUsd !== undefined);
-  if (usable.length === 0) return undefined;
-  const actual = usable.reduce((sum, record) => sum + (record.costUsd ?? 0), 0);
-  const uncached = usable.reduce((sum, record) => sum + (record.uncachedUsd ?? 0), 0);
-  if (uncached <= 0) return undefined;
-  return { actual, uncached, saved: uncached - actual, pct: (1 - actual / uncached) * 100 };
-}
 
 // --- ledger lines ----------------------------------------------------------------------
 
@@ -237,17 +137,12 @@ function renderLedger(
   );
   for (const record of records) {
     const { usage } = record;
-    const eventText = record.classification.kind === "hit"
-      ? "hit"
-      : record.classification.kind === "cold"
-        ? "cold start"
-        : `${record.classification.kind} \u2014 ${record.classification.cause?.detail ?? "unknown"}`;
     lines.push(
       `  ${col(String(record.index), 4)} ${col(record.gapMs !== undefined ? formatDuration(record.gapMs) : "\u2014", 7)}` +
       ` ${col(compactCount(usage.input), 8)} ${col(compactCount(usage.cacheRead), 8)}` +
       ` ${col(compactCount(usage.cacheWrite), 8)} ${col(compactCount(usage.output), 7)}` +
       ` ${col(record.costUsd !== undefined ? formatUsd(record.costUsd) : "\u2014", 7)}` +
-      `  ${EVENT_GLYPHS[record.classification.kind]} ${eventText}${record.restored ? " (restored)" : ""}`,
+      `  ${EVENT_GLYPHS[record.classification.kind]} ${renderLedgerEvent(record)}${record.restored ? " (restored)" : ""}`,
     );
   }
   const totals = records.reduce(
@@ -341,6 +236,8 @@ interface CachemireState {
   lastCallThinkingLevel?: string;
   currentThinkingLevel?: string;
   thinkingChanged: boolean;
+  /** Billed effort-change verdicts per route; outlives sessions (see thinking.ts). */
+  thinkingEvidence: ThinkingEvidenceLedger;
   expectedRead: number;
   rates?: ModelRates;
   modelLabel?: string;
@@ -377,6 +274,7 @@ function state(): CachemireState {
       window: UNKNOWN_WINDOW,
       modelSwitched: false,
       thinkingChanged: false,
+      thinkingEvidence: new Map(),
       expectedRead: 0,
       compacted: false,
       inCompaction: false,
@@ -477,6 +375,11 @@ export default function piCachemire(pi: ExtensionAPI): void {
     // current one); the forecast must exist before the first widget render.
     refreshSwitchForecast(pi, ctx, ctx.sessionManager.getLeafId(), model);
     s.lastCallThinkingLevel = s.currentThinkingLevel = pi.getThinkingLevel();
+    // Route evidence belongs to the process (provider and extension stack), not the
+    // session; a resumed session still tells which efforts may hold a warm entry.
+    // SAFETY: a reload re-imports this file over the global state of the version it replaces.
+    if (event.reason === "startup" || !s.thinkingEvidence) s.thinkingEvidence = new Map();
+    rememberBilledEfforts(s.thinkingEvidence, entries, ctx.sessionManager.getLeafId(), model, Date.now());
     s.compacted = false;
     s.inCompaction = false;
     s.pendingFingerprint = undefined;
@@ -550,6 +453,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
         window: s.pendingPreviousWindow ?? s.window,
         expectedRead: s.expectedRead,
         fingerprintCause: s.pendingFingerprintCause,
+        thinkingCacheNeutral: thinkingChangesPreserveCache(thinkingRoute(ctx.model), s.thinkingEvidence),
         rates: s.rates,
         switchForecast: s.switchForecast === undefined ? undefined : {
           ...s.switchForecast,
@@ -599,14 +503,14 @@ export default function piCachemire(pi: ExtensionAPI): void {
     s.currentThinkingLevel = event.level;
     // Material only when something was billed at the old level AND the new level changes
     // the wire params for this model; cycling back before the next call revives the
-    // cache. Cache-safe mid-conversation effort protocols stay neutral here and in the
-    // send-time fingerprint diff.
+    // cache. Routes whose contract or billed evidence keeps the prefix stay neutral.
     s.thinkingChanged = s.records.length > 0 && ctx.model?.reasoning === true &&
       thinkingChangeInvalidatesCache(
         thinkingRoute(ctx.model),
         ctx.model.thinkingLevelMap,
         s.lastCallThinkingLevel,
         event.level,
+        s.thinkingEvidence,
       );
     updateWidget();
   });
@@ -652,7 +556,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     updateWidget();
   });
 
-  pi.on("message_end", async (event) => {
+  pi.on("message_end", async (event, ctx) => {
     if (!ownsState()) return;
     const message = event.message;
     if (message.role !== "assistant") return;
@@ -677,6 +581,21 @@ export default function piCachemire(pi: ExtensionAPI): void {
       fingerprintCause,
     });
     const activeWindow = confirmedWindow(s.pendingRetention, usage) ?? UNKNOWN_WINDOW;
+    // The billed verdict on an effort change, whatever the payload looked like at
+    // Cachemire's hook: a later extension or provider may have transformed it.
+    const thinkingBreakExpected = s.thinkingChanged;
+    const route = thinkingRoute(ctx.model);
+    const thinkingChange = route && recordBilledThinking(s.thinkingEvidence, route, {
+      map: ctx.model?.thinkingLevelMap,
+      lastCallLevel: s.lastCallThinkingLevel,
+      currentLevel: s.currentThinkingLevel,
+      incomparable: s.modelSwitched || s.compacted || s.inCompaction,
+      classification,
+      thinkingNamedAtSend: fingerprintCause?.kind === "thinking",
+      windowExpired: pastWindow(s.pendingPreviousWindow ?? s.window, cacheGapMs),
+      usage,
+      expectedRead: s.expectedRead,
+    });
     const record: CallRecord = {
       index: s.records.length + 1,
       at: now,
@@ -688,6 +607,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
       rewroteTokens: usage.cacheWrite > 0 ? usage.cacheWrite : usage.input,
       switched: s.modelSwitched ? true : undefined,
       postCompaction: s.compacted ? { modelSwitched: s.modelSwitched } : undefined,
+      thinkingChange,
       costUsd: usage.cost.total,
       uncachedUsd: uncachedCostUsd(usage, s.rates),
     };
@@ -751,6 +671,9 @@ export default function piCachemire(pi: ExtensionAPI): void {
     ) {
       // Append an unpredicted break once provider usage proves it.
       appendChatLine(econLine("warning", renderMissLine(record)));
+    } else if (s.config.missWarnings && thinkingBreakExpected && thinkingChange?.held) {
+      // An expected break that held: say so once; the evidence keeps later ones quiet.
+      appendChatLine(econLine("success", renderHeldLine(record)));
     }
     updateWidget(now);
   });

--- a/extensions/pi-cachemire/render.ts
+++ b/extensions/pi-cachemire/render.ts
@@ -85,10 +85,28 @@ export function renderMissLine(record: CallRecord): string {
   return `${what} \u00b7 cause: ${record.classification.cause?.detail ?? "unknown"}`;
 }
 
+/** The `event` cell of a `/cache` ledger row. */
+export function renderLedgerEvent(record: CallRecord): string {
+  const { kind, cause } = record.classification;
+  if (kind === "hit") {
+    const change = record.thinkingChange;
+    return change ? `hit \u2014 effort ${change.from} \u2192 ${change.to} kept the prefix` : "hit";
+  }
+  if (kind === "cold") return "cold start";
+  return `${kind} \u2014 ${cause?.detail ?? "unknown"}`;
+}
+
 // A predicted break that resolved into a hit: good news, and a small lesson about
-// shared-prefix warmth (another session with the same harness prefix kept it alive).
+// shared-prefix warmth (another session with the same harness prefix kept it alive)
+// or about the route: an effort change that read the prior prefix back is billed
+// proof that this route keeps it, whatever the payload looked like at Cachemire's hook.
 export function renderHeldLine(record: CallRecord): string {
   if (isPostCompaction(record)) return renderCompactionLine(record);
+  const change = record.thinkingChange;
+  if (change?.held) {
+    return `cache held \u00b7 read ${compactCount(record.usage.cacheRead)} of ${compactCount(record.expectedRead)} expected` +
+      ` \u00b7 effort ${change.from} \u2192 ${change.to} kept the prefix warm on this route`;
+  }
   if (record.switched) {
     // The old expectation is denominated in the previous model's tokenizer, so it is
     // never composed with this read. Warmth this session did not write (a twin session's

--- a/extensions/pi-cachemire/thinking.ts
+++ b/extensions/pi-cachemire/thinking.ts
@@ -1,8 +1,59 @@
+// Thinking-effort changes and the cache. Two sources decide whether an effort change
+// is cache-key material on a route: the static wire contract (Pi's catalogue flag or a
+// verified direct route) and, once a change has been billed, the usage itself.
+// Cachemire reads a request only at its own hook position; a later-loaded extension or
+// an extension-registered provider can transform it afterwards (Pi documents this), so
+// the billed verdict outranks both the contract and the send-time payload.
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { isJsonObject, type JsonFields, nonNegativeNumberValue, stringValue } from "../_lib/boundary.ts";
+import type { CallClassification, ThinkingEvidence, UsageLike } from "./types.ts";
+
 export interface ThinkingRoute {
 	provider: string;
 	model: string;
 	api: string;
 	supportsMidConvoEffort: boolean;
+}
+
+/** What this process has billed on one route: every wire effort ever billed there,
+ * and the most recent effort-change verdict. */
+interface RouteThinkingRecord {
+	billedEfforts: Set<string>;
+	verdict?: ThinkingEvidence;
+}
+
+/** Per route, for the life of this Pi process: the route's behaviour belongs to the
+ * provider and extension stack, not to a session. */
+export type ThinkingEvidenceLedger = Map<string, RouteThinkingRecord>;
+
+type ActiveModel = NonNullable<ExtensionContext["model"]>;
+
+export function thinkingRoute(model: ExtensionContext["model"]): ThinkingRoute | undefined {
+	return model && routeOf(model);
+}
+
+function routeOf(model: ActiveModel): ThinkingRoute {
+	return {
+		provider: model.provider,
+		model: model.id,
+		api: model.api,
+		supportsMidConvoEffort:
+			isJsonObject(model.compat) && model.compat.supportsMidConvoEffort === true,
+	};
+}
+
+function routeKey(route: ThinkingRoute): string {
+	return `${route.provider}/${route.api}/${route.model}`;
+}
+
+function routeRecord(ledger: ThinkingEvidenceLedger, route: ThinkingRoute): RouteThinkingRecord {
+	const key = routeKey(route);
+	const existing = ledger.get(key);
+	if (existing) return existing;
+	const created: RouteThinkingRecord = { billedEfforts: new Set() };
+	ledger.set(key, created);
+	return created;
 }
 
 export function wireThinkingEffort(
@@ -17,14 +68,25 @@ export function wireThinkingEffort(
 	return "high";
 }
 
-export function thinkingChangesPreserveCache(route: ThinkingRoute | undefined): boolean {
-	if (route?.api !== "anthropic-messages") return false;
-	// The exact-model fallback covers stale local overrides that shadow Pi's catalogue
-	// flag. Direct Pi 0.85.1 calls retained full message-heavy prefixes on both changes.
+// The static contract. The exact-model fallback covers stale local overrides that
+// shadow Pi's catalogue flag; direct Pi 0.85.1 calls retained full message-heavy
+// prefixes on both effort changes.
+function contractPreservesCache(route: ThinkingRoute): boolean {
+	if (route.api !== "anthropic-messages") return false;
 	return (
 		route.supportsMidConvoEffort ||
 		(route.provider === "anthropic" && route.model === "claude-fable-5-1")
 	);
+}
+
+/** The most recent billed verdict on the exact route wins over the contract either way. */
+export function thinkingChangesPreserveCache(
+	route: ThinkingRoute | undefined,
+	ledger?: ThinkingEvidenceLedger,
+): boolean {
+	if (!route) return false;
+	const verdict = ledger?.get(routeKey(route))?.verdict;
+	return verdict ? verdict.held : contractPreservesCache(route);
 }
 
 export function thinkingChangeInvalidatesCache(
@@ -32,12 +94,113 @@ export function thinkingChangeInvalidatesCache(
 	map: Partial<Record<string, string | null>> | undefined,
 	previousLevel: string | undefined,
 	nextLevel: string | undefined,
+	ledger?: ThinkingEvidenceLedger,
 ): boolean {
 	if (previousLevel === undefined || nextLevel === undefined) return false;
 	const previousEffort = wireThinkingEffort(map, previousLevel);
 	const nextEffort = wireThinkingEffort(map, nextLevel);
 	return (
 		previousEffort !== nextEffort &&
-		(!thinkingChangesPreserveCache(route) || previousEffort === "off" || nextEffort === "off")
+		(!thinkingChangesPreserveCache(route, ledger) || previousEffort === "off" || nextEffort === "off")
 	);
+}
+
+export interface BilledThinkingChange {
+	map: Partial<Record<string, string | null>> | undefined;
+	/** Level at the previous billed call and at this one. */
+	lastCallLevel: string | undefined;
+	currentLevel: string | undefined;
+	/** The two calls do not share a prefix to compare: model switch or compaction. */
+	incomparable: boolean;
+	classification: CallClassification;
+	/** Send-time forensics named the thinking wire change as the first divergence. */
+	thinkingNamedAtSend: boolean;
+	/** A retention window also closed, so a miss proves nothing about effort. */
+	windowExpired: boolean;
+	usage: UsageLike;
+	expectedRead: number;
+}
+
+/**
+ * Books one billed call on its route and returns the verdict it carries, if any. A hit
+ * on an effort the route has never billed before is evidence that the route keeps its
+ * prefix: a hit on a previously billed effort proves nothing, because providers keep a
+ * cache entry per effort and a return within retention reads that entry back. A miss
+ * counts against the route only when the payload showed the effort change and nothing
+ * else (expiry, another named mutation) explains it. Turning thinking on or off stays
+ * a distinct mutation and never produces evidence.
+ */
+export function recordBilledThinking(
+	ledger: ThinkingEvidenceLedger,
+	route: ThinkingRoute,
+	change: BilledThinkingChange,
+): ThinkingEvidence | undefined {
+	const record = routeRecord(ledger, route);
+	const verdict = thinkingVerdict(change, record.billedEfforts);
+	if (change.currentLevel !== undefined) {
+		record.billedEfforts.add(wireThinkingEffort(change.map, change.currentLevel));
+	}
+	if (verdict) record.verdict = verdict;
+	return verdict;
+}
+
+/** The longest retention Cachemire knows (OpenAI extended, `OPENAI_EXTENDED_WINDOW` in
+ * retention.ts, which this module cannot import without a cycle; a test pins the two):
+ * an effort billed within it may still have a warm entry when a later process returns. */
+export const EFFORT_MEMORY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Seeds the active route with the efforts a resumed session billed recently, walking
+ * Pi's persisted `thinking_level_change` entries along the active path, so a return to
+ * one of them in this process is not mistaken for fresh evidence.
+ */
+export function rememberBilledEfforts(
+	ledger: ThinkingEvidenceLedger,
+	entries: readonly unknown[],
+	leafId: string | null,
+	model: ExtensionContext["model"],
+	now: number,
+): void {
+	if (!model || leafId === null) return;
+	const route = routeOf(model);
+	const byId = new Map<string, JsonFields>();
+	for (const entry of entries) {
+		if (isJsonObject(entry) && typeof entry.id === "string") byId.set(entry.id, entry);
+	}
+	const path: JsonFields[] = [];
+	for (let id: string | undefined = leafId; id !== undefined; id = stringValue(path.at(-1)?.parentId)) {
+		const entry = byId.get(id);
+		if (!entry) break;
+		path.push(entry);
+	}
+	const record = routeRecord(ledger, route);
+	let level: string | undefined;
+	for (const entry of path.reverse()) {
+		if (entry.type === "thinking_level_change") {
+			level = stringValue(entry.thinkingLevel);
+			continue;
+		}
+		if (entry.type !== "message" || !isJsonObject(entry.message) || entry.message.role !== "assistant") continue;
+		const { message } = entry;
+		if (message.provider !== route.provider || message.api !== route.api || message.model !== route.model) continue;
+		const at = nonNegativeNumberValue(message.timestamp);
+		if (level === undefined || at === undefined || now - at > EFFORT_MEMORY_MS) continue;
+		record.billedEfforts.add(wireThinkingEffort(model.thinkingLevelMap, level));
+	}
+}
+
+function thinkingVerdict(
+	change: BilledThinkingChange,
+	billedEfforts: ReadonlySet<string>,
+): ThinkingEvidence | undefined {
+	if (change.incomparable || change.lastCallLevel === undefined || change.currentLevel === undefined) {
+		return undefined;
+	}
+	const from = wireThinkingEffort(change.map, change.lastCallLevel);
+	const to = wireThinkingEffort(change.map, change.currentLevel);
+	if (from === to || from === "off" || to === "off") return undefined;
+	const verdict = { from, to, cacheRead: change.usage.cacheRead, expectedRead: change.expectedRead };
+	if (change.classification.kind === "hit") return billedEfforts.has(to) ? undefined : { ...verdict, held: true };
+	if (change.classification.kind === "cold") return undefined;
+	return change.thinkingNamedAtSend && !change.windowExpired ? { ...verdict, held: false } : undefined;
 }

--- a/extensions/pi-cachemire/types.ts
+++ b/extensions/pi-cachemire/types.ts
@@ -40,6 +40,16 @@ export interface CallClassification {
   cause?: CallCause;
 }
 
+/** Billed verdict on one effort-to-effort change: the usage, not the keystroke, decides. */
+export interface ThinkingEvidence {
+  /** Wire efforts at the previous billed call and at this one. */
+  from: string;
+  to: string;
+  held: boolean;
+  cacheRead: number;
+  expectedRead: number;
+}
+
 export interface CallRecord {
   index: number;
   at: number;
@@ -55,6 +65,8 @@ export interface CallRecord {
    * composed with this call's counts (design language §7). */
   switched?: boolean;
   postCompaction?: { modelSwitched: boolean };
+  /** This call billed an effort change on the same route as the previous one. */
+  thinkingChange?: ThinkingEvidence;
   costUsd?: number;
   uncachedUsd?: number;
   restored?: boolean;

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -322,7 +322,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 834,
+      "extensions/pi-cachemire/index.ts": 757,
       "extensions/pi-contextimate/index.ts": 1483,
       "extensions/pi-traceline/index.ts": 1677,
       "tests/contract/pi-internals.test.ts": 355,

--- a/tests/cachemire/lineage-events.test.ts
+++ b/tests/cachemire/lineage-events.test.ts
@@ -107,7 +107,7 @@ test("first request after hot reload diagnoses a changed tool schema", async () 
 
   await fire(oldRuntime, "session_start", { reason: "startup" }, oldContext);
   await fire(oldRuntime, "before_provider_request", { payload: payload(["before reload"], [oldTool]) }, oldContext);
-  await fire(oldRuntime, "message_end", { message: oldAssistant });
+  await fire(oldRuntime, "message_end", { message: oldAssistant }, oldContext);
   entries.push({
     type: "message",
     id: "assistant-1",
@@ -170,7 +170,7 @@ test("session_tree rebases classification to the selected provider-known prompt"
     assert.equal(notifications.length, 0, "branching must not price the abandoned 200k leaf");
     await fire(runtime, "message_end", {
       message: { ...assistant(now, 100_000), usage: usage(0, 90_000, 10_000) },
-    });
+    }, ctx);
 
     await fire(runtime, "before_provider_request", {
       payload: payload(["base", "new branch", "aborted suffix"]),

--- a/tests/cachemire/model-switch-events.test.ts
+++ b/tests/cachemire/model-switch-events.test.ts
@@ -180,7 +180,7 @@ test("event flow: the same model over a different wire API is a switch", async (
     await fire(probe, "message_end", { message: {
       role: "assistant", content: [], provider: "anthropic", api: "bedrock-anthropic", model: "claude-opus-4-8",
       stopReason: "stop", timestamp: Date.now(), usage: usage(80_000, 0, 0),
-    } });
+    } }, ctx);
     assert.doesNotMatch(widgets.at(-1)!, /model switched/, "fresh usage must re-baseline the currency");
   } finally {
     await fire(probe, "session_shutdown", {});

--- a/tests/cachemire/thinking-events.test.ts
+++ b/tests/cachemire/thinking-events.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Model, ThinkingLevel } from "@earendil-works/pi-ai";
 
 import piCachemire from "../../extensions/pi-cachemire/index.ts";
 import { hostExtension, IsolatedProject } from "../harness/extension-host.ts";
@@ -19,37 +19,82 @@ const fable: Model<"anthropic-messages"> = {
 	maxTokens: 128_000,
 };
 
-const payload = {
-	model: fable.id,
-	system: [{ type: "text", text: "fixture", cache_control: { type: "ephemeral" } }],
-	messages: [{ role: "user", content: [{ type: "text", text: "first" }] }],
-	thinking: { type: "adaptive" },
-	output_config: { effort: "low" },
+// Same wire contract, no catalogue flag and no verified exception: the static rule
+// expects every effort change to break the cache.
+const fableFive: Model<"anthropic-messages"> = { ...fable, id: "claude-fable-5", name: "Claude Fable 5" };
+
+// Pi's own catalogue record for the Codex route.
+const astra: Model<"openai-codex-responses"> = {
+	id: "gpt-6-astra",
+	name: "GPT-6 Astra",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	thinkingLevelMap: { off: null, minimal: "low", low: "low", medium: "medium", high: "high", xhigh: "xhigh" },
+	input: ["text", "image"],
+	cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+	contextWindow: 272_000,
+	maxTokens: 128_000,
 };
 
-const assistant: AssistantMessage = {
-	role: "assistant",
-	content: [{ type: "text", text: "answer" }],
-	provider: fable.provider,
-	api: fable.api,
-	model: fable.id,
-	usage: {
-		input: 2,
-		output: 10,
-		cacheRead: 0,
-		cacheWrite: 100_000,
-		totalTokens: 100_012,
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-	},
-	stopReason: "stop",
-	timestamp: Date.now(),
-};
+function anthropicPayload(model: Model<"anthropic-messages">, effort: string, turns: string[]) {
+	return {
+		model: model.id,
+		system: [{ type: "text", text: "fixture", cache_control: { type: "ephemeral" } }],
+		messages: turns.map((text) => ({ role: "user", content: [{ type: "text", text }] })),
+		thinking: { type: "adaptive" },
+		output_config: { effort },
+	};
+}
+
+// What Cachemire sees at its own hook: Pi's request-level effort. A later-loaded
+// extension may rewrite this into OpenAI's configuration_update protocol afterwards;
+// the billed usage, not this payload, says whether the prefix survived.
+function astraPayload(effort: string, turns: string[]) {
+	return {
+		model: astra.id,
+		instructions: "fixture",
+		input: turns.map((text) => ({ role: "user", content: [{ type: "input_text", text }] })),
+		reasoning: { effort },
+	};
+}
+
+function billed(model: Model<string>, usage: { input: number; cacheRead: number; cacheWrite: number }): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "answer" }],
+		provider: model.provider,
+		api: model.api,
+		model: model.id,
+		usage: {
+			...usage,
+			output: 10,
+			totalTokens: usage.input + usage.cacheRead + usage.cacheWrite + 10,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+const assistant = billed(fable, { input: 2, cacheRead: 0, cacheWrite: 100_000 });
+
+// One billed turn as Pi runs it: the user entry advances the leaf before the request,
+// the assistant entry after the bill, so each call anchors its own lineage snapshot.
+async function call(host: Awaited<ReturnType<typeof hostExtension>>, payload: unknown, message: AssistantMessage) {
+	const runner = host.session.extensionRunner;
+	host.session.sessionManager.appendMessage({ role: "user", content: String(host.session.sessionManager.getEntries().length), timestamp: Date.now() });
+	await runner.emitBeforeProviderRequest(payload);
+	await runner.emitMessageEnd({ type: "message_end", message });
+	host.session.sessionManager.appendMessage(message);
+}
 
 test("thinking_level_select keeps direct Claude Fable 5.1 cache UI silent", async () => {
 	const project = new IsolatedProject();
 	const host = await hostExtension(piCachemire, { project, model: fable, thinkingLevel: "low" });
 	try {
-		await host.session.extensionRunner.emitBeforeProviderRequest(payload);
+		await host.session.extensionRunner.emitBeforeProviderRequest(anthropicPayload(fable, "low", ["first"]));
 		await host.session.extensionRunner.emitMessageEnd({ type: "message_end", message: assistant });
 		assert.equal(host.ui.widgetLines("pi-cachemire"), undefined, "a healthy cache is silent");
 
@@ -63,6 +108,120 @@ test("thinking_level_select keeps direct Claude Fable 5.1 cache UI silent", asyn
 			undefined,
 			"the cache-safe effort change must not show a false stale clock",
 		);
+	} finally {
+		await host.dispose();
+		project.dispose();
+	}
+});
+
+test("a billed hit after an effort change silences a route the contract expects to break", async () => {
+	const project = new IsolatedProject();
+	const host = await hostExtension(piCachemire, { project, model: fableFive, thinkingLevel: "low" });
+	const runner = host.session.extensionRunner;
+	const notices = host.ui.notifications;
+	try {
+		await call(host, anthropicPayload(fableFive, "low", ["first"]), billed(fableFive, { input: 2, cacheRead: 0, cacheWrite: 100_000 }));
+
+		// No evidence yet: the contract rule predicts a break, at the keystroke and in flight.
+		await runner.emit({ type: "thinking_level_select", previousLevel: "low", level: "high" });
+		assert.match(host.ui.widgetLines("pi-cachemire")?.join("\n") ?? "", /thinking level changed/);
+		host.session.sessionManager.appendMessage({ role: "user", content: "second", timestamp: Date.now() });
+		await runner.emitBeforeProviderRequest(anthropicPayload(fableFive, "high", ["first", "second"]));
+		assert.equal(notices.length, 1);
+		assert.match(notices[0]!, /cache breaking .* cause: thinking changed \(thinking effort low \u2192 thinking effort high\)/);
+
+		// The usage says the prefix survived: the prediction resolves into a held line.
+		const held = billed(fableFive, { input: 200, cacheRead: 100_000, cacheWrite: 300 });
+		await runner.emitMessageEnd({ type: "message_end", message: held });
+		host.session.sessionManager.appendMessage(held);
+		assert.equal(notices.length, 2);
+		assert.equal(
+			notices[1],
+			"\u25cd cache held \u00b7 read 100.0k of 100.0k expected \u00b7 effort low \u2192 high kept the prefix warm on this route",
+		);
+
+		// The verdict now outranks the contract: the next change is quiet end to end.
+		await runner.emit({ type: "thinking_level_select", previousLevel: "high", level: "low" });
+		assert.equal(host.ui.widgetLines("pi-cachemire"), undefined, "evidence must silence the stale clock");
+		host.session.sessionManager.appendMessage({ role: "user", content: "third", timestamp: Date.now() });
+		await runner.emitBeforeProviderRequest(anthropicPayload(fableFive, "low", ["first", "second", "third"]));
+		assert.equal(notices.length, 2, "evidence must silence the in-flight prediction");
+		const quiet = billed(fableFive, { input: 200, cacheRead: 100_300, cacheWrite: 300 });
+		await runner.emitMessageEnd({ type: "message_end", message: quiet });
+		host.session.sessionManager.appendMessage(quiet);
+		assert.equal(notices.length, 2, "a hit that was expected earns no line");
+
+		// The payload diff still saw the wire change; only the claim was withheld. A miss
+		// on the same route names it, so the verdict can flip back.
+		await runner.emit({ type: "thinking_level_select", previousLevel: "low", level: "high" });
+		await call(
+			host,
+			anthropicPayload(fableFive, "high", ["first", "second", "third", "fourth"]),
+			billed(fableFive, { input: 2, cacheRead: 0, cacheWrite: 101_000 }),
+		);
+		assert.equal(notices.length, 3);
+		assert.match(notices[2]!, /cache broke .* cause: thinking changed \(thinking effort low \u2192 thinking effort high\)/);
+		await runner.emit({ type: "thinking_level_select", previousLevel: "high", level: "low" });
+		assert.match(host.ui.widgetLines("pi-cachemire")?.join("\n") ?? "", /thinking level changed/, "a billed miss reinstates the expectation");
+
+		// Turning thinking off is a different mutation and stays material regardless.
+		await runner.emit({ type: "thinking_level_select", previousLevel: "low", level: "off" });
+		assert.match(host.ui.widgetLines("pi-cachemire")?.join("\n") ?? "", /thinking level changed/);
+	} finally {
+		await host.dispose();
+		project.dispose();
+	}
+});
+
+test("GPT-6 Astra: the usage decides, and only a fresh effort can prove the route holds", async () => {
+	const project = new IsolatedProject();
+	const host = await hostExtension(piCachemire, { project, model: astra, thinkingLevel: "low" });
+	const runner = host.session.extensionRunner;
+	const notices = host.ui.notifications;
+	const turns = ["first"];
+	const change = async (previousLevel: ThinkingLevel, level: ThinkingLevel, usage: { input: number; cacheRead: number }) => {
+		await runner.emit({ type: "thinking_level_select", previousLevel, level });
+		turns.push(level);
+		await call(host, astraPayload(level, turns), billed(astra, { ...usage, cacheWrite: 0 }));
+	};
+	try {
+		await call(host, astraPayload("low", turns), billed(astra, { input: 30_000, cacheRead: 0, cacheWrite: 0 }));
+
+		// Stock Pi: the request-level effort changes and the bill says miss. The payload
+		// diff names it, and an OpenAI window never earns an in-flight claim.
+		await change("low", "high", { input: 30_600, cacheRead: 0 });
+		assert.equal(notices.length, 1);
+		assert.match(notices[0]!, /^\u25cd cache broke .* cause: thinking changed \(effort low \u2192 effort high\)$/);
+		await change("high", "medium", { input: 30_800, cacheRead: 0 });
+		assert.equal(notices.length, 2);
+		assert.match(notices[1]!, /cause: thinking changed \(effort high \u2192 effort medium\)$/);
+
+		// Back to an effort already billed: the provider still holds that effort's own
+		// entry, so the hit is real but proves nothing about the route. No line, and the
+		// expectation stays.
+		await change("medium", "high", { input: 400, cacheRead: 30_600 });
+		assert.equal(notices.length, 2, "a hit on a previously billed effort is not evidence");
+
+		// A hit on an effort this route has never billed is the verdict: a later-loaded
+		// extension kept the prefix (configuration_update) even though the payload
+		// Cachemire saw changed effort. Say so once; record it.
+		await change("high", "xhigh", { input: 400, cacheRead: 30_800 });
+		assert.equal(notices.length, 3);
+		assert.equal(
+			notices[2],
+			"\u25cd cache held \u00b7 read 30.8k of 31.0k expected \u00b7 effort high \u2192 xhigh kept the prefix warm on this route",
+		);
+
+		// The route now holds: an expected hit earns no line.
+		await change("xhigh", "low", { input: 400, cacheRead: 31_200 });
+		assert.equal(notices.length, 3);
+
+		await host.session.prompt("/cache");
+		const ledger = notices.at(-1)!;
+		assert.match(ledger, /\u25cc miss \u2014 thinking changed \(effort low \u2192 effort high\)/);
+		assert.match(ledger, /\u25cc miss \u2014 thinking changed \(effort high \u2192 effort medium\)/);
+		assert.match(ledger, /\u25cf hit \u2014 effort high \u2192 xhigh kept the prefix/);
+		assert.equal((ledger.match(/\u25cf hit \u2014/g) ?? []).length, 1, "only the fresh-effort hit names the change");
 	} finally {
 		await host.dispose();
 		project.dispose();

--- a/tests/cachemire/thinking.test.ts
+++ b/tests/cachemire/thinking.test.ts
@@ -1,12 +1,19 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import type { Model } from "@earendil-works/pi-ai";
 
 import { diffFingerprints, fingerprintPayload } from "../../extensions/pi-cachemire/classify.ts";
+import { OPENAI_EXTENDED_WINDOW } from "../../extensions/pi-cachemire/retention.ts";
 import {
+	type BilledThinkingChange,
+	EFFORT_MEMORY_MS,
+	recordBilledThinking,
+	rememberBilledEfforts,
 	thinkingChangeInvalidatesCache,
 	thinkingChangesPreserveCache,
-	wireThinkingEffort,
+	type ThinkingEvidenceLedger,
 	type ThinkingRoute,
+	wireThinkingEffort,
 } from "../../extensions/pi-cachemire/thinking.ts";
 
 const directAnthropic = (
@@ -131,4 +138,137 @@ test("GPT-6 Astra stays material until Pi appends configuration_update", () => {
 		{ type: "configuration_update", reasoning: { effort: "high" } },
 		{ role: "user", content: [{ type: "input_text", text: "second" }] },
 	]))), undefined, "the documented append-only protocol preserves the old prefix");
+});
+
+// --- billed evidence -----------------------------------------------------------------
+
+const astraRoute: ThinkingRoute = {
+	provider: "openai-codex",
+	model: "gpt-6-astra",
+	api: "openai-codex-responses",
+	supportsMidConvoEffort: false,
+};
+const astraMap = { off: null, minimal: "low", low: "low", medium: "medium", high: "high", xhigh: "xhigh" };
+const bill = (cacheRead: number, expectedRead = 30_000) => ({
+	usage: { input: expectedRead - cacheRead, output: 10, cacheRead, cacheWrite: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+	expectedRead,
+});
+const change = (overrides: Partial<BilledThinkingChange>): BilledThinkingChange => ({
+	map: astraMap,
+	lastCallLevel: "low",
+	currentLevel: "high",
+	incomparable: false,
+	classification: { kind: "hit" },
+	thinkingNamedAtSend: true,
+	windowExpired: false,
+	...bill(29_800),
+	...overrides,
+});
+
+test("a billed hit on a fresh effort, or an attributable miss, is evidence; nothing else is", () => {
+	// Each verdict is booked on a fresh ledger so the cases stay independent.
+	const observe = (overrides: Partial<BilledThinkingChange>, billedBefore: string[] = ["low"]) => {
+		const ledger: ThinkingEvidenceLedger = new Map();
+		for (const level of billedBefore) recordBilledThinking(ledger, astraRoute, change({ lastCallLevel: undefined, currentLevel: level }));
+		return recordBilledThinking(ledger, astraRoute, change(overrides));
+	};
+	assert.deepEqual(observe({}), {
+		from: "low", to: "high", held: true, cacheRead: 29_800, expectedRead: 30_000,
+	});
+	const miss = { kind: "miss", cause: { kind: "thinking", detail: "thinking changed (effort low \u2192 effort high)" } } as const;
+	assert.equal(observe({ classification: miss, ...bill(0) })?.held, false);
+	assert.equal(observe({ classification: { kind: "partial" }, ...bill(1_000) })?.held, false);
+
+	// A hit on an effort the route already billed reads that effort's own cache entry
+	// back (stock Pi on Astra: low → high missed, then medium → high hit): no evidence.
+	assert.equal(observe({}, ["low", "high", "medium"]), undefined);
+	assert.equal(observe({ classification: miss, ...bill(0) }, ["low", "high"])?.held, false, "a miss counts regardless");
+
+	// A miss the payload did not attribute to thinking, or that a closed window
+	// explains, says nothing about the route.
+	assert.equal(observe({ classification: miss, thinkingNamedAtSend: false, ...bill(0) }), undefined);
+	assert.equal(observe({ classification: miss, windowExpired: true, ...bill(0) }), undefined);
+	// A hit reads the prefix back even when the payload diff saw nothing: still evidence.
+	assert.equal(observe({ thinkingNamedAtSend: false })?.held, true);
+
+	// Not an effort-to-effort change on a comparable prefix.
+	assert.equal(observe({ classification: { kind: "cold" }, ...bill(0) }), undefined);
+	assert.equal(observe({ incomparable: true }), undefined);
+	assert.equal(observe({ lastCallLevel: undefined }), undefined);
+	assert.equal(observe({ lastCallLevel: "minimal", currentLevel: "low" }), undefined, "same wire effort");
+	assert.equal(observe({ lastCallLevel: "off" }), undefined, "turning thinking on is a different mutation");
+	assert.equal(observe({ currentLevel: "off" }), undefined, "turning thinking off is a different mutation");
+});
+
+test("the most recent billed verdict on the exact route outranks the contract either way", () => {
+	const ledger: ThinkingEvidenceLedger = new Map();
+	const hit = change({});
+	const miss = change({
+		classification: { kind: "miss", cause: { kind: "thinking", detail: "thinking changed (effort low \u2192 effort high)" } },
+		...bill(0),
+	});
+	const invalidates = (route: ThinkingRoute, previous: string, next: string) =>
+		thinkingChangeInvalidatesCache(route, astraMap, previous, next, ledger);
+
+	assert.equal(invalidates(astraRoute, "low", "high"), true, "no evidence: the contract decides");
+	assert.equal(recordBilledThinking(ledger, astraRoute, hit)?.held, true);
+	assert.equal(thinkingChangesPreserveCache(astraRoute, ledger), true);
+	assert.equal(invalidates(astraRoute, "low", "high"), false);
+	assert.equal(invalidates(astraRoute, "high", "off"), true, "off toggles stay material with held evidence");
+	assert.equal(invalidates({ ...astraRoute, provider: "openai" }, "low", "high"), true, "evidence is per exact route");
+	assert.equal(invalidates({ ...astraRoute, api: "openai-responses" }, "low", "high"), true);
+	assert.equal(invalidates({ ...astraRoute, model: "gpt-6" }, "low", "high"), true);
+
+	assert.equal(recordBilledThinking(ledger, astraRoute, miss)?.held, false);
+	assert.equal(invalidates(astraRoute, "low", "high"), true, "a later miss reinstates the expectation");
+	assert.equal(recordBilledThinking(ledger, astraRoute, hit), undefined, "high was billed before: no new verdict");
+	assert.equal(invalidates(astraRoute, "low", "high"), true);
+
+	// The contract's own neutrality is evidence-overridable too: a billed miss on a route
+	// the catalogue calls safe wins until a fresh-effort hit says otherwise.
+	const flagged = directAnthropic("claude-fable-5-1", true);
+	assert.equal(thinkingChangesPreserveCache(flagged, ledger), true);
+	recordBilledThinking(ledger, flagged, miss);
+	assert.equal(thinkingChangesPreserveCache(flagged, ledger), false);
+	recordBilledThinking(ledger, flagged, change({ lastCallLevel: "high", currentLevel: "medium" }));
+	assert.equal(thinkingChangesPreserveCache(flagged, ledger), true);
+});
+
+test("a resumed session remembers which efforts its history billed within retention", () => {
+	assert.equal(EFFORT_MEMORY_MS, OPENAI_EXTENDED_WINDOW.maxMs, "the memory bound is the longest known retention");
+	const now = 1_800_000_000_000;
+	const model: Model<"openai-codex-responses"> = {
+		provider: "openai-codex", id: "gpt-6-astra", name: "GPT-6 Astra", api: "openai-codex-responses",
+		baseUrl: "https://chatgpt.com/backend-api", reasoning: true, thinkingLevelMap: astraMap, input: ["text"],
+		cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 }, contextWindow: 272_000, maxTokens: 128_000,
+	};
+	const assistant = (id: string, parentId: string, at: number, modelId = model.id) => ({
+		type: "message", id, parentId, timestamp: new Date(at).toISOString(),
+		message: { role: "assistant", provider: model.provider, api: model.api, model: modelId, timestamp: at, content: [] },
+	});
+	const level = (id: string, parentId: string, thinkingLevel: string) => ({ type: "thinking_level_change", id, parentId, thinkingLevel });
+	const entries = [
+		level("t0", null as unknown as string, "medium"),
+		assistant("a1", "t0", now - EFFORT_MEMORY_MS - 60_000), // medium, but too old to be warm
+		level("t1", "a1", "high"),
+		assistant("a2", "t1", now - 600_000), // high, ten minutes ago
+		level("t2", "a2", "minimal"),
+		assistant("a3", "t2", now - 300_000), // minimal maps to the low wire effort
+		assistant("a4", "a3", now - 200_000, "gpt-5.6-sol"), // another route
+		level("t3", "a3", "xhigh"), // abandoned branch: not on the path to the leaf
+		assistant("a5", "t3", now - 100_000),
+	];
+
+	const ledger: ThinkingEvidenceLedger = new Map();
+	rememberBilledEfforts(ledger, entries, "a4", model, now);
+	const hitOn = (to: string) =>
+		recordBilledThinking(ledger, astraRoute, change({ lastCallLevel: "medium", currentLevel: to }));
+	assert.equal(hitOn("high"), undefined, "high was billed ten minutes ago: its entry may still be warm");
+	assert.equal(hitOn("low"), undefined, "minimal billed the low wire effort");
+	assert.equal(hitOn("xhigh")?.held, true, "the abandoned branch is not on the resumed path");
+	assert.equal(recordBilledThinking(ledger, astraRoute, change({ lastCallLevel: "high", currentLevel: "medium" }))?.held, true,
+		"medium was last billed beyond the longest retention");
+
+	rememberBilledEfforts(new Map(), entries, null, model, now);
+	rememberBilledEfforts(new Map(), entries, "a4", undefined, now);
 });

--- a/tests/contract/pi-cache-retention-seams.test.ts
+++ b/tests/contract/pi-cache-retention-seams.test.ts
@@ -144,6 +144,27 @@ test("Pi 0.85.1 changes Astra request-level effort instead of appending an updat
   assert.doesNotMatch(codex, /configuration_update/);
 });
 
+// Cachemire reads the request at its own hook position. Pi runs before_provider_request
+// per extension in load order and threads each replacement payload into later handlers
+// only, so a later-loaded rewrite (for example an append-only configuration_update for
+// Astra) is invisible to Cachemire: the billed usage, not the payload, is the verdict.
+test("Pi threads before_provider_request replacements through later extensions in load order", () => {
+  const runner = readFileSync(join(piRoot, "dist", "core", "extensions", "runner.js"), "utf8");
+  const emit = runner.match(/async emitBeforeProviderRequest\(payload\) \{[\s\S]*?\n {4}\}\n/)?.[0];
+  assert.ok(emit, "emitBeforeProviderRequest moved: re-verify Cachemire's evidence model against the new hook order");
+  assert.match(emit, /for \(const ext of this\.extensions\) \{\s*const handlers = ext\.handlers\.get\("before_provider_request"\)/);
+  assert.match(emit, /payload: currentPayload,/);
+  assert.match(emit, /if \(handlerResult !== undefined\) \{\s*currentPayload = handlerResult;/);
+});
+
+// A resumed session seeds the route's billed efforts from Pi's persisted level changes.
+test("Pi persists thinking level changes as session entries Cachemire can replay", () => {
+  const declarations = readFileSync(join(piRoot, "dist", "core", "session-manager.d.ts"), "utf8");
+  assert.match(declarations, /interface SessionEntryBase \{\s*type: string;\s*id: string;\s*parentId: string \| null;\s*timestamp: string;/);
+  assert.match(declarations, /interface ThinkingLevelChangeEntry extends SessionEntryBase \{\s*type: "thinking_level_change";\s*thinkingLevel: string;/);
+  assert.match(declarations, /appendThinkingLevelChange\(thinkingLevel: string\): string;/);
+});
+
 test("installed provider records keep Cachemire's new routes exact", () => {
   for (const [file, api, model, provider] of [
     ["minimax.json", "anthropic-messages", "MiniMax-M2.7", "minimax"],


### PR DESCRIPTION
## Why

Cachemire reads a request at its own `before_provider_request` position. Pi runs that hook per extension in load order and threads a replacement payload only into later handlers (pinned by a new contract test), so a later-loaded extension such as `pi-codex-conversion`'s append-only `configuration_update` for GPT-6 Astra is invisible to it. Cachemire warned about breaks that never came.

## What

- **The bill outranks the payload.** Per route (provider/api/model), process-scoped, the most recent billed effort-to-effort verdict decides the expectation. A hit on an effort the route has never billed silences the stale clock and in-flight claim for later changes there, and says so once: `cache held · read 10.4k of 10.5k expected · effort low → high kept the prefix warm on this route`. A miss the payload attributed to thinking, with no closed window to blame, reinstates them.
- **A hit on a previously billed effort proves nothing.** Live stock Pi on Astra: `low→high` miss, `high→medium` miss, then `medium→high` hit because the `high` entry was still warm (per-effort cache, not neutrality). A resumed session seeds those efforts from Pi's persisted `thinking_level_change` entries within the longest known retention (24h).
- On/off toggles stay material; the payload diff still names the wire change on a miss; `/cache` hit rows name the change (`hit — effort low → high kept the prefix`).
- `predictBreak` + economics helpers move to `extensions/pi-cachemire/economics.ts` (index.ts line budget).
- Docs: design language §7, `docs/pi-cachemire.md`, README, audit addendum with the live results, CHANGELOG.

## Verification

- `npm run check`: lint clean, typecheck clean, 382 tests (new: hosted event flows for an Anthropic contract route and Astra; unit coverage for verdicts, precedence, resume seeding; contract pins for the runner hook order and session entry shape).
- Live E2E, real `pi` 0.85.1 TUI in an isolated HOME with real tool calls on `openai-codex/gpt-6-astra` (~10.5k-token prompt), all on this revision's code:
  - Cachemire loaded before `pi-codex-conversion` (live order): held line printed once on `low→high`, `high→medium` silent, ledger names both. Twice.
  - Cachemire loaded after it: same; one run billed a genuine provider-side miss reported as `cause: unknown` and left the verdict alone.
  - Stock Pi: both misses named `thinking changed`; the `medium→high` return is a plain `hit`, no false verdict.
  - `--continue` resume: no false evidence (miss with `unknown` cause, no restored fingerprint to blame thinking).
