### PR TITLE
fix(cachemire): close four holes in thinking-effort evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
   the last 24 hours. On/off toggles stay material.
   The `/cache` ledger names the change on hit rows. `predictBreak` and the session
   economics helpers moved to `extensions/pi-cachemire/economics.ts`.
+  Review follow-up: a miss counts against a route only while the previous window
+  still promised a warm entry (a reached Anthropic TTL, a passed OpenAI 30-minute
+  minimum, any maximum or unknown window means eviction explains it as well, and the
+  resolved cause now says `(also 30m minimum passed)`); a contract-neutral Anthropic
+  route (Claude Fable 5.1) now names the effort change on a miss instead of `unknown`,
+  so the bill can overrule the contract there too; and the level a change is measured
+  from, plus the efforts already billed, come from the active path's persisted entries
+  on start and on every branch switch, since Pi restores neither on `/tree`.
 - Development: the repo now lints with Oxlint and a vendored copy of
   [anti-slop](https://github.com/dmmulroy/anti-slop) (`tools/oxlint/anti-slop`,
   `.oxlintrc.json`), fed into the existing agent-lint baseline as shrink-only debt.

--- a/docs/cache-thinking-change-audit-2026-09-10.md
+++ b/docs/cache-thinking-change-audit-2026-09-10.md
@@ -137,6 +137,38 @@ calls on `openai-codex/gpt-6-astra` and a ~10.5k-token prompt:
   effort neutrality: it is why a hit counts as evidence only on an effort the route
   has never billed before
 
+### Review follow-up, same day
+
+An independent review of the merged change found four holes in the evidence rules,
+all confirmed in code and closed together:
+
+- on a contract-neutral Anthropic route the cache-key diff withheld the effort change
+  (so that lineage keeps one prefix across efforts), which also kept it out of the
+  resolved cause: a miss there read `cause: unknown` and could never record that the
+  route breaks. The withheld change is now named after the fact, so the resolved
+  cause and the verdict see it while lineage and the in-flight claim still do not
+- a miss counted against a route unless a contract TTL or a maximum had provably
+  closed. OpenAI routes carry a 30-minute minimum or an unknown window, which never
+  "close", so a miss after hours idle was booked as proof that the effort change
+  broke the cache. The rule is now the inverse: a miss counts only while the previous
+  window still promised a warm entry (contract inside its TTL, minimum or bounded
+  inside its floor). The resolved cause shares the blame with a passed minimum
+- the level a change was measured from came from Pi's current level at session start
+  and was never touched on a branch switch. Pi restores the level on resume but not on
+  `/tree`, and `--thinking` on `--continue` overrides it, so the recorded pair could
+  be `medium → high` while the wire went `high → high`. The active path's last billed
+  call now supplies it, on start and on every `session_tree`
+- the billed-effort seed ran only at start on the path of that moment, so a sibling
+  branch billed at some effort in an earlier process was not seeded; navigating there
+  and returning to that effort hit its own warm entry and read as fresh evidence. The
+  seed now runs on every path change. A hit served by another session's identical
+  prefix stays indistinguishable and is accepted as a residual
+
+Each is pinned by a hosted test that fails against the merged revision. Live
+regression on the positive Astra scenario (Cachemire before `pi-codex-conversion`)
+reproduced the earlier result; the negative paths cannot be forced on a real provider
+and stay hosted.
+
 ## Sources
 
 - OpenAI, [Reasoning models](https://developers.openai.com/api/docs/guides/reasoning),

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -250,13 +250,18 @@ Anomaly thresholds tint the quantity suffix or the glyph, never the body:
   the route's expectation for the rest of the process: a hit on an effort the route
   has never billed before silences the stale clock and the in-flight claim for later
   changes on the exact provider, API and model; a miss the payload attributed to
-  thinking, with no closed window to blame, reinstates them. A hit on an effort
-  billed earlier proves nothing: providers keep an entry per effort, and a return
-  within retention reads that entry back. The first hit that contradicts an expected
-  break says so once (`cache held · … · effort low → high kept the prefix warm on
-  this route`); an expected hit earns no line. Evidence never softens an on/off
-  toggle, and the payload diff still names the wire change when a miss follows, so
-  nothing is learned silently
+  thinking, while the previous window still promised a warm entry, reinstates them.
+  A hit on an effort billed earlier proves nothing: providers keep an entry per
+  effort, and a return within retention reads that entry back. A miss after the
+  window stopped vouching (a reached TTL, a passed minimum, any maximum or unknown)
+  proves nothing either: eviction explains it as well. Measure the change from the
+  level the active path's last call was billed at, and count the efforts that path
+  billed, on every path change, since Pi restores neither on a branch switch. The
+  first hit that contradicts an expected break says so once (`cache held · … ·
+  effort low → high kept the prefix warm on this route`); an expected hit earns no
+  line. Evidence never softens an on/off toggle, and the wire change is always
+  named when a miss follows, even where the contract withheld it from the cache-key
+  diff, so nothing is learned silently
 
 ## 8. Panels
 

--- a/docs/pi-cachemire.md
+++ b/docs/pi-cachemire.md
@@ -140,10 +140,14 @@ route (provider, API and model), for the rest of the Pi process:
   own entry back: stock Pi on Astra missed on `low → high` and `high → medium`, then
   hit on `medium → high` because the `high` entry was still warm. Cachemire counts
   the hit and leaves the verdict alone
-- a miss or partial that the payload diff attributed to thinking, with no closed
-  retention window to blame, records that the route breaks, and reinstates both
-- a miss with another named cause, or after a closed window, proves nothing about
-  effort and leaves the verdict alone
+- a miss or partial that the payload diff attributed to thinking, while the previous
+  window still promised a warm entry (an Anthropic TTL not yet reached, an OpenAI
+  30-minute minimum not yet passed), records that the route breaks, and reinstates both
+- a miss with another named cause, or once the window stopped vouching for warmth,
+  proves nothing about effort and leaves the verdict alone. A maximum never vouches,
+  and neither does an unknown window: ordinary eviction explains such a miss as well
+  as the effort change does, and the resolved cause says so
+  (`thinking changed (effort high → effort medium) (also 30m minimum passed)`)
 
 The first hit that contradicts an expected break says so once:
 
@@ -153,17 +157,24 @@ The first hit that contradicts an expected break says so once:
 
 An expected hit earns no line, and the `/cache` ledger row reads
 `hit — effort low → high kept the prefix`. Evidence never softens turning thinking on <!-- agent-lint-disable-line POG007 -->
-or off, which stays a distinct mutation. The payload diff still names the wire change
-when a miss follows, so a route that stops holding (for example after the rewriting
-extension is disabled) corrects itself on the next billed change rather than staying
-quietly wrong.
+or off, which stays a distinct mutation. The wire change is always named when a miss
+follows, so a route that stops holding (for example after the rewriting extension is
+disabled) corrects itself on the next billed change rather than staying quietly wrong.
+On a contract-neutral route the cache-key diff withholds the effort change, so that
+lineage keeps treating requests at different efforts as one prefix and the in-flight
+claim stays silent; the resolved cause still names it, and a billed miss charges it.
 
 Verdicts live in the process, not the session: the behaviour belongs to the provider
 and extension stack, so `/new`, `/resume` and `/reload` keep them and a fresh `pi`
-starts without any. A resumed session still tells which efforts its history billed on
-the active path within the longest known retention (24 hours, OpenAI extended), read
-from Pi's persisted thinking-level entries, so a return to one of them in the new
-process is not mistaken for fresh evidence.
+starts without any. The active path still says two things a process cannot know on its
+own, read from Pi's persisted thinking-level entries whenever the path changes (start,
+resume, and every branch switch, since Pi restores neither on a switch): which efforts
+were billed there within the longest known retention (24 hours, OpenAI extended), so a
+return to one of them is not mistaken for fresh evidence, and the level its last call
+was billed at, which the next change is measured from. The level Pi is holding can
+differ from that after a late change before quitting, a `--thinking` flag on resume, or
+a branch switch. A hit served by another session's identical prefix remains
+indistinguishable from this session's own and is accepted as such.
 
 Unknown routes get no retention-based prediction. If billed usage later proves a miss,
 Cachemire can report an observed payload mutation. A miss without such evidence keeps an

--- a/extensions/pi-cachemire/README.md
+++ b/extensions/pi-cachemire/README.md
@@ -74,8 +74,12 @@ The bill outranks the payload. A later-loaded extension can rewrite the request 
 Cachemire has read it, so the billed effort changes on a route decide what Cachemire
 expects from that route for the rest of the process. A hit on an effort the route has
 never billed before says so once and silences later warnings on that route; a miss that
-the payload attributed to thinking reinstates them. Returning to an effort billed
-earlier proves nothing either way, because providers keep a warm entry per effort:
+the payload attributed to thinking, while the window still promised a warm entry,
+reinstates them. Returning to an effort billed earlier proves nothing either way,
+because providers keep a warm entry per effort, and a miss after the window stopped
+vouching proves nothing either, because eviction explains it just as well. The path
+Cachemire is on decides what a change is measured from, at start and on every branch
+switch:
 
 ```
 ◍ cache held · read 29.8k of 30.0k expected · effort low → high kept the prefix warm on this route

--- a/extensions/pi-cachemire/classify.ts
+++ b/extensions/pi-cachemire/classify.ts
@@ -26,6 +26,16 @@ export function pastWindow(window: CacheWindow | undefined, gapMs: number | unde
   return false;
 }
 
+/** The window still promised a warm entry after this idle gap: a contract inside its
+ * TTL, or a minimum (or bounded) retention inside its floor. A maximum promises nothing
+ * before it, and an unknown window nothing at all. */
+export function withinWarmPromise(window: CacheWindow | undefined, gapMs: number | undefined): boolean {
+  if (!window || gapMs === undefined) return false;
+  if (window.kind === "contract") return gapMs < window.ttlMs;
+  if (window.kind === "minimum" || window.kind === "bounded") return gapMs < window.minMs;
+  return false;
+}
+
 // Shared cause wording for predictions and resolved classifications.
 export function expiryCause(window: CacheWindow | undefined, gapMs: number | undefined): CallCause | undefined {
   if (!window || gapMs === undefined) return undefined;
@@ -150,6 +160,24 @@ function isEffortThinking(value: string | undefined): boolean {
   return value?.startsWith("thinking effort ") === true;
 }
 
+function thinkingCause(prev: RequestFingerprint, cur: RequestFingerprint): CallCause {
+  return { kind: "thinking", detail: `thinking changed (${prev.thinking ?? "?"} \u2192 ${cur.thinking ?? "?"})` };
+}
+
+/**
+ * The effort change the cache-key diff withheld because the route's contract calls it
+ * neutral. Lineage keeps treating such requests as one prefix; the resolved cause must
+ * still name the change, or a miss on that route could never charge it and the bill
+ * would never outrank the contract.
+ */
+export function withheldThinkingCause(
+  prev: RequestFingerprint | undefined,
+  cur: RequestFingerprint,
+): CallCause | undefined {
+  if (!prev || prev.thinking === cur.thinking || cur.thinkingCacheNeutral !== true) return undefined;
+  return isEffortThinking(prev.thinking) && isEffortThinking(cur.thinking) ? thinkingCause(prev, cur) : undefined;
+}
+
 // --- forensics: name the first divergent prefix segment --------------------------------
 
 export function diffFingerprints(prev: RequestFingerprint, cur: RequestFingerprint): CallCause | undefined {
@@ -180,9 +208,7 @@ export function diffFingerprints(prev: RequestFingerprint, cur: RequestFingerpri
   // drags along (e.g. thinking blocks stripped on disable) is a side effect.
   const cacheSafeEffortChange = cur.thinkingCacheNeutral === true &&
     isEffortThinking(prev.thinking) && isEffortThinking(cur.thinking);
-  if (prev.thinking !== cur.thinking && !cacheSafeEffortChange) {
-    return { kind: "thinking", detail: `thinking changed (${prev.thinking ?? "?"} \u2192 ${cur.thinking ?? "?"})` };
-  }
+  if (prev.thinking !== cur.thinking && !cacheSafeEffortChange) return thinkingCause(prev, cur);
   // History: the previous request's messages must be a prefix of the current ones.
   const checkable = Math.min(prev.messageHashes.length, cur.messageHashes.length);
   for (let i = 0; i < checkable; i++) {
@@ -232,12 +258,16 @@ export function classifyCall(args: ClassifyInput): CallClassification {
   if (args.compacted) {
     cause = { kind: "compaction", detail: "compaction rewrote history" };
   } else if (args.fingerprintCause) {
-    const expiry = args.window?.kind === "maximum" || args.window?.kind === "bounded"
-      ? "retention maximum reached"
-      : "TTL reached";
-    cause = pastWindow(args.window, args.gapMs)
-      ? { ...args.fingerprintCause, detail: `${args.fingerprintCause.detail} (also ${expiry})` }
-      : args.fingerprintCause;
+    // A window that no longer vouches for warmth shares the blame: a reached contract
+    // or maximum, or a minimum floor passed (which proves nothing either way).
+    const lapse = pastWindow(args.window, args.gapMs)
+      ? args.window?.kind === "maximum" || args.window?.kind === "bounded" ? "retention maximum reached" : "TTL reached"
+      : (args.window?.kind === "minimum" || args.window?.kind === "bounded") && !withinWarmPromise(args.window, args.gapMs)
+        ? `${formatDuration(args.window.minMs)} minimum passed`
+        : undefined;
+    cause = lapse === undefined
+      ? args.fingerprintCause
+      : { ...args.fingerprintCause, detail: `${args.fingerprintCause.detail} (also ${lapse})` };
   } else if (idleCause) {
     cause = idleCause;
   } else {

--- a/extensions/pi-cachemire/index.ts
+++ b/extensions/pi-cachemire/index.ts
@@ -14,7 +14,14 @@ import {
 import { configPaths, readJsonConfig } from "../_lib/config.ts";
 import { compactCount, formatDuration, formatUsd } from "../_lib/fmt.ts";
 import { GLYPH, SCALE, SEP, ink, panelHeader, type Tone } from "../_lib/style.ts";
-import { classifyCall, diffFingerprints, fingerprintPayload, pastWindow } from "./classify.ts";
+import {
+  classifyCall,
+  diffFingerprints,
+  fingerprintPayload,
+  pastWindow,
+  withheldThinkingCause,
+  withinWarmPromise,
+} from "./classify.ts";
 import { UNKNOWN_WINDOW, cacheClock, nextClockUpdateMs, withinWarmHorizon } from "./clock.ts";
 import { predictBreak, rewriteCostUsd, sessionSavings, uncachedCostUsd } from "./economics.ts";
 import { activeToolDefinitions, computeSwitchForecast, type SwitchForecast, type SwitchTarget } from "./forecast.ts";
@@ -38,7 +45,7 @@ import {
 } from "./retention.ts";
 import {
   recordBilledThinking,
-  rememberBilledEfforts,
+  restoreBilledThinking,
   thinkingChangeInvalidatesCache,
   thinkingChangesPreserveCache,
   type ThinkingEvidenceLedger,
@@ -350,6 +357,31 @@ export default function piCachemire(pi: ExtensionAPI): void {
   const ownerToken = Symbol("pi-cachemire-owner");
   const ownsState = () => g.__piCachemireOwner === ownerToken;
 
+  // Material only when a warm prefix exists to break AND the current level changes the
+  // wire params for this model against the level its last call was billed at; cycling
+  // back before the next call revives the cache. Routes whose contract or billed
+  // evidence keeps the prefix stay neutral.
+  const markThinkingChange = (model: ExtensionContext["model"]) => {
+    s.thinkingChanged = s.expectedRead > 0 && model?.reasoning === true &&
+      thinkingChangeInvalidatesCache(
+        thinkingRoute(model),
+        model.thinkingLevelMap,
+        s.lastCallThinkingLevel,
+        s.currentThinkingLevel,
+        s.thinkingEvidence,
+      );
+  };
+
+  // The active path decides what the next effort change is measured from: the level
+  // its last billed call used, not the level Pi is holding now, which differs after a
+  // late change before quitting, a --thinking flag on resume, or a branch switch.
+  const restoreThinkingForPath = (ctx: ExtensionContext, entries: readonly unknown[], leafId: string | null) => {
+    const lastBilledLevel = restoreBilledThinking(s.thinkingEvidence, entries, leafId, ctx.model, Date.now());
+    s.currentThinkingLevel = pi.getThinkingLevel();
+    s.lastCallThinkingLevel = lastBilledLevel ?? s.currentThinkingLevel;
+    markThinkingChange(ctx.model);
+  };
+
   pi.on("session_start", async (event, ctx) => {
     if (!ctx.hasUI) return;
     if (g.__piCachemireOwner !== undefined && !ownsState()) return;
@@ -374,12 +406,12 @@ export default function piCachemire(pi: ExtensionAPI): void {
     // A restored branch can already be mid-switch (billed by a different model than the
     // current one); the forecast must exist before the first widget render.
     refreshSwitchForecast(pi, ctx, ctx.sessionManager.getLeafId(), model);
-    s.lastCallThinkingLevel = s.currentThinkingLevel = pi.getThinkingLevel();
     // Route evidence belongs to the process (provider and extension stack), not the
-    // session; a resumed session still tells which efforts may hold a warm entry.
+    // session; a resumed path still tells which efforts may hold a warm entry and what
+    // its last call was billed at.
     // SAFETY: a reload re-imports this file over the global state of the version it replaces.
     if (event.reason === "startup" || !s.thinkingEvidence) s.thinkingEvidence = new Map();
-    rememberBilledEfforts(s.thinkingEvidence, entries, ctx.sessionManager.getLeafId(), model, Date.now());
+    restoreThinkingForPath(ctx, entries, ctx.sessionManager.getLeafId());
     s.compacted = false;
     s.inCompaction = false;
     s.pendingFingerprint = undefined;
@@ -423,7 +455,8 @@ export default function piCachemire(pi: ExtensionAPI): void {
       resolution,
       { provider: ctx.model?.provider, model: ctx.model?.id ?? s.pendingFingerprint.model, api: ctx.model?.api },
     ));
-    s.pendingFingerprintCause = resolution.cause;
+    s.pendingFingerprintCause = resolution.cause ??
+      withheldThinkingCause(resolution.baseline?.fingerprint, s.pendingFingerprint);
     s.pendingRequestLeafId = ctx.sessionManager.getLeafId();
     if (firstAttempt) {
       s.pendingPreviousRequestAt = s.lastRequestAt;
@@ -501,17 +534,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     // call so far used — a baseline that needs no session_start timing assumptions.
     s.lastCallThinkingLevel ??= event.previousLevel;
     s.currentThinkingLevel = event.level;
-    // Material only when something was billed at the old level AND the new level changes
-    // the wire params for this model; cycling back before the next call revives the
-    // cache. Routes whose contract or billed evidence keeps the prefix stay neutral.
-    s.thinkingChanged = s.records.length > 0 && ctx.model?.reasoning === true &&
-      thinkingChangeInvalidatesCache(
-        thinkingRoute(ctx.model),
-        ctx.model.thinkingLevelMap,
-        s.lastCallThinkingLevel,
-        event.level,
-        s.thinkingEvidence,
-      );
+    markThinkingChange(ctx.model);
     updateWidget();
   });
 
@@ -541,6 +564,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
     ));
     // Checking out a branch billed by another model is a switch in lineage terms.
     refreshSwitchForecast(pi, ctx, event.newLeafId, ctx.model);
+    restoreThinkingForPath(ctx, entries, event.newLeafId);
     updateWidget();
   });
 
@@ -592,7 +616,7 @@ export default function piCachemire(pi: ExtensionAPI): void {
       incomparable: s.modelSwitched || s.compacted || s.inCompaction,
       classification,
       thinkingNamedAtSend: fingerprintCause?.kind === "thinking",
-      windowExpired: pastWindow(s.pendingPreviousWindow ?? s.window, cacheGapMs),
+      warmPromised: withinWarmPromise(s.pendingPreviousWindow ?? s.window, cacheGapMs),
       usage,
       expectedRead: s.expectedRead,
     });

--- a/extensions/pi-cachemire/thinking.ts
+++ b/extensions/pi-cachemire/thinking.ts
@@ -115,8 +115,9 @@ export interface BilledThinkingChange {
 	classification: CallClassification;
 	/** Send-time forensics named the thinking wire change as the first divergence. */
 	thinkingNamedAtSend: boolean;
-	/** A retention window also closed, so a miss proves nothing about effort. */
-	windowExpired: boolean;
+	/** The previous window still promised a warm entry at request time; without that
+	 * promise a miss may be ordinary expiry and proves nothing about effort. */
+	warmPromised: boolean;
 	usage: UsageLike;
 	expectedRead: number;
 }
@@ -126,9 +127,9 @@ export interface BilledThinkingChange {
  * on an effort the route has never billed before is evidence that the route keeps its
  * prefix: a hit on a previously billed effort proves nothing, because providers keep a
  * cache entry per effort and a return within retention reads that entry back. A miss
- * counts against the route only when the payload showed the effort change and nothing
- * else (expiry, another named mutation) explains it. Turning thinking on or off stays
- * a distinct mutation and never produces evidence.
+ * counts against the route only when the payload showed the effort change, nothing
+ * else was named, and the window still promised a warm entry. Turning thinking on or
+ * off stays a distinct mutation and never produces evidence.
  */
 export function recordBilledThinking(
 	ledger: ThinkingEvidenceLedger,
@@ -150,18 +151,20 @@ export function recordBilledThinking(
 export const EFFORT_MEMORY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Seeds the active route with the efforts a resumed session billed recently, walking
- * Pi's persisted `thinking_level_change` entries along the active path, so a return to
- * one of them in this process is not mistaken for fresh evidence.
+ * Replays the active path's persisted `thinking_level_change` entries: seeds the route
+ * with the efforts billed there recently, so a return to one of them in this process is
+ * not mistaken for fresh evidence, and returns the level the path's last billed call
+ * used, which is what the next call's effort change is measured from. Pi restores
+ * neither on a branch switch, so this runs on every path change, not only at start.
  */
-export function rememberBilledEfforts(
+export function restoreBilledThinking(
 	ledger: ThinkingEvidenceLedger,
 	entries: readonly unknown[],
 	leafId: string | null,
 	model: ExtensionContext["model"],
 	now: number,
-): void {
-	if (!model || leafId === null) return;
+): string | undefined {
+	if (!model || leafId === null) return undefined;
 	const route = routeOf(model);
 	const byId = new Map<string, JsonFields>();
 	for (const entry of entries) {
@@ -175,18 +178,21 @@ export function rememberBilledEfforts(
 	}
 	const record = routeRecord(ledger, route);
 	let level: string | undefined;
+	let lastBilledLevel: string | undefined;
 	for (const entry of path.reverse()) {
 		if (entry.type === "thinking_level_change") {
 			level = stringValue(entry.thinkingLevel);
 			continue;
 		}
 		if (entry.type !== "message" || !isJsonObject(entry.message) || entry.message.role !== "assistant") continue;
+		lastBilledLevel = level;
 		const { message } = entry;
 		if (message.provider !== route.provider || message.api !== route.api || message.model !== route.model) continue;
 		const at = nonNegativeNumberValue(message.timestamp);
 		if (level === undefined || at === undefined || now - at > EFFORT_MEMORY_MS) continue;
 		record.billedEfforts.add(wireThinkingEffort(model.thinkingLevelMap, level));
 	}
+	return lastBilledLevel;
 }
 
 function thinkingVerdict(
@@ -202,5 +208,5 @@ function thinkingVerdict(
 	const verdict = { from, to, cacheRead: change.usage.cacheRead, expectedRead: change.expectedRead };
 	if (change.classification.kind === "hit") return billedEfforts.has(to) ? undefined : { ...verdict, held: true };
 	if (change.classification.kind === "cold") return undefined;
-	return change.thinkingNamedAtSend && !change.windowExpired ? { ...verdict, held: false } : undefined;
+	return change.thinkingNamedAtSend && change.warmPromised ? { ...verdict, held: false } : undefined;
 }

--- a/scripts/dev/agent-lint-baseline.json
+++ b/scripts/dev/agent-lint-baseline.json
@@ -322,7 +322,7 @@
   "lineBudgets": {
     "defaultTsMax": 350,
     "files": {
-      "extensions/pi-cachemire/index.ts": 757,
+      "extensions/pi-cachemire/index.ts": 781,
       "extensions/pi-contextimate/index.ts": 1483,
       "extensions/pi-traceline/index.ts": 1677,
       "tests/contract/pi-internals.test.ts": 355,

--- a/tests/cachemire/thinking-events.test.ts
+++ b/tests/cachemire/thinking-events.test.ts
@@ -1,6 +1,7 @@
-import { test } from "node:test";
+import { mock, test } from "node:test";
 import assert from "node:assert/strict";
 import type { AssistantMessage, Model, ThinkingLevel } from "@earendil-works/pi-ai";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
 
 import piCachemire from "../../extensions/pi-cachemire/index.ts";
 import { hostExtension, IsolatedProject } from "../harness/extension-host.ts";
@@ -222,6 +223,116 @@ test("GPT-6 Astra: the usage decides, and only a fresh effort can prove the rout
 		assert.match(ledger, /\u25cc miss \u2014 thinking changed \(effort high \u2192 effort medium\)/);
 		assert.match(ledger, /\u25cf hit \u2014 effort high \u2192 xhigh kept the prefix/);
 		assert.equal((ledger.match(/\u25cf hit \u2014/g) ?? []).length, 1, "only the fresh-effort hit names the change");
+	} finally {
+		await host.dispose();
+		project.dispose();
+	}
+});
+
+test("a billed miss on a contract-neutral route names the effort change and charges the route", async () => {
+	const project = new IsolatedProject();
+	const host = await hostExtension(piCachemire, { project, model: fable, thinkingLevel: "low" });
+	const runner = host.session.extensionRunner;
+	const notices = host.ui.notifications;
+	try {
+		await call(host, anthropicPayload(fable, "low", ["first"]), billed(fable, { input: 2, cacheRead: 0, cacheWrite: 100_000 }));
+		host.session.setThinkingLevel("high");
+		assert.equal(host.ui.widgetLines("pi-cachemire"), undefined, "the contract calls the change neutral: no claim");
+
+		// The cache-key diff withheld the change (lineage keeps one prefix), and the contract
+		// silenced the in-flight claim; the bill still says miss, so the change is charged.
+		await call(host, anthropicPayload(fable, "high", ["first", "second"]), billed(fable, { input: 2, cacheRead: 0, cacheWrite: 101_000 }));
+		assert.equal(notices.length, 1, "no in-flight claim on a contract-neutral route");
+		assert.match(notices[0]!, /^\u25cd cache broke .* cause: thinking changed \(thinking effort low \u2192 thinking effort high\)$/);
+
+		// The verdict now outranks the contract: the next change is material end to end.
+		host.session.setThinkingLevel("low");
+		assert.match(host.ui.widgetLines("pi-cachemire")?.join("\n") ?? "", /thinking level changed/, "a billed miss overrides the contract");
+		host.session.sessionManager.appendMessage({ role: "user", content: "third", timestamp: Date.now() });
+		await runner.emitBeforeProviderRequest(anthropicPayload(fable, "low", ["first", "second", "third"]));
+		assert.equal(notices.length, 2);
+		assert.match(notices[1]!, /^\u25cd cache breaking .* cause: thinking changed \(thinking effort high \u2192 thinking effort low\)$/);
+		const back = billed(fable, { input: 200, cacheRead: 101_000, cacheWrite: 300 });
+		await runner.emitMessageEnd({ type: "message_end", message: back });
+		host.session.sessionManager.appendMessage(back);
+		assert.equal(notices.length, 2, "the claim resolves in place; a hit on a billed effort adds nothing");
+		host.session.setThinkingLevel("high");
+		assert.match(host.ui.widgetLines("pi-cachemire")?.join("\n") ?? "", /thinking level changed/, "low was billed before: that hit is not a fresh verdict");
+	} finally {
+		await host.dispose();
+		project.dispose();
+	}
+});
+
+test("GPT-6 Astra: a miss after the retention floor is expiry, not evidence against a route that held", async () => {
+	mock.timers.enable({ apis: ["Date"], now: Date.now() });
+	const project = new IsolatedProject();
+	const host = await hostExtension(piCachemire, { project, model: astra, thinkingLevel: "low" });
+	const notices = host.ui.notifications;
+	const turns = ["first"];
+	const change = async (level: ThinkingLevel, usage: { input: number; cacheRead: number }) => {
+		host.session.setThinkingLevel(level);
+		turns.push(level);
+		await call(host, astraPayload(level, turns), billed(astra, { ...usage, cacheWrite: 0 }));
+	};
+	try {
+		await call(host, astraPayload("low", turns), billed(astra, { input: 30_000, cacheRead: 0, cacheWrite: 0 }));
+		await change("high", { input: 400, cacheRead: 29_800 });
+		assert.equal(notices.length, 1);
+		assert.match(notices[0]!, /^\u25cd cache held .* effort low \u2192 high kept the prefix warm on this route$/);
+
+		// Three hours idle: the 30-minute minimum stopped vouching for the entry long ago.
+		// The payload diff still names the effort change, the lapse shares the blame, and
+		// the verdict is left alone.
+		mock.timers.tick(3 * 60 * 60 * 1000);
+		await change("medium", { input: 30_800, cacheRead: 0 });
+		assert.equal(notices.length, 2);
+		assert.match(notices[1]!, /^\u25cd cache broke .* cause: thinking changed \(effort high \u2192 effort medium\) \(also 30m minimum passed\)$/);
+
+		// Still held: a fresh-effort hit is expected and earns no line.
+		await change("xhigh", { input: 400, cacheRead: 30_600 });
+		assert.equal(notices.length, 2, "an unproven miss must not reinstate the expectation");
+	} finally {
+		mock.timers.reset();
+		await host.dispose();
+		project.dispose();
+	}
+});
+
+test("a branch switch measures the next effort change from that branch's last billed call", async () => {
+	const project = new IsolatedProject();
+	// A session file from an earlier process: one turn at low, then two sibling branches,
+	// A billed at high and B (the leaf being resumed) billed at low.
+	const history = SessionManager.inMemory(project.dir);
+	const now = Date.now();
+	const turn = (text: string, level: string, prompt: number, at: number) => {
+		history.appendMessage({ role: "user", content: text, timestamp: at - 1_000 });
+		const message = { ...billed(astra, { input: prompt, cacheRead: 0, cacheWrite: 0 }), timestamp: at };
+		history.appendMessage(message);
+		return { id: history.getLeafId()!, level, prompt };
+	};
+	history.appendThinkingLevelChange("low");
+	const root = turn("first", "low", 20_000, now - 3_000_000);
+	history.appendThinkingLevelChange("high");
+	const branchA = turn("second (A)", "high", 30_000, now - 2_000_000);
+	history.branch(root.id);
+	turn("second (B)", "low", 30_500, now - 1_000_000);
+
+	// pi --continue: a fresh process (startup) opening the file at branch B's leaf.
+	const host = await hostExtension(piCachemire, { project, model: astra, sessionManager: history });
+	const notices = host.ui.notifications;
+	try {
+		assert.equal(host.session.thinkingLevel, "low", "Pi restores the resumed branch's level");
+		await host.session.navigateTree(branchA.id);
+		assert.equal(host.session.thinkingLevel, "low", "Pi does not restore the level on a branch switch");
+
+		// Cachemire does: branch A was last billed at high, so returning to high is no
+		// change on the wire. The hit reads A's own entry back and proves nothing.
+		host.session.setThinkingLevel("high");
+		await call(host, astraPayload("high", ["first", "second (A)", "third"]), billed(astra, { input: 400, cacheRead: 29_900, cacheWrite: 0 }));
+		assert.deepEqual(notices, [], "a return to the branch's billed effort is not a fresh-effort verdict");
+		await host.session.prompt("/cache");
+		assert.doesNotMatch(notices.at(-1)!, /kept the prefix/);
 	} finally {
 		await host.dispose();
 		project.dispose();

--- a/tests/cachemire/thinking.test.ts
+++ b/tests/cachemire/thinking.test.ts
@@ -2,13 +2,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { Model } from "@earendil-works/pi-ai";
 
-import { diffFingerprints, fingerprintPayload } from "../../extensions/pi-cachemire/classify.ts";
+import { diffFingerprints, fingerprintPayload, withheldThinkingCause, withinWarmPromise } from "../../extensions/pi-cachemire/classify.ts";
 import { OPENAI_EXTENDED_WINDOW } from "../../extensions/pi-cachemire/retention.ts";
 import {
 	type BilledThinkingChange,
 	EFFORT_MEMORY_MS,
 	recordBilledThinking,
-	rememberBilledEfforts,
+	restoreBilledThinking,
 	thinkingChangeInvalidatesCache,
 	thinkingChangesPreserveCache,
 	type ThinkingEvidenceLedger,
@@ -160,7 +160,7 @@ const change = (overrides: Partial<BilledThinkingChange>): BilledThinkingChange 
 	incomparable: false,
 	classification: { kind: "hit" },
 	thinkingNamedAtSend: true,
-	windowExpired: false,
+	warmPromised: true,
 	...bill(29_800),
 	...overrides,
 });
@@ -184,10 +184,10 @@ test("a billed hit on a fresh effort, or an attributable miss, is evidence; noth
 	assert.equal(observe({}, ["low", "high", "medium"]), undefined);
 	assert.equal(observe({ classification: miss, ...bill(0) }, ["low", "high"])?.held, false, "a miss counts regardless");
 
-	// A miss the payload did not attribute to thinking, or that a closed window
-	// explains, says nothing about the route.
+	// A miss the payload did not attribute to thinking, or that arrived after the window
+	// stopped vouching for warmth (ordinary expiry explains it), says nothing about the route.
 	assert.equal(observe({ classification: miss, thinkingNamedAtSend: false, ...bill(0) }), undefined);
-	assert.equal(observe({ classification: miss, windowExpired: true, ...bill(0) }), undefined);
+	assert.equal(observe({ classification: miss, warmPromised: false, ...bill(0) }), undefined);
 	// A hit reads the prefix back even when the payload diff saw nothing: still evidence.
 	assert.equal(observe({ thinkingNamedAtSend: false })?.held, true);
 
@@ -234,6 +234,41 @@ test("the most recent billed verdict on the exact route outranks the contract ei
 	assert.equal(thinkingChangesPreserveCache(flagged, ledger), true);
 });
 
+test("only a window still vouching for warmth lets a miss count against a route", () => {
+	const minute = 60_000;
+	assert.equal(withinWarmPromise({ kind: "contract", ttlMs: 5 * minute, source: "observed" }, 4 * minute), true);
+	assert.equal(withinWarmPromise({ kind: "contract", ttlMs: 5 * minute, source: "observed" }, 5 * minute), false);
+	assert.equal(withinWarmPromise({ kind: "minimum", minMs: 30 * minute }, 29 * minute), true, "inside the floor the provider promises the entry");
+	assert.equal(withinWarmPromise({ kind: "minimum", minMs: 30 * minute }, 3 * 60 * minute), false, "past the floor a miss may be plain eviction");
+	assert.equal(withinWarmPromise({ kind: "bounded", minMs: 5 * minute, maxMs: 60 * minute }, 4 * minute), true);
+	assert.equal(withinWarmPromise({ kind: "bounded", minMs: 5 * minute, maxMs: 60 * minute }, 10 * minute), false);
+	assert.equal(withinWarmPromise({ kind: "maximum", maxMs: 60 * minute }, 1), false, "a maximum never promises warmth");
+	assert.equal(withinWarmPromise({ kind: "unknown" }, 1), false);
+	assert.equal(withinWarmPromise(undefined, 1), false);
+	assert.equal(withinWarmPromise({ kind: "contract", ttlMs: 5 * minute, source: "observed" }, undefined), false);
+});
+
+test("a contract-neutral effort change is withheld from the cache-key diff but not from the bill", () => {
+	const flagged = directAnthropic("claude-fable-5-1", true);
+	const low = fingerprintPayload(anthropicRequest("low"), flagged);
+	const high = fingerprintPayload(anthropicRequest("high"), flagged);
+	assert.equal(diffFingerprints(low, high), undefined, "lineage treats the two requests as one prefix");
+	assert.deepEqual(withheldThinkingCause(low, high), {
+		kind: "thinking",
+		detail: "thinking changed (thinking effort low \u2192 thinking effort high)",
+	});
+	assert.equal(withheldThinkingCause(low, low), undefined, "no wire change to withhold");
+	assert.equal(withheldThinkingCause(undefined, high), undefined);
+	const plain = directAnthropic("claude-fable-5");
+	assert.equal(
+		withheldThinkingCause(fingerprintPayload(anthropicRequest("low"), plain), fingerprintPayload(anthropicRequest("high"), plain)),
+		undefined,
+		"a route the contract expects to break names the change in the diff itself",
+	);
+	const off = fingerprintPayload({ ...anthropicRequest("low"), thinking: { type: "disabled" }, output_config: undefined }, flagged);
+	assert.equal(withheldThinkingCause(low, off), undefined, "on/off is never withheld, so never re-named");
+});
+
 test("a resumed session remembers which efforts its history billed within retention", () => {
 	assert.equal(EFFORT_MEMORY_MS, OPENAI_EXTENDED_WINDOW.maxMs, "the memory bound is the longest known retention");
 	const now = 1_800_000_000_000;
@@ -260,7 +295,7 @@ test("a resumed session remembers which efforts its history billed within retent
 	];
 
 	const ledger: ThinkingEvidenceLedger = new Map();
-	rememberBilledEfforts(ledger, entries, "a4", model, now);
+	assert.equal(restoreBilledThinking(ledger, entries, "a4", model, now), "minimal", "the path's last call was billed at the level in force then, whatever its route");
 	const hitOn = (to: string) =>
 		recordBilledThinking(ledger, astraRoute, change({ lastCallLevel: "medium", currentLevel: to }));
 	assert.equal(hitOn("high"), undefined, "high was billed ten minutes ago: its entry may still be warm");
@@ -269,6 +304,8 @@ test("a resumed session remembers which efforts its history billed within retent
 	assert.equal(recordBilledThinking(ledger, astraRoute, change({ lastCallLevel: "high", currentLevel: "medium" }))?.held, true,
 		"medium was last billed beyond the longest retention");
 
-	rememberBilledEfforts(new Map(), entries, null, model, now);
-	rememberBilledEfforts(new Map(), entries, "a4", undefined, now);
+	assert.equal(restoreBilledThinking(new Map(), entries, "a5", model, now), "xhigh", "another leaf, another last level");
+	assert.equal(restoreBilledThinking(new Map(), entries, "t0", model, now), undefined, "nothing billed yet on this path");
+	assert.equal(restoreBilledThinking(new Map(), entries, null, model, now), undefined);
+	assert.equal(restoreBilledThinking(new Map(), entries, "a4", undefined, now), undefined);
 });

--- a/tests/harness/extension-host.ts
+++ b/tests/harness/extension-host.ts
@@ -93,6 +93,8 @@ export async function hostExtension(
     reason?: SessionStartEvent["reason"];
     model?: CreateAgentSessionOptions["model"];
     thinkingLevel?: CreateAgentSessionOptions["thinkingLevel"];
+    /** A pre-populated session to resume, as Pi does from a session file. */
+    sessionManager?: SessionManager;
   },
 ): Promise<HostedExtension> {
   const { project, interactive = true, reason = "startup", model, thinkingLevel } = options;
@@ -107,7 +109,7 @@ export async function hostExtension(
     cwd,
     agentDir,
     resourceLoader: loader,
-    sessionManager: SessionManager.inMemory(cwd),
+    sessionManager: options.sessionManager ?? SessionManager.inMemory(cwd),
     model,
     thinkingLevel,
     noTools: "all",


### PR DESCRIPTION
Follow-up to #119 from an independent review. All four findings were confirmed in code and closed together.

| Finding | Root cause | Fix |
|---|---|---|
| A miss is ignored on routes assumed to preserve the cache | On contract-neutral Anthropic routes the cache-key diff withholds the effort change (lineage needs that), which also kept it out of the resolved cause: `cause: unknown`, and `held: false` was unreachable | `withheldThinkingCause` names the change after the fact for the resolved cause and the verdict; lineage and the in-flight claim still do not see it |
| Ordinary expiry mistaken for a thinking break | `windowExpired` used `pastWindow`, true only for a reached contract TTL or maximum; OpenAI's 30m minimum and unknown windows never "close", so a miss after hours idle recorded `held: false` | Inverted to `withinWarmPromise`: a miss counts only while the window still promised a warm entry. Cause now reads `… (also 30m minimum passed)` |
| Wrong previous effort after resume or branch switch | `session_start` used Pi's current level, not the path's last billed level; `session_tree` never touched it, and Pi restores messages but not the level on `/tree` | `restoreBilledThinking` returns the path's last billed level; used on start and every `session_tree`, `thinkingChanged` recomputed |
| A hit from elsewhere mistaken for proof | Billed-effort seed ran once at start on that moment's path; a sibling branch billed in an earlier process was not seeded | Seed runs on every path change. Cross-session identical-prefix hits remain indistinguishable and are documented as accepted |

## Verification

- `npm run check`: lint clean, typecheck clean, 387 tests.
- Each finding is pinned by a hosted test that **fails against `e170755`** (verified by stashing the source and re-running): Fable 5.1 miss naming and charging the change; Astra miss after 3h idle (Date mocked) leaving a `held` verdict alone; a resumed session file with two branches driven through Pi's real `navigateTree`. Unit coverage for `withinWarmPromise`, `withheldThinkingCause`, and the last-billed-level walk.
- Live regression, real `pi` 0.85.1 TUI in an isolated HOME with real Bash tool calls on `openai-codex/gpt-6-astra` (Cachemire before `pi-codex-conversion`), on this revision: `low → high` printed `cache held · read 10.1k of 10.2k expected · effort low → high kept the prefix warm on this route` once, `high → medium` silent, `/cache` names both. The negative paths cannot be forced on a real provider and stay hosted.
- Performance: the path walk is O(session entries) on `session_start` and `/tree` navigation only, where Cachemire and Pi already walk the entries; the request-time addition is one string compare.
